### PR TITLE
Only load stubs in dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,15 +35,15 @@
     "autoload": {
         "psr-4": {
             "DrupalRector\\": "src"
-        },
-        "classmap": [
-            "stubs"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {
             "DrupalRector\\Tests\\": "tests/src"
-        }
+        },
+        "classmap": [
+            "stubs"
+        ]
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
## Description
Prevents stubs used for testing from breaking end user's PHPUnit tests for Drupal


## To Test
- Checkout
- Run a Functional test in core. No errors

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3223276