### PR TITLE
rector-prefixed is fixed,use specific commit until there's a new release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "jawira/case-converter": "^1.1",
-        "rector/rector-prefixed": "<0.7.19"
+        "rector/rector-prefixed": "dev-master#cd10d7f"
     },
     "license": "MIT",
     "authors": [
@@ -47,5 +47,11 @@
     "prefer-stable": true,
     "require-dev": {
         "behat/behat": "^3.6"
+    },
+    "repositories": {
+        "rector-prefixed": {
+            "type": "vcs",
+            "url": "https://github.com/rectorphp/rector-prefixed.git"
+        }
     }
 }


### PR DESCRIPTION
rector-prefixed was broken for a month and finally got fixed:
https://github.com/rectorphp/rector/issues/3256#issuecomment-631446202

It includes various improvements, some important ones:
* Stop indentation fixes
* Keep empty `'<?php ?>'` code without deleting it.

One of the best ways to test it:
`composer require drupal/feeds`
`vendor/bin/rector process --dry-run web/modules/contrib/feeds`

In the previous rector-prefixed version there were many lines that changed because of indentation corrections, which doesn't happen with the new rector-prefixed.