### PR TITLE
Add comments to exclude tests paths

### DIFF
--- a/rector-config-docroot-dir.yml
+++ b/rector-config-docroot-dir.yml
@@ -14,6 +14,11 @@ parameters:
     - 'docroot/modules'
     - 'docroot/profiles'
 
+  exclude_paths:
+  # If you would like to skip test directories, uncomment the following lines:
+  #   - '*/tests/*'
+  #   - '*/Tests/*'
+
   file_extensions:
     - module
     - theme

--- a/rector-config-web-dir.yml
+++ b/rector-config-web-dir.yml
@@ -14,6 +14,11 @@ parameters:
     - 'web/modules'
     - 'web/profiles'
 
+  exclude_paths:
+  # If you would like to skip test directories, uncomment the following lines:
+  #   - '*/tests/*'
+  #   - '*/Tests/*'
+
   file_extensions:
     - module
     - theme

--- a/rector.yml
+++ b/rector.yml
@@ -14,6 +14,11 @@ parameters:
     - 'web/modules'
     - 'web/profiles'
 
+  exclude_paths:
+  # If you would like to skip test directories, uncomment the following lines:
+  #   - '*/tests/*'
+  #   - '*/Tests/*'
+
   file_extensions:
     - module
     - theme


### PR DESCRIPTION
Rector goes through tests directories, which require phpunit, etc.

When a developer needs to get their website ready for Drupal9 ASAP, they can skip fixing these tests directories.