### PR TITLE
Issue #3222671: AssertLegacyTrait rector rules

### DIFF
--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertTextTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertTextTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertTextTest extends BrowserTestBase {
+
+    public function testAssertText() {
+        $current_content = $this->randomMachineName();
+        $this->drupalGet('test-page');
+        $this->assertText($current_content, 'Block content displays on the test page.');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertTextTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertTextTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertTextTest extends BrowserTestBase {
+
+    public function testAssertText() {
+        $current_content = $this->randomMachineName();
+        $this->drupalGet('test-page');
+        // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+        // Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.
+        // The passed text should be HTML decoded, exactly as a human sees it in the browser.
+        $this->assertSession()->pageTextContains($current_content);
+    }
+
+}

--- a/src/Rector/Deprecation/AssertEqualRector.php
+++ b/src/Rector/Deprecation/AssertEqualRector.php
@@ -15,7 +15,7 @@ final class AssertEqualRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertEqual() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertEqual('Actual', 'Expected', 'Message');

--- a/src/Rector/Deprecation/AssertEqualRector.php
+++ b/src/Rector/Deprecation/AssertEqualRector.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertEqualRector extends AssertLegacyTraitBase
+{
+
+    protected $deprecatedMethodName = 'assertEqual';
+    protected $methodName = 'assertEquals';
+    protected $isAssertSessionMethod = false;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$this->assertEqual('Actual', 'Expected', 'Message');
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$this->assertEquals('Actual', 'Expected', 'Message');
+CODE_AFTER
+            )
+        ]);
+    }
+
+}

--- a/src/Rector/Deprecation/AssertFieldByNameRector.php
+++ b/src/Rector/Deprecation/AssertFieldByNameRector.php
@@ -2,7 +2,6 @@
 
 namespace DrupalRector\Rector\Deprecation;
 
-use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
 use PhpParser\Node;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -13,7 +12,7 @@ final class AssertFieldByNameRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertFieldByName() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertFieldByName('field_name', 'expected_value');

--- a/src/Rector/Deprecation/AssertFieldByNameRector.php
+++ b/src/Rector/Deprecation/AssertFieldByNameRector.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertFieldByNameRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$this->assertFieldByName('field_name', 'expected_value');
+$this->assertFieldByName("field_name[0][value][date]", '', 'Date element found.');
+$this->assertFieldByName("field_name[0][value][time]", null, 'Time element found.');
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$this->assertSession()->fieldValueEquals('field_name', 'expected_value');
+$this->assertSession()->fieldExists("field_name[0][value][date]", '', 'Date element found.');
+$this->assertSession()->fieldExists("field_name[0][value][time]", null, 'Time element found.');
+CODE_AFTER
+            )
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\MethodCall::class,
+        ];
+    }
+
+    public function refactor(Node $node)
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+        if ($this->getName($node->name) !== 'assertFieldByName') {
+            return null;
+        }
+
+        $args = $node->args;
+        if (count($args) === 3) {
+            array_pop($args);
+        }
+        $assertSessionNode = $this->nodeFactory->createLocalMethodCall('assertSession');
+
+        // If we have one argument, change to fieldExists and return early.
+        if (count($args) === 1) {
+            return $this->nodeFactory->createMethodCall($assertSessionNode, 'fieldExists', $args);
+        }
+        // Check if argument two is a `null` and convert to fieldExists.
+        $arg2 = $args[1]->value;
+        if ($arg2 instanceof Node\Expr\ConstFetch && (string) $arg2->name === 'null') {
+            return $this->nodeFactory->createMethodCall($assertSessionNode, 'fieldExists', [$args[0]]);
+        }
+
+        return $this->nodeFactory->createMethodCall($assertSessionNode, 'fieldValueEquals', $args);
+    }
+}

--- a/src/Rector/Deprecation/AssertIdenticalRector.php
+++ b/src/Rector/Deprecation/AssertIdenticalRector.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertIdenticalRector extends AssertLegacyTraitBase
+{
+
+    protected $deprecatedMethodName = 'assertIdentical';
+    protected $methodName = 'assertSame';
+    protected $isAssertSessionMethod = false;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertIdentical() calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$this->assertIdentical('Actual', 'Expected', 'Message');
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$this->assertSame('Actual', 'Expected', 'Message');
+CODE_AFTER
+            )
+        ]);
+    }
+
+}

--- a/src/Rector/Deprecation/AssertRawRector.php
+++ b/src/Rector/Deprecation/AssertRawRector.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertRawRector extends AssertLegacyTraitBase
+{
+
+    protected $deprecatedMethodName = 'assertRaw';
+    protected $methodName = 'responseContains';
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertRaw() calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$this->assertRaw('bartik/logo.svg');
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$this->assertSession()->responseContains('bartik/logo.svg');
+CODE_AFTER
+            )
+        ]);
+    }
+
+    protected function processArgs(array $args): array
+    {
+        // We do not pass the full `$node->args` to the new method call, as the
+        // legacy assert from Simpletest used to support a message. In fact,
+        // assertText dropped that, but many code bases still have a second
+        // argument for the message. Let's help them drop it.
+        return [$args[0]];
+    }
+
+}

