### PR TITLE
Fix REQUEST_TIME deprecation message. Noted by @mglaman

### DIFF
--- a/deprecation-index.yml
+++ b/deprecation-index.yml
@@ -156,7 +156,7 @@
     - FileUnmanagedSaveDataStatic.php
 'REQUEST_TIME':
     Rector: RequestTimeConstRector.php
-    PHPStan: 'Call to deprecated const REQUEST_TIME. Deprecated in drupal:8.3.0 and is removed from drupal:10.0.0. Use Drupal::time()->getRequestTime().'
+    PHPStan: 'Call to deprecated constant REQUEST_TIME. Deprecated in drupal:8.3.0 and is removed from drupal:10.0.0. Use Drupal::time()->getRequestTime().'
     Examples:
         - request_time_const.php
 'entity_get_display()':


### PR DESCRIPTION
## Description

Deprecation message is wrong for REQUEST TIME. Thus it does not match up with the result from upgrade status and does not get flagged as covered.

## To Test

- Add steps to test this feature

## Drupal.org issue

https://www.drupal.org/project/rector/issues/3226932
