### PR TITLE
Issue #3226796: Include rector-symfony config set lists for deprecated code fixes

### DIFF
--- a/config/drupal-9/drupal-9.0-deprecations.php
+++ b/config/drupal-9/drupal-9.0-deprecations.php
@@ -3,8 +3,14 @@
 declare(strict_types=1);
 
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Symfony\Set\SymfonySetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_80);
+    $containerConfigurator->import(SymfonySetList::SYMFONY_40);
+    $containerConfigurator->import(SymfonySetList::SYMFONY_41);
+    $containerConfigurator->import(SymfonySetList::SYMFONY_42);
+    $containerConfigurator->import(SymfonySetList::SYMFONY_43);
+    $containerConfigurator->import(SymfonySetList::SYMFONY_44);
 };

--- a/fixtures/d9/rector_examples/src/DispatchingService.php
+++ b/fixtures/d9/rector_examples/src/DispatchingService.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\rector_examples;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class DispatchingService {
+
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $event_dispatcher) {
+        $this->eventDispatcher = $event_dispatcher;
+    }
+
+    public function doADispatch() {
+        $this->eventDispatcher->dispatch('sample_event_name', new Event());
+    }
+
+}

--- a/fixtures/d9/rector_examples/src/EventSubscriber/ExceptionSubscriber.php
+++ b/fixtures/d9/rector_examples/src/EventSubscriber/ExceptionSubscriber.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\rector_examples\EventSubscriber;
+
+use Drupal\Core\EventSubscriber\CustomPageExceptionHtmlSubscriber;
+use Drupal\Core\ParamConverter\ParamNotConvertedException;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+class ExceptionSubscriber extends CustomPageExceptionHtmlSubscriber {
+
+    public function on404(GetResponseForExceptionEvent $event) {
+        $exception = $event->getException();
+        $previous = $exception->getPrevious();
+        if ($previous instanceof ParamNotConvertedException) {
+            // logic
+        }
+        else {
+            parent::on404($event);
+        }
+    }
+}

--- a/fixtures/d9/rector_examples_updated/src/DispatchingService.php
+++ b/fixtures/d9/rector_examples_updated/src/DispatchingService.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\rector_examples;
+
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+final class DispatchingService {
+
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    public function __construct(EventDispatcherInterface $event_dispatcher) {
+        $this->eventDispatcher = $event_dispatcher;
+    }
+
+    public function doADispatch() {
+        $this->eventDispatcher->dispatch(new Event(), 'sample_event_name');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/src/EventSubscriber/ExceptionSubscriber.php
+++ b/fixtures/d9/rector_examples_updated/src/EventSubscriber/ExceptionSubscriber.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\rector_examples\EventSubscriber;
+
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Drupal\Core\EventSubscriber\CustomPageExceptionHtmlSubscriber;
+use Drupal\Core\ParamConverter\ParamNotConvertedException;
+
+class ExceptionSubscriber extends CustomPageExceptionHtmlSubscriber {
+
+    public function on404(ExceptionEvent $event) {
+        $exception = $event->getException();
+        $previous = $exception->getPrevious();
+        if ($previous instanceof ParamNotConvertedException) {
+            // logic
+        }
+        else {
+            parent::on404($event);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds all of the Symfony 4 Rector rules for deprecated code.


## To Test
Functional tests shows deprecated class renames and fixing of the `dispatch` call (object first, name second and optional).

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3226796