### PR TITLE
Issue #3225109: Include rector-phpunit config set lists for deprecated code fixes

### DIFF
--- a/config/drupal-8/drupal-8-all-deprecations.php
+++ b/config/drupal-8/drupal-8-all-deprecations.php
@@ -3,10 +3,15 @@
 declare(strict_types=1);
 
 use Rector\Core\Configuration\Option;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/drupal-8.*');
+
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_60);
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_70);
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_75);
 
     $parameters = $containerConfigurator->parameters();
 

--- a/config/drupal-9/drupal-9.0-deprecations.php
+++ b/config/drupal-9/drupal-9.0-deprecations.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_80);
 };

--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -48,10 +48,13 @@ use DrupalRector\Rector\Deprecation\GetAllOptionsRector;
 use DrupalRector\Rector\Deprecation\GetRawContentRector;
 use DrupalRector\Rector\Deprecation\PassRector;
 use DrupalRector\Rector\Deprecation\UiHelperTraitDrupalPostFormRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
+
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_90);
 
     $services->set(UiHelperTraitDrupalPostFormRector::class);
     // AssertLegacyTrait items

--- a/config/drupal-9/drupal-9.2-deprecations.php
+++ b/config/drupal-9/drupal-9.2-deprecations.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_91);
 };

--- a/fixtures/d8/rector_examples/test/src/Unit/UnitTestCaseGetMock.php
+++ b/fixtures/d8/rector_examples/test/src/Unit/UnitTestCaseGetMock.php
@@ -24,7 +24,7 @@ class UnitTestCaseGetMock extends UnitTestCase {
   /**
    * An example of chaining method calls.
    *
-   * This should not get updated, since `getMockBuilder()` is not deprecated.
+   * This will be updated by Rector PHPUnit.
    */
   public function chaining_method_calls() {
     $this->entityTypeManager = $this->getMockBuilder('Drupal\Core\Entity\EntityTypeManagerInterface')

--- a/fixtures/d8/rector_examples_updated/test/src/Unit/UnitTestCaseGetMock.php
+++ b/fixtures/d8/rector_examples_updated/test/src/Unit/UnitTestCaseGetMock.php
@@ -24,11 +24,9 @@ class UnitTestCaseGetMock extends UnitTestCase {
   /**
    * An example of chaining method calls.
    *
-   * This should not get updated, since `getMockBuilder()` is not deprecated.
+   * This will be updated by Rector PHPUnit.
    */
   public function chaining_method_calls() {
-    $this->entityTypeManager = $this->getMockBuilder('Drupal\Core\Entity\EntityTypeManagerInterface')
-      ->disableOriginalConstructor()
-      ->getMock();
+      $this->entityTypeManager = $this->createMock('Drupal\Core\Entity\EntityTypeManagerInterface');
   }
 }

--- a/fixtures/d9/rector_examples/tests/src/Kernel/SetupVoidTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Kernel/SetupVoidTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\rector_examples\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp()
+    {
+        parent::setUp();
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Kernel/SetupVoidTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Kernel/SetupVoidTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\rector_examples\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+}


### PR DESCRIPTION
## Description
Adds Rector's PHPUnit rules so that deprecated PHPUnit stuff is fixed.

See https://dev.acquia.com/drupal10/deprecation_status/errors?error=%2APHPUnit%2A&category=Non-Drupal%20core%20deprecation


## To Test
- Add steps to test this feature

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3225109
