### PR TITLE
Add EntityInterface::link() rule.

### DIFF
--- a/config/drupal-8/drupal-8.0-deprecations.yml
+++ b/config/drupal-8/drupal-8.0-deprecations.yml
@@ -11,6 +11,7 @@ services:
   DrupalRector\Rector\Deprecation\DrupalURLRector: ~
   DrupalRector\Rector\Deprecation\FormatDateRector: ~
   DrupalRector\Rector\Deprecation\DrupalLRector: ~
+  DrupalRector\Rector\Deprecation\EntityInterfaceLinkRector: ~
   DrupalRector\Rector\Deprecation\EntityInterfaceUrlInfoRector: ~
   DrupalRector\Rector\Deprecation\EntityLoadRector: ~
   DrupalRector\Rector\Deprecation\FileLoadRector: ~

--- a/deprecation-index.yml
+++ b/deprecation-index.yml
@@ -161,7 +161,11 @@
   PHPStan: 'Call to deprecated method urlInfo() of class Drupal​\​Core​\​Entity​\​EntityInterface. Deprecated in drupal:8.0.0 and is removed from drupal:9.0.0. Use Drupal​\​Core​\​Entity​\​EntityInterface::toUrl() instead.'
   Examples:
     - entity_interface_url_info.php
-    - EntityInterfaceUrlInfoStatic.php
+'EntityInterface:link()':
+  Rector: EntityInterfaceLinkRector.php
+  PHPStan: 'Call to deprecated method link() of class Drupal​\​Core​\​Entity​\​EntityInterface. Deprecated in drupal:8.0.0 and is removed from drupal:9.0.0. Use Drupal​\​Core​\​EntityInterface::toLink()->toString() instead.'
+  Examples:
+    - entity_interface_link.php
 'entity_load()':
   Rector: EntityLoadRector.php
   PHPStan: 'Call to deprecated function entity_load(). Deprecated in drupal:8.0.0 and is removed from drupal:9.0.0. Use the entity type storage''s load() method.'

--- a/rector_examples/entity_interface_link.php
+++ b/rector_examples/entity_interface_link.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This demonstrates the deprecated static calls that might be called from procedural code like `.module` files.
+ */
+
+/**
+ * A simple example.
+ */
+function simple_example() {
+  /* @var \Drupal\node\Entity\Node $node */
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load(123);
+
+  $link = $node->link();
+}
+
+/**
+ * An example using arguments.
+ */
+function example_using_arguments() {
+  /* @var \Drupal\node\Entity\Node $node */
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load(123);
+
+  $link = $node->link('Hello world', 'canonical', ['absolute' => TRUE]);
+}

--- a/rector_examples_updated/entity_interface_link.php
+++ b/rector_examples_updated/entity_interface_link.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * This demonstrates the deprecated static calls that might be called from procedural code like `.module` files.
+ */
+
+/**
+ * A simple example.
+ */
+function simple_example() {
+  /* @var \Drupal\node\Entity\Node $node */
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load(123);
+
+  $link = $node->toLink()->toString();
+}
+
+/**
+ * An example using arguments.
+ */
+function example_using_arguments() {
+  /* @var \Drupal\node\Entity\Node $node */
+  $node = \Drupal::entityTypeManager()->getStorage('node')->load(123);
+
+  $link = $node->toLink('Hello world', 'canonical', ['absolute' => TRUE])->toString();
+}

--- a/src/Rector/Deprecation/EntityInterfaceLinkRector.php
+++ b/src/Rector/Deprecation/EntityInterfaceLinkRector.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace DrupalRector\Rector\Deprecation;
+
+use Rector\Core\RectorDefinition\RectorDefinition;
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+
+/**
+ * Replaces deprecated function call to EntityInterface::link.
+ *
+ * See https://www.drupal.org/node/2614344 for change record.
+ *
+ * What is covered:
+ * - Changes the name of the method and adds toString().
+ *
+ * Improvement opportunities:
+ * - Checks the variable has a certain class.
+ */
+final class EntityInterfaceLinkRector extends AbstractRector
+{
+    /**
+     * @inheritdoc
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Fixes deprecated link() calls',[
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$url = $entity->link();
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$url = $entity->toLink()->toString();
+CODE_AFTER
+        )
+      ]);
+    }
+
+  /**
+   * @inheritdoc
+   */
+  public function getNodeTypes(): array
+  {
+      return [
+          Node\Expr\MethodCall::class,
+      ];
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function refactor(Node $node): ?Node
+  {
+      /** @var Node\Expr\MethodCall $node */
+      // TODO: Check the class to see if it implements Drupal\Core\Entity\EntityInterface.
+      if ($this->getName($node->name) === 'link') {
+          $toLink_node = $node;
+
+          $toLink_node->name = new Node\Name('toLink');
+
+          // Add ->toString();
+          $new_node = new Node\Expr\MethodCall($toLink_node, new Node\Identifier('toString'));
+
+          return $new_node;
+      }
+
+      return null;
+  }
+
+}


### PR DESCRIPTION
The deprecation index also has a reference to an example removed where it was never added.