### PR TITLE
Issue #3219157: Support Windows file paths

### DIFF
--- a/.github/workflows/functional_test__rector_examples.yml
+++ b/.github/workflows/functional_test__rector_examples.yml
@@ -7,7 +7,10 @@ jobs:
     run_functional_test:
         name: Run functional test
 # START: SHARED SETUP
-        runs-on: ubuntu-latest  
+        runs-on: ${{ matrix.operating-system }}
+        strategy:
+            matrix:
+                operating-system: ['ubuntu-latest', 'windows-latest']
         steps:
             -   uses: actions/checkout@v2
             -   uses: shivammathur/setup-php@v2
@@ -23,14 +26,14 @@ jobs:
 # START: SHARED DRUPAL INSTALL SETUP
             -   name: Setup Drupal
                 run: |
-                    COMPOSER_MEMORY_LIMIT=-1 composer create-project drupal/recommended-project:~8 ../drupal --no-interaction
+                    composer create-project drupal/recommended-project:~8 ../drupal --no-interaction
                     cd ..
                     mv drupal/* .
                     composer config minimum-stability dev
                     composer config prefer-stable true
                     composer config preferred-install dist
                     composer config repositories.drupal composer https://packages.drupal.org/8
-                    COMPOSER_MEMORY_LIMIT=-1 composer require drupal/core-dev:~8 --with-all-dependencies
+                    composer require drupal/core-dev:~8 --with-all-dependencies
             # We add a local repository `repositories.0` which takes precendence over the packagist repository that is automatically added.
             -   name: Install Drupal Rector
                 run: |

--- a/rector.php
+++ b/rector.php
@@ -15,10 +15,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $drupalFinder->locateRoot(__DIR__);
     $drupalRoot = $drupalFinder->getDrupalRoot();
     $parameters->set(Option::AUTOLOAD_PATHS, [
-        $drupalRoot . '/core',
-        $drupalRoot . '/modules',
-        $drupalRoot . '/profiles',
-        $drupalRoot . '/themes'
+        \realpath($drupalRoot . '/core'),
+        \realpath($drupalRoot . '/modules'),
+        \realpath($drupalRoot . '/profiles'),
+        \realpath($drupalRoot . '/themes')
     ]);
 
     $parameters->set(Option::SKIP, ['*/upgrade_status/tests/modules/*']);


### PR DESCRIPTION
Would benefit from manual testing or an AppVeyor run on Windows.

**NOTE** Leaving as a Draft until manual review. Also, not sure if we should go down the Windows runner rabbithole – specifically with trying to configure the Composer VCS URL.

How to add this PR to your Drupal project:

```
cd /path/to/drupal/recommended-project
composer config repositories.1 vcs https://github.com/bluehorndigital/drupal-rector.git
composer require palantirnet/drupal-rector:dev-issue-3219157
cp vendor/palantirnet/drupal-rector/rector.php .
php vendor/bin/rector 
```