--- a/src/Rector/Deprecation/AssertResponseRector.php
+++ b/src/Rector/Deprecation/AssertResponseRector.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertResponseRector extends AssertLegacyTraitBase
+{
+
+    protected $deprecatedMethodName = 'assertResponse';
+    protected $methodName = 'statusCodeEquals';
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertResponse() calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$this->assertResponse(200);
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$this->assertSession()->statusCodeEquals(200);
+CODE_AFTER
+            )
+        ]);
+    }
+
+}

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -2,13 +2,14 @@
 
 namespace DrupalRector\Rector\Deprecation;
 
+use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertTextRector extends AbstractRector
+final class AssertTextRector extends AssertLegacyTraitBase
 {
 
     use AddCommentTrait;
@@ -30,13 +31,6 @@ CODE_AFTER
         ]);
     }
 
-    public function getNodeTypes(): array
-    {
-        return [
-            Node\Expr\MethodCall::class,
-        ];
-    }
-
     public function refactor(Node $node): ?Node
     {
         assert($node instanceof Node\Expr\MethodCall);
@@ -48,11 +42,10 @@ CODE_AFTER
             'Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.'
             . PHP_EOL . '// The passed text should be HTML decoded, exactly as a human sees it in the browser.'
         );
-        $assertSessionNode = $this->nodeFactory->createLocalMethodCall('assertSession');
         // We do not pass the full `$node->args` to the new method call, as the
         // legacy assert from Simpletest used to support a message. In fact,
         // assertText dropped that, but many code bases still have a second
         // argument for the message. Let's help them drop it.
-        return $this->nodeFactory->createMethodCall($assertSessionNode, 'pageTextContains', [$node->args[0]]);
+        return $this->createAssertSessionMethodCall('pageTextContains', [$node->args[0]]);
     }
 }

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -4,7 +4,6 @@ namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
 use DrupalRector\Utility\AddCommentTrait;
-use PhpParser\Node;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -19,7 +19,7 @@ final class AssertTextRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertText() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->drupalGet('test-page');

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Utility\AddCommentTrait;
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class AssertTextRector extends AbstractRector
+{
+
+    use AddCommentTrait;
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$this->drupalGet('test-page');
+$this->assertText('Expected content', 'Page has expected content.');
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$this->drupalGet('test-page');
+$this->assertSession()->pageTextContains('Expected content', 'Page has expected content.');
+CODE_AFTER
+            )
+        ]);
+    }
+
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\MethodCall::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+        if ($this->getName($node->name) !== 'assertText') {
+            return null;
+        }
+        $this->addDrupalRectorComment(
+            $node,
+            'Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.'
+            . PHP_EOL . '// The passed text should be HTML decoded, exactly as a human sees it in the browser.'
+        );
+        $assertSessionNode = $this->nodeFactory->createLocalMethodCall('assertSession');
+        // We do not pass the full `$node->args` to the new method call, as the
+        // legacy assert from Simpletest used to support a message. In fact,
+        // assertText dropped that, but many code bases still have a second
+        // argument for the message. Let's help them drop it.
+        return $this->nodeFactory->createMethodCall($assertSessionNode, 'pageTextContains', [$node->args[0]]);
+    }
+}

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -5,14 +5,18 @@ namespace DrupalRector\Rector\Deprecation;
 use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
-use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class AssertTextRector extends AssertLegacyTraitBase
 {
-
     use AddCommentTrait;
+
+    // @codingStandardsIgnoreLine
+    protected $comment = 'Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.' .
+        PHP_EOL . '// The passed text should be HTML decoded, exactly as a human sees it in the browser.';
+    protected $deprecatedMethodName = 'assertText';
+    protected $methodName = 'pageTextContains';
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -31,21 +35,12 @@ CODE_AFTER
         ]);
     }
 
-    public function refactor(Node $node): ?Node
+    protected function processArgs(array $args): array
     {
-        assert($node instanceof Node\Expr\MethodCall);
-        if ($this->getName($node->name) !== 'assertText') {
-            return null;
-        }
-        $this->addDrupalRectorComment(
-            $node,
-            'Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.'
-            . PHP_EOL . '// The passed text should be HTML decoded, exactly as a human sees it in the browser.'
-        );
         // We do not pass the full `$node->args` to the new method call, as the
         // legacy assert from Simpletest used to support a message. In fact,
         // assertText dropped that, but many code bases still have a second
         // argument for the message. Let's help them drop it.
-        return $this->createAssertSessionMethodCall('pageTextContains', [$node->args[0]]);
+        return [$args[0]];
     }
 }

