### PR TITLE
Fix CI, remove git repo requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,11 +46,5 @@
     "prefer-stable": true,
     "require-dev": {
         "behat/behat": "^3.6"
-    },
-    "repositories": {
-        "rector-prefixed": {
-            "type": "vcs",
-            "url": "https://github.com/rectorphp/rector-prefixed.git"
-        }
     }
 }


### PR DESCRIPTION
I looked into the CI setup and could not understand why the the custom repository is required. rector-prefixed is available on Packagist. The GitHub Archive URLs have no rate-limit, therefor setting up authentication is not required.

