### PR TITLE
BrowserTestBase getmock incorrect in deprecation index

### DIFF
--- a/deprecation-index.yml
+++ b/deprecation-index.yml
@@ -60,7 +60,7 @@
     - FileScanDirectoryStatic.php
 'BrowserTestBase::getMock()':
   Rector: BrowserTestBaseGetMock.php
-  PHPStan: 'Call to deprecated method getMock() of class Drupal\Tests\UnitTestCase. Deprecated in drupal:8.5.0 and is removed from drupal:9.0.0. Use Drupal\Tests\PhpunitCompatibilityTrait::createMock() instead.'
+  PHPStan: 'Call to deprecated method getMock() of class Drupal\Tests\BrowserTestBase. Deprecated in drupal:8.5.0 and is removed from drupal:9.0.0. Use Drupal\Tests\PhpunitCompatibilityTrait::createMock() instead.'
   Examples:
       - BrowserTestBaseGetMock.php
 'KernelTestBase::getMock()':


### PR DESCRIPTION
As discussed earlier in https://github.com/palantirnet/drupal-rector/pull/73