### PR TITLE
Pin to 8.8.x so that we don't remove the deprecated functions yet.

### DIFF
--- a/.github/workflows/local_package_functional_tests.yml
+++ b/.github/workflows/local_package_functional_tests.yml
@@ -19,7 +19,7 @@ jobs:
             # This is copied from `local_package_run_rector`.
             -    run: |
                     # Download the latest Drupal core project and all its dependencies
-                    composer create-project drupal/recommended-project ../drupal --no-progress
+                    composer create-project drupal/recommended-project:~8.8.0 ../drupal --no-progress
                     mv ../drupal/* ..
 
             # This is copied from `local_package_run_rector`.

--- a/.github/workflows/local_package_functional_tests.yml
+++ b/.github/workflows/local_package_functional_tests.yml
@@ -19,7 +19,7 @@ jobs:
             # This is copied from `local_package_run_rector`.
             -    run: |
                     # Download the latest Drupal core project and all its dependencies
-                    composer create-project drupal/recommended-project:~8.8.0 ../drupal --no-progress
+                    composer create-project drupal/recommended-project:~8 ../drupal --no-progress
                     mv ../drupal/* ..
 
             # This is copied from `local_package_run_rector`.

--- a/.github/workflows/local_package_run_rector.yml
+++ b/.github/workflows/local_package_run_rector.yml
@@ -22,7 +22,7 @@ jobs:
 
             -   run: |
                     # Download the latest Drupal core project and all its dependencies
-                    composer create-project drupal/recommended-project ../drupal --no-progress
+                    composer create-project drupal/recommended-project:~8.8.0 ../drupal --no-progress
                     mv ../drupal/* ..
 
             -   run: |

--- a/.github/workflows/local_package_run_rector.yml
+++ b/.github/workflows/local_package_run_rector.yml
@@ -22,7 +22,7 @@ jobs:
 
             -   run: |
                     # Download the latest Drupal core project and all its dependencies
-                    composer create-project drupal/recommended-project:~8.8.0 ../drupal --no-progress
+                    composer create-project drupal/recommended-project:~8 ../drupal --no-progress
                     mv ../drupal/* ..
 
             -   run: |

--- a/.github/workflows/packagist_package_run_rector.yml
+++ b/.github/workflows/packagist_package_run_rector.yml
@@ -25,7 +25,7 @@ jobs:
 
             -   run: |
                     # Download the latest Drupal core project and all its dependencies
-                    composer create-project drupal/recommended-project:~8.8.0 drupal --no-progress
+                    composer create-project drupal/recommended-project:~8 drupal --no-progress
 
             -   run: |
                     # Install drupal-rector:dev-master from Github

--- a/.github/workflows/packagist_package_run_rector.yml
+++ b/.github/workflows/packagist_package_run_rector.yml
@@ -25,7 +25,7 @@ jobs:
 
             -   run: |
                     # Download the latest Drupal core project and all its dependencies
-                    composer create-project drupal/recommended-project drupal --no-progress
+                    composer create-project drupal/recommended-project:~8.8.0 drupal --no-progress
 
             -   run: |
                     # Install drupal-rector:dev-master from Github


### PR DESCRIPTION
We'll need to do more testing with 8.9 and 9.x.

Fixes #106?