### PR TITLE
Allow only rector-prefixed versions below 0.7.19

### DIFF
--- a/.github/workflows/drupal_rector_examples.yml
+++ b/.github/workflows/drupal_rector_examples.yml
@@ -1,8 +1,10 @@
 name: drupal_rector_examples
 
-# This test will run on every pull request, and on every commit on any branch
 on:
-    [push, pull_request]
+    pull_request: null
+    push:
+        branches:
+            - master
 
 jobs:
     drupal_rector_examples:

--- a/.github/workflows/drupal_rector_examples.yml
+++ b/.github/workflows/drupal_rector_examples.yml
@@ -1,10 +1,8 @@
 name: drupal_rector_examples
 
+# This test will run on every pull request, and on every commit on any branch
 on:
-    pull_request: null
-    push:
-        branches:
-            - master
+    [push, pull_request]
 
 jobs:
     drupal_rector_examples:

--- a/.github/workflows/local_package_run_rector.yml
+++ b/.github/workflows/local_package_run_rector.yml
@@ -1,0 +1,48 @@
+name: local_package_run_rector
+
+# This test will run on every pull request, and on every commit on any branch
+on:
+        [push, pull_request]
+
+jobs:
+    run_rector_on_rector_examples_module:
+        name: Run Drupal Rector
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.3
+                    coverage: none # disable xdebug, pcov
+                    extensions: "intl"
+
+#           Uncomment to enable SSH access to Github Actions - https://github.com/marketplace/actions/debugging-with-tmate#getting-started
+#            - name: Debugging with tmate
+#              uses: mxschmitt/action-tmate@v2
+
+            -   run: |
+                    # Download the latest Drupal core project and all its dependencies
+                    composer create-project drupal/recommended-project ../drupal --no-progress
+                    mv ../drupal/* ..
+
+            -   run: |
+                    # Install drupal-rector using current github-actions directory (allow testing for both forks and main repo)
+                    cd ..
+                    composer config repositories.drupal-rector '{"type": "path", "url": "drupal-rector", "options": {"symlink": true}}'
+                    composer require palantirnet/drupal-rector:@dev --prefer-source --no-progress
+
+            -   run: |
+                    # Prepare rector config files with Drupal specific settings
+                    cd ..
+                    cp vendor/palantirnet/drupal-rector/rector.yml .
+
+            -   run: |
+                    # Prepare rector_examples folder in the drupal modules directory
+                    cd ..
+                    mkdir -p web/modules/custom
+                    cp -r vendor/palantirnet/drupal-rector/rector_examples web/modules/custom/.
+
+            -   run: |
+                    # Run Rector
+                    cd ..
+                    vendor/bin/rector process web/modules/custom/rector_examples

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "jawira/case-converter": "^1.1",
-        "rector/rector-prefixed": "^0.7.16"
+        "rector/rector-prefixed": "<0.7.19"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
Rector-prefix 0.7.19 is broken - 
Issue:
https://github.com/rectorphp/rector/issues/3256

PR to prevent it from happening in the future:
https://github.com/rectorphp/rector/pull/3255#issuecomment-619294496

