### PR TITLE
REC-34: Adding Deprecation for Drupal::l() method and proper substitution

### DIFF
--- a/config/drupal-8/drupal-8.0-deprecations.yml
+++ b/config/drupal-8/drupal-8.0-deprecations.yml
@@ -6,3 +6,4 @@ services:
   DrupalRector\Rector\Deprecation\DBQueryRector: ~
   DrupalRector\Rector\Deprecation\URLRector: ~
   DrupalRector\Rector\Deprecation\FormatDateRector: ~
+  DrupalRector\Rector\Deprecation\DrupalLRector: ~

--- a/deprecation-index.yml
+++ b/deprecation-index.yml
@@ -104,3 +104,11 @@
     - file_create_directory_updated.php
     - FileCreateDirectoryNoUseStatement.php
     - FileCreateDirectoryNoUseStatementUpdated.php
+'Drupal::l()':
+  Rector: DrupalLRector.php
+  PHPStan: 'Call to deprecated method l() of class Drupal. Deprecated in drupal:8.0.0 and is removed from drupal:9.0.0. Use Drupal​\​Core​\​Link::fromTextAndUrl() instead.'
+  Examples:
+    - drupal_l.php
+    - drupal_l_updated.php
+    - DrupalLStatic.php
+    - DrupalLStaticUpdated.php

--- a/rector_examples/drupal_l.php
+++ b/rector_examples/drupal_l.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * This demonstrates the deprecated static calls that might be called from procedural code like `.module` files.
+ */
+
+/**
+ * A simple example using the minimum number of arguments.
+ */
+function simple_example() {
+    \Drupal::l('User Login', \Drupal::service('url_generator')->generateFromRoute('user.login'));
+}

--- a/rector_examples/drupal_l_updated.php
+++ b/rector_examples/drupal_l_updated.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * This demonstrates the updated static calls that might be called from procedural code like `.module` files.
+ */
+
+/**
+ * A simple example using the minimum number of arguments.
+ */
+function simple_example() {
+    \Drupal::service('link_generator')->generate('User Login', \Drupal::service('url_generator')->generateFromRoute('user.login'));
+}
+

--- a/rector_examples/rector_examples.services.yml
+++ b/rector_examples/rector_examples.services.yml
@@ -29,7 +29,8 @@ services:
   rector_examples.unicode_strtolower_static:
     class: Drupal\rector_examples\UnicodeStrtolowerStatic
 
-  rector_examples.url:
+  rector_examples.url_static:
     class: Drupal\rector_examples\URLStatic
 
-
+  rector_examples.drupal_l_static:
+    class: Drupal\rector_examples\DrupalLStatic

--- a/rector_examples/src/DrupalLStatic.php
+++ b/rector_examples/src/DrupalLStatic.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\rector_examples;
+
+/**
+ * Example of static method calls from a class.
+ */
+class DrupalLStatic {
+
+  /**
+   * A simple example using the minimum number of arguments.
+   */
+  public function simple_example() {
+    \Drupal::l('User Login', \Drupal::service('url_generator')->generateFromRoute('user.login'));
+  }
+
+}

--- a/rector_examples/src/DrupalLStaticUpdated.php
+++ b/rector_examples/src/DrupalLStaticUpdated.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\rector_examples;
+
+/**
+ * Example of updated static method calls from a class.
+ */
+class DrupalLStaticUpdated {
+
+  /**
+   * A simple example using the minimum number of arguments.
+   */
+  public function simple_example() {
+    \Drupal::service('link_generator')->generate('User Login', \Drupal::service('url_generator')->generateFromRoute('user.login'));
+  }
+
+}

--- a/src/Rector/Deprecation/DrupalLRector.php
+++ b/src/Rector/Deprecation/DrupalLRector.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace DrupalRector\Rector\Deprecation;
+
+use Rector\RectorDefinition\CodeSample;
+use Rector\RectorDefinition\RectorDefinition;
+
+/**
+ * Replaces deprecated \Drupal::l() calls.
+ *
+ * See https://www.drupal.org/node/2346779 for change record.
+ *
+ * What is covered:
+ * - Static replacement
+ *
+ * Improvement opportunities
+ * - Dependency injection
+ */
+final class DrupalLRector extends StaticToServiceBase
+{
+    protected $deprecatedFullQualifiedClassName = 'Drupal';
+
+    protected $deprecatedMethodName = 'l';
+
+    protected $serviceName = 'link_generator';
+
+    protected $serviceMethodName = 'generate';
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Fixes deprecated \Drupal::l() calls',[
+            new CodeSample(
+                <<<'CODE_BEFORE'
+\Drupal::l('User Login', \Drupal::service('url_generator')->generateFromRoute('user.login'));
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+\Drupal::service('link_generator')->generate('User Login', \Drupal::service('url_generator')->generateFromRoute('user.login'));
+CODE_AFTER
+            )
+        ]);
+    }
+}


### PR DESCRIPTION
Related to https://palantir.atlassian.net/browse/REC-34