### PR TITLE
Add ability to fix Twig deprecations, with `replace` filter as first example

### DIFF
--- a/config/drupal-8/drupal-8-all-deprecations.php
+++ b/config/drupal-8/drupal-8-all-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Twig\Transformer\TwigReplaceTransformer;
 use Rector\Core\Configuration\Option;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -13,4 +14,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::BOOTSTRAP_FILES, [
         __DIR__ . '/../drupal-phpunit-bootstrap-file.php'
     ]);
+
+    $services = $containerConfigurator->services();
+    $services->load('DrupalRector\\', __DIR__ . '/../../src');
+    $services->set(TwigReplaceTransformer::class);
 };

--- a/rector_examples/twig_replace.html.twig
+++ b/rector_examples/twig_replace.html.twig
@@ -1,1 +1,10 @@
+{# This demonstrates the deprecated calls to the Twig replace filter. #}
+
+{# With single quotes #}
 {% set themeclass = item.title|replace(' ', '-') %}
+
+{# With double quotes #}
+{% set themeclass = item.title|replace(" ", "-") %}
+
+{# With no space after comma #}
+{% set themeclass = item.title|replace(" ","-") %}

--- a/rector_examples/twig_replace.html.twig
+++ b/rector_examples/twig_replace.html.twig
@@ -1,0 +1,1 @@
+{% set themeclass = item.title|replace(' ', '-') %}

--- a/rector_examples_updated/twig_replace.html.twig
+++ b/rector_examples_updated/twig_replace.html.twig
@@ -1,0 +1,10 @@
+{# This demonstrates the deprecated calls to the Twig replace filter. #}
+
+{# With single quotes #}
+{% set themeclass = item.title|replace({' ': '-'}) %}
+
+{# With double quotes #}
+{% set themeclass = item.title|replace({' ': '-'}) %}
+
+{# With no space after comma #}
+{% set themeclass = item.title|replace({' ': '-'}) %}

--- a/src/Twig/Transformer/TwigReplaceTransformer.php
+++ b/src/Twig/Transformer/TwigReplaceTransformer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DrupalRector\Twig\Transformer;
+
+use Rector\Core\Provider\CurrentFileProvider;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class TwigReplaceTransformer implements TwigTransformer
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Convert replace function into array', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+{% set themeclass = item.title|replace(' ', '-') %}
+CODE_SAMPLE
+                ,
+                <<<'CODE_SAMPLE'
+{% set themeclass = item.title|replace({' ': '-'}) %}
+CODE_SAMPLE
+            ),
+        ]);
+    }
+
+    public function transform(string $twigContent): string
+    {
+        $twigContent = preg_replace('/replace\([\'"]{1}(.*)[\'"]{1},\s*[\'"]{1}(.*)[\'"]{1}\)/i', 'replace({\'$1\': \'$2\'})', $twigContent);
+        return $twigContent;
+    }
+}

--- a/src/Twig/Transformer/TwigTransformer.php
+++ b/src/Twig/Transformer/TwigTransformer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace DrupalRector\Twig\Transformer;
+
+use Rector\Core\Contract\Rector\RectorInterface;
+use Rector\Core\Provider\CurrentFileProvider;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+interface TwigTransformer extends RectorInterface
+{
+    public function transform(string $twigContent): string;
+}

--- a/src/Twig/TwigProcessor.php
+++ b/src/Twig/TwigProcessor.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Twig;
+
+use DrupalRector\Twig\Transformer;
+use Rector\Core\Contract\Processor\FileProcessorInterface;
+use Rector\Core\Provider\CurrentFileProvider;
+use Rector\Core\ValueObject\Application\File;
+
+final class TwigProcessor implements FileProcessorInterface
+{
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_FILE_EXTENSIONS = ['twig'];
+
+    /**
+     * @var string[]
+     */
+    private $transformerClasses = [
+        Transformer\TwigReplaceTransformer::class,
+    ];
+
+    /**
+     * @param File[] $files
+     */
+    public function process(array $files): void
+    {
+        foreach ($files as $file) {
+            $this->processFile($file);
+        }
+    }
+
+    public function supports(File $file): bool
+    {
+        $smartFileInfo = $file->getSmartFileInfo();
+        return $smartFileInfo->hasSuffixes($this->getSupportedFileExtensions());
+    }
+
+    public function getSupportedFileExtensions(): array
+    {
+        return self::ALLOWED_FILE_EXTENSIONS;
+    }
+
+    private function processFile(File $file): void
+    {
+        $fileContent = $file->getFileContent();
+
+        foreach ($this->transformerClasses as $transformerClass) {
+            $transformer = new $transformerClass;
+            $changedFileContent = $transformer->transform($fileContent);
+        }
+
+        $file->changeFileContent($changedFileContent);
+    }
+}


### PR DESCRIPTION
The character by character replacement syntax for the `replace` Twig filter was [deprecated in 8.0.0](https://api.drupal.org/api/drupal/vendor%21twig%21twig%21lib%21Twig%21Extension%21Core.php/function/twig_replace_filter/8.0.x).

This PR creates a Twig file processor as well as a transformer for the filter.