### PR TITLE
Issue #3217942: Bump Rector to 0.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ast"
     ],
     "require": {
-        "rector/rector-prefixed": "~0.10.0",
+        "rector/rector": "~0.11.0",
         "webflo/drupal-finder": "^1.2"
     },
     "license": "MIT",


### PR DESCRIPTION
## Description
Get to the latest Rector minor.

## To Test
Check out this PR and run against a Drupal site, verify 0.11 works as expected.

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3217942