### PR TITLE
Fix issue with GetMockBase.

### DIFF
--- a/rector_examples/test/src/Unit/UnitTestCaseGetMock.php
+++ b/rector_examples/test/src/Unit/UnitTestCaseGetMock.php
@@ -20,4 +20,15 @@ class UnitTestCaseGetMock extends UnitTestCase {
   public function class_name_as_string() {
     $this->entityTypeManager = $this->getMock('Drupal\Core\Entity\EntityTypeManagerInterface');
   }
+
+  /**
+   * An example of chaining method calls.
+   *
+   * This should not get updated, since `getMockBuilder()` is not deprecated.
+   */
+  public function chaining_method_calls() {
+    $this->entityTypeManager = $this->getMockBuilder('Drupal\Core\Entity\EntityTypeManagerInterface')
+      ->disableOriginalConstructor()
+      ->getMock();
+  }
 }

--- a/rector_examples_updated/test/src/Unit/UnitTestCaseGetMock.php
+++ b/rector_examples_updated/test/src/Unit/UnitTestCaseGetMock.php
@@ -20,4 +20,15 @@ class UnitTestCaseGetMock extends UnitTestCase {
   public function class_name_as_string() {
     $this->entityTypeManager = $this->createMock('Drupal\Core\Entity\EntityTypeManagerInterface');
   }
+
+  /**
+   * An example of chaining method calls.
+   *
+   * This should not get updated, since `getMockBuilder()` is not deprecated.
+   */
+  public function chaining_method_calls() {
+    $this->entityTypeManager = $this->getMockBuilder('Drupal\Core\Entity\EntityTypeManagerInterface')
+      ->disableOriginalConstructor()
+      ->getMock();
+  }
 }

--- a/src/Rector/Deprecation/Base/GetMockBase.php
+++ b/src/Rector/Deprecation/Base/GetMockBase.php
@@ -39,12 +39,8 @@ abstract class GetMockBase extends AbstractRector
    */
   public function refactor(Node $node): ?Node
   {
-    $class_name = $node->getAttribute(AttributeKey::CLASS_NAME);
-
-    $parent_class = $node->getAttribute(AttributeKey::PARENT_CLASS_NAME);
-
     /* @var Node\Expr\MethodCall $node */
-    if ($this->getName($node->name) === 'getMock' && $this->getName($node->var) === 'this' && !is_null($class_name) && !is_null($parent_class) && $parent_class === $this->baseClassBeingExtended) {
+    if ($this->getName($node->name) === 'getMock' && ($node->var instanceof Node\Expr\Variable) && $this->getName($node->var) === 'this' && $node->hasAttribute(AttributeKey::PARENT_CLASS_NAME) && $node->getAttribute(AttributeKey::PARENT_CLASS_NAME) === $this->baseClassBeingExtended) {
 
       // Build the arguments.
       $method_arguments = $node->args;


### PR DESCRIPTION
When this was called on a method, like in the new example, an error was thrown.

The new conditional logic checks that we are acting on the `this` which is a variable.