### PR TITLE
rector-prefixed 0.7.27

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "jawira/case-converter": "^1.1",
-        "rector/rector-prefixed": "dev-master#cae75a5"
+        "rector/rector-prefixed": "0.7.27"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
rector-prefixed 0.7.27 was finally released
(it is the first released version that fixes the phar file that was broken since version 0.7.19)