### PR TITLE
Cleans up internal function doc mismatches.

### DIFF
--- a/src/Rector/Deprecation/AssertFieldRector.php
+++ b/src/Rector/Deprecation/AssertFieldRector.php
@@ -15,7 +15,7 @@ final class AssertFieldRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertEscaped() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertField() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertField('files[upload]', 'Found file upload field.');

--- a/src/Rector/Deprecation/AssertHeaderRector.php
+++ b/src/Rector/Deprecation/AssertHeaderRector.php
@@ -14,7 +14,7 @@ final class AssertHeaderRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertResponse() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertHeader calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertHeader('Foo', 'Bar');

--- a/src/Rector/Deprecation/AssertNoCacheTagRector.php
+++ b/src/Rector/Deprecation/AssertNoCacheTagRector.php
@@ -14,7 +14,7 @@ final class AssertNoCacheTagRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertResponse() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoCacheTag() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoCacheTag('some-cache-tag');

--- a/src/Rector/Deprecation/AssertNoFieldByNameRector.php
+++ b/src/Rector/Deprecation/AssertNoFieldByNameRector.php
@@ -16,7 +16,7 @@ final class AssertNoFieldByNameRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertResponse() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoFieldByName() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertNoFieldByName('name');

--- a/src/Rector/Deprecation/AssertOptionSelectedRector.php
+++ b/src/Rector/Deprecation/AssertOptionSelectedRector.php
@@ -12,7 +12,7 @@ final class AssertOptionSelectedRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertOptionSelected() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertOptionSelected('options', 2);

--- a/src/Rector/Deprecation/DBDeleteRector.php
+++ b/src/Rector/Deprecation/DBDeleteRector.php
@@ -28,7 +28,7 @@ final class DBDeleteRector extends DBBase
    */
   public function getRuleDefinition(): RuleDefinition
   {
-    return new RuleDefinition('Fixes deprecated db_insert() calls',[
+    return new RuleDefinition('Fixes deprecated db_delete() calls',[
       new CodeSample(
         <<<'CODE_BEFORE'
 db_delete($table, $options);

--- a/src/Rector/Deprecation/FileDirectoryOsTempRector.php
+++ b/src/Rector/Deprecation/FileDirectoryOsTempRector.php
@@ -27,7 +27,7 @@ final class FileDirectoryOsTempRector extends FunctionToStatic
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated file_directory_temp() calls',[
+        return new RuleDefinition('Fixes deprecated file_directory_os_temp() calls',[
             new CodeSample(
                 <<<'CODE_BEFORE'
 $dir = file_directory_os_temp();

--- a/src/Rector/Deprecation/GetAllOptionsRector.php
+++ b/src/Rector/Deprecation/GetAllOptionsRector.php
@@ -24,7 +24,7 @@ final class GetAllOptionsRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::getRawContent() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::getAllOptions() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->drupalGet('/form-test/select');


### PR DESCRIPTION
## Description

Fixes internal documentation mismatches in the RuleDefinition() method of various rectors.


## To Test
- Check documentation of RuleDefinition() in the affects files.

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3227957#comment-14190104