--- a/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
+++ b/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
@@ -2,11 +2,20 @@
 
 namespace DrupalRector\Rector\Deprecation\Base;
 
+use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use Rector\Core\Rector\AbstractRector;
 
 abstract class AssertLegacyTraitBase extends AbstractRector
 {
+
+    use AddCommentTrait;
+
+    protected $comment = '';
+    protected $deprecatedMethodName;
+    protected $methodName;
+    protected $isAssertSessionMethod = true;
+
     public function getNodeTypes(): array
     {
         return [
@@ -18,6 +27,29 @@ abstract class AssertLegacyTraitBase extends AbstractRector
     {
         $assertSessionNode = $this->nodeFactory->createLocalMethodCall('assertSession');
         return $this->nodeFactory->createMethodCall($assertSessionNode, $method, $args);
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\MethodCall);
+        if ($this->getName($node->name) !== $this->deprecatedMethodName) {
+            return null;
+        }
+
+        if ($this->comment !== '') {
+            $this->addDrupalRectorComment($node, $this->comment);
+        }
+
+        $args = $this->processArgs($node->args);
+        if ($this->isAssertSessionMethod) {
+            return $this->createAssertSessionMethodCall($this->methodName, $args);
+        }
+        return $this->nodeFactory->createLocalMethodCall($this->methodName, $args);
+    }
+
+    protected function processArgs(array $args): array
+    {
+        return $args;
     }
 }
 

--- a/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
+++ b/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation\Base;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+
+abstract class AssertLegacyTraitBase extends AbstractRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\MethodCall::class,
+        ];
+    }
+
+    protected function createAssertSessionMethodCall(string $method, array $args): Node\Expr\MethodCall
+    {
+        $assertSessionNode = $this->nodeFactory->createLocalMethodCall('assertSession');
+        return $this->nodeFactory->createMethodCall($assertSessionNode, $method, $args);
+    }
+}
+

--- a/src/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
+++ b/src/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
@@ -83,7 +83,6 @@ CODE_AFTER
             [$path, $edit, $button, $options, $htmlId] = $this->safeArgDestructure($node);
             $pathValue = $path->value;
             assert($pathValue instanceof Node\Scalar\String_);
-
             if ($options === null) {
                 $drupalGetNode = $this->nodeFactory->createLocalMethodCall('drupalGet', [$path]);
             } else {

--- a/tests/src/Rector/Deprecation/AssertEqualRector/AssertEqualRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertEqualRector/AssertEqualRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertEqualRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @coversDefaultClass \DrupalRector\Rector\Deprecation\DatetimeStorageTimezoneRector
+ */
+class AssertEqualRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertEqualRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertEqualRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\AssertEqualRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AssertEqualRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/AssertEqualRector/fixture/simple.php.inc
+++ b/tests/src/Rector/Deprecation/AssertEqualRector/fixture/simple.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->assertEqual('Actual', 'Expected', 'Message');
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->assertEquals('Actual', 'Expected', 'Message');
+    }
+}
+?>

--- a/tests/src/Rector/Deprecation/AssertFieldByNameRector/AssertFieldByNameRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertFieldByNameRector/AssertFieldByNameRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertFieldByNameRectorTest;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @coversDefaultClass \DrupalRector\Rector\Deprecation\DatetimeStorageTimezoneRector
+ */
+class AssertFieldByNameRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertFieldByNameRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertFieldByNameRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\AssertFieldByNameRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AssertFieldByNameRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/AssertFieldByNameRector/fixture/with_value_check.php.inc
+++ b/tests/src/Rector/Deprecation/AssertFieldByNameRector/fixture/with_value_check.php.inc
@@ -1,0 +1,51 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $edit = [
+            'aggregator_allowed_html_tags' => '<a>',
+            'aggregator_summary_items' => 10,
+            'aggregator_clear' => 3600,
+            'aggregator_teaser_length' => 200,
+            'aggregator_fetcher' => 'aggregator_test_fetcher',
+            'aggregator_parser' => 'aggregator_test_parser',
+            'aggregator_processors[aggregator_test_processor]' => 'aggregator_test_processor',
+        ];
+        foreach ($edit as $name => $value) {
+            $this->assertFieldByName($name, $value, new FormattableMarkup('"@name" has correct default value.', ['@name' => $name]));
+        }
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $edit = [
+            'aggregator_allowed_html_tags' => '<a>',
+            'aggregator_summary_items' => 10,
+            'aggregator_clear' => 3600,
+            'aggregator_teaser_length' => 200,
+            'aggregator_fetcher' => 'aggregator_test_fetcher',
+            'aggregator_parser' => 'aggregator_test_parser',
+            'aggregator_processors[aggregator_test_processor]' => 'aggregator_test_processor',
+        ];
+        foreach ($edit as $name => $value) {
+            $this->assertSession()->fieldValueEquals($name, $value);
+        }
+    }
+}
+?>

