### PR TITLE
Add rule for node_load_multiple

### DIFF
--- a/rector_examples/node_load_multiple.php
+++ b/rector_examples/node_load_multiple.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * This demonstrates the deprecated static calls that might be called from procedural code like `.module` files.
+ */
+
+/**
+ * A simple example.
+ */
+function simple_example() {
+  $nodes = node_load_multiple([123, 456]);
+}
+
+/**
+ * An example using all of the arguments.
+ */
+function all_arguments() {
+  /* @var \Drupal\node\Entity\Node $node */
+  $node = node_load_multiple([123, 456], TRUE);
+}
+
+/**
+ * An example using a variable for the argument.
+ */
+function all_arguments_as_variables() {
+  $node_ids = [123, 456];
+  $reset = TRUE;
+  $nodes = node_load_multiple($node_ids, $reset);
+}

--- a/rector_examples/node_load_multiple.php
+++ b/rector_examples/node_load_multiple.php
@@ -15,8 +15,7 @@ function simple_example() {
  * An example using all of the arguments.
  */
 function all_arguments() {
-  /* @var \Drupal\node\Entity\Node $node */
-  $node = node_load_multiple([123, 456], TRUE);
+  $nodes = node_load_multiple([123, 456], TRUE);
 }
 
 /**

--- a/rector_examples_updated/node_load_multiple.php
+++ b/rector_examples_updated/node_load_multiple.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * This demonstrates the deprecated static calls that might be called from procedural code like `.module` files.
+ */
+
+/**
+ * A simple example.
+ */
+function simple_example() {
+  $nodes = \Drupal::service('entity_type.manager')->getStorage('node')->loadMultiple([123, 456]);
+}
+
+/**
+ * An example using all of the arguments.
+ */
+function all_arguments() {
+  // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+  // A ternary operator is used here to keep the conditional contained within this part of the expression. Consider wrapping this statement in an `if / else` statement.
+  $nodes = TRUE ? \Drupal::service('entity_type.manager')->getStorage('node')->resetCache([123, 456])->loadMultiple([123, 456]) : \Drupal::service('entity_type.manager')->getStorage('node')->loadMultiple([123, 456]);
+}
+
+/**
+ * An example using a variable for the argument.
+ */
+function all_arguments_as_variables() {
+  $node_ids = [123, 456];
+  $reset = TRUE;
+  // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+  // A ternary operator is used here to keep the conditional contained within this part of the expression. Consider wrapping this statement in an `if / else` statement.
+  $nodes = $reset ? \Drupal::service('entity_type.manager')->getStorage('node')->resetCache($node_ids)->loadMultiple($node_ids) : \Drupal::service('entity_type.manager')->getStorage('node')->loadMultiple($node_ids);
+}

--- a/src/Rector/Deprecation/NodeLoadMultipleRector.php
+++ b/src/Rector/Deprecation/NodeLoadMultipleRector.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\EntityLoadBase;
+use Rector\Core\RectorDefinition\CodeSample;
+use Rector\Core\RectorDefinition\RectorDefinition;
+
+/**
+ * Replaced deprecated node_load_multiple() calls.
+ *
+ * See https://www.drupal.org/node/2266845 for change record.
+ *
+ * What is covered:
+ * - See EntityLoadBase.php
+ *
+ * Improvement opportunities
+ * - See EntityLoadBase.php
+ */
+final class NodeLoadMultipleRector extends EntityLoadBase
+{
+    protected $entityType = 'node';
+
+    /**
+     * @inheritdoc
+     */
+    public function getDefinition(): RectorDefinition
+    {
+        return new RectorDefinition('Fixes deprecated node_load_multiple() use',[
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$nodes = node_load_multiple([123, 456]);
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$nodes = \Drupal::entityManager()->getStorage('node')->loadMultiple([123, 456]);
+CODE_AFTER
+            )
+        ]);
+    }
+
+}


### PR DESCRIPTION
node_load_multiple() can be properly refactored by tweaking the existing logic in EntityLoadBase.

I tried improving it by using a protected variable ($isMultiple), defaulting it to FALSE in EntityLoadBase and setting it to TRUE in NodeLoadMultipleRector, as well as updating EntityLoadBase to now use it to determine $method_name, etc. For some reason, that change caused the is_null() check for $this->entityType to start returning TRUE, so I just left those changes out of the PR.

I also ran a quick sanity check by diffing a processed copy of rector_examples/node_load.php vs. the _updated version, which showed no changes at all.