--- a/tests/src/Rector/Deprecation/AssertFieldByNameRector/fixture/without_value_check.php.inc
+++ b/tests/src/Rector/Deprecation/AssertFieldByNameRector/fixture/without_value_check.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $field_name = 'foo';
+        $this->assertFieldByName("{$field_name}[0][value][date]", '', 'Date element found.');
+        $this->assertFieldByName("{$field_name}[0][value][time]", null, 'Time element found.');
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $field_name = 'foo';
+        $this->assertSession()->fieldValueEquals("{$field_name}[0][value][date]", '');
+        $this->assertSession()->fieldExists("{$field_name}[0][value][time]");
+    }
+}
+?>

--- a/tests/src/Rector/Deprecation/AssertIdenticalRector/AssertIdenticalRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertIdenticalRector/AssertIdenticalRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertIdenticalRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @coversDefaultClass \DrupalRector\Rector\Deprecation\DatetimeStorageTimezoneRector
+ */
+class AssertIdenticalRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertIdenticalRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertIdenticalRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\AssertIdenticalRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AssertIdenticalRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/AssertIdenticalRector/fixture/simple.php.inc
+++ b/tests/src/Rector/Deprecation/AssertIdenticalRector/fixture/simple.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->assertIdentical('Actual', 'Expected', 'Message');
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->assertSame('Actual', 'Expected', 'Message');
+    }
+}
+?>

--- a/tests/src/Rector/Deprecation/AssertRawRector/AssertRawRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertRawRector/AssertRawRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertRawRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @coversDefaultClass \DrupalRector\Rector\Deprecation\DatetimeStorageTimezoneRector
+ */
+class AssertRawRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertRawRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertRawRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\AssertRawRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AssertRawRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/AssertRawRector/fixture/simple.php.inc
+++ b/tests/src/Rector/Deprecation/AssertRawRector/fixture/simple.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->drupalGet('test-page');
+        $this->assertRaw('bartik/logo.svg', 'Make sure the original bartik logo exists.');
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->drupalGet('test-page');
+        $this->assertSession()->responseContains('bartik/logo.svg');
+    }
+}
+?>

--- a/tests/src/Rector/Deprecation/AssertResponseRector/AssertResponseRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertResponseRector/AssertResponseRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertTextRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @coversDefaultClass \DrupalRector\Rector\Deprecation\DatetimeStorageTimezoneRector
+ */
+class AssertResponseRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertResponseRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertResponseRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\AssertResponseRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AssertResponseRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/AssertResponseRector/fixture/simple.php.inc
+++ b/tests/src/Rector/Deprecation/AssertResponseRector/fixture/simple.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->drupalGet('test-page');
+        $this->assertResponse(200);
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->drupalGet('test-page');
+        $this->assertSession()->statusCodeEquals(200);
+    }
+}
+?>

--- a/tests/src/Rector/Deprecation/AssertTextRector/AssertTextRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertTextRector/AssertTextRectorTest.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertTextRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+/**
+ * @coversDefaultClass \DrupalRector\Rector\Deprecation\DatetimeStorageTimezoneRector
+ */
+class AssertTextRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertTextRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertTextRector/config/configured_rule.php
@@ -1,14 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\AssertTextRector;
-use DrupalRector\Rector\Deprecation\UiHelperTraitDrupalPostFormRector;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(UiHelperTraitDrupalPostFormRector::class);
     $services->set(AssertTextRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
 };

--- a/tests/src/Rector/Deprecation/AssertTextRector/fixture/simple.php.inc
+++ b/tests/src/Rector/Deprecation/AssertTextRector/fixture/simple.php.inc
@@ -1,0 +1,36 @@
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $current_content = $this->randomMachineName();
+        $this->drupalGet('test-page');
+        $this->assertText($current_content, 'Block content displays on the test page.');
+    }
+}
+?>
+-----
+<?php
+
+use Drupal\Tests\BrowserTestBase;
+
+class BrowserTestBaseGetMock extends BrowserTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $current_content = $this->randomMachineName();
+        $this->drupalGet('test-page');
+        // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+        // Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.
+        // The passed text should be HTML decoded, exactly as a human sees it in the browser.
+        $this->assertSession()->pageTextContains($current_content);
+    }
+}
+?>


### PR DESCRIPTION
## Description
Adds rules for legacy assertion methods. This takes care of the top 7 (excluding `drupalPostForm` which was already fixed.)

* assertText
* assertEqual
* assertIdentical
* assertResponse
* assertRaw
* assertFieldByName 


## To Test
- Add steps to test this feature

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3222671