### PR TITLE
Use fully qualified names in RuleDefinition

### DIFF
--- a/src/Rector/Deprecation/AssertCacheTagRector.php
+++ b/src/Rector/Deprecation/AssertCacheTagRector.php
@@ -15,7 +15,7 @@ final class AssertCacheTagRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertCacheTag() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertCacheTag() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertCacheTag('some-cache-tag');

--- a/src/Rector/Deprecation/AssertElementNotPresentRector.php
+++ b/src/Rector/Deprecation/AssertElementNotPresentRector.php
@@ -14,7 +14,7 @@ final class AssertElementNotPresentRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertElementNotPresent() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertElementNotPresent() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertElementNotPresent('css', '.region-content-message.region-empty');

--- a/src/Rector/Deprecation/AssertElementPresentRector.php
+++ b/src/Rector/Deprecation/AssertElementPresentRector.php
@@ -14,7 +14,7 @@ final class AssertElementPresentRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertElementPresent() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertElementPresent() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertElementPresent('css', '.region-content-message.region-empty');

--- a/src/Rector/Deprecation/AssertEqualRector.php
+++ b/src/Rector/Deprecation/AssertEqualRector.php
@@ -15,7 +15,7 @@ final class AssertEqualRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertEqual() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assertEqual() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertEqual('Actual', 'Expected', 'Message');

--- a/src/Rector/Deprecation/AssertEscapedRector.php
+++ b/src/Rector/Deprecation/AssertEscapedRector.php
@@ -14,7 +14,7 @@ final class AssertEscapedRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertEscaped() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertEscaped() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertEscaped('Demonstrate block regions (<"Cat" & \'Mouse\'>)');

--- a/src/Rector/Deprecation/AssertFieldByIdRector.php
+++ b/src/Rector/Deprecation/AssertFieldByIdRector.php
@@ -12,7 +12,7 @@ final class AssertFieldByIdRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertFieldById() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertFieldById() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertFieldById('edit-name', NULL);

--- a/src/Rector/Deprecation/AssertFieldByNameRector.php
+++ b/src/Rector/Deprecation/AssertFieldByNameRector.php
@@ -12,7 +12,7 @@ final class AssertFieldByNameRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertFieldByName() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertFieldByName() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertFieldByName('field_name', 'expected_value');

--- a/src/Rector/Deprecation/AssertFieldCheckedRector.php
+++ b/src/Rector/Deprecation/AssertFieldCheckedRector.php
@@ -14,7 +14,7 @@ final class AssertFieldCheckedRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertFieldChecked() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertFieldChecked() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertFieldChecked('edit-settings-view-mode', 'default');

--- a/src/Rector/Deprecation/AssertFieldRector.php
+++ b/src/Rector/Deprecation/AssertFieldRector.php
@@ -15,7 +15,7 @@ final class AssertFieldRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertField() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertField() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertField('files[upload]', 'Found file upload field.');

--- a/src/Rector/Deprecation/AssertHeaderRector.php
+++ b/src/Rector/Deprecation/AssertHeaderRector.php
@@ -14,7 +14,7 @@ final class AssertHeaderRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertHeader calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertHeader() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertHeader('Foo', 'Bar');

--- a/src/Rector/Deprecation/AssertIdenticalObjectRector.php
+++ b/src/Rector/Deprecation/AssertIdenticalObjectRector.php
@@ -15,7 +15,7 @@ final class AssertIdenticalObjectRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertIdenticalObject() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assertIdenticalObject() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertIdenticalObject('Actual', 'Expected', 'Message');

--- a/src/Rector/Deprecation/AssertIdenticalRector.php
+++ b/src/Rector/Deprecation/AssertIdenticalRector.php
@@ -15,7 +15,7 @@ final class AssertIdenticalRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertIdentical() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assertIdentical() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertIdentical('Actual', 'Expected', 'Message');

--- a/src/Rector/Deprecation/AssertLinkByHrefRector.php
+++ b/src/Rector/Deprecation/AssertLinkByHrefRector.php
@@ -15,7 +15,7 @@ final class AssertLinkByHrefRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertLinkByHref() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertLinkByHref() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertLinkByHref('user/1/translations');

--- a/src/Rector/Deprecation/AssertLinkRector.php
+++ b/src/Rector/Deprecation/AssertLinkRector.php
@@ -15,7 +15,7 @@ final class AssertLinkRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertLink() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertLink() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertLink('Anonymous comment title');

--- a/src/Rector/Deprecation/AssertNoCacheTagRector.php
+++ b/src/Rector/Deprecation/AssertNoCacheTagRector.php
@@ -14,7 +14,7 @@ final class AssertNoCacheTagRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoCacheTag() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoCacheTag() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoCacheTag('some-cache-tag');

--- a/src/Rector/Deprecation/AssertNoEscapedRector.php
+++ b/src/Rector/Deprecation/AssertNoEscapedRector.php
@@ -14,7 +14,7 @@ final class AssertNoEscapedRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoEscaped() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoEscaped() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoEscaped('<div class="escaped">');

--- a/src/Rector/Deprecation/AssertNoFieldByIdRector.php
+++ b/src/Rector/Deprecation/AssertNoFieldByIdRector.php
@@ -12,7 +12,7 @@ final class AssertNoFieldByIdRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoFieldById() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoFieldById() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertNoFieldById('name');

--- a/src/Rector/Deprecation/AssertNoFieldByNameRector.php
+++ b/src/Rector/Deprecation/AssertNoFieldByNameRector.php
@@ -16,7 +16,7 @@ final class AssertNoFieldByNameRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoFieldByName() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoFieldByName() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertNoFieldByName('name');

--- a/src/Rector/Deprecation/AssertNoFieldCheckedRector.php
+++ b/src/Rector/Deprecation/AssertNoFieldCheckedRector.php
@@ -14,7 +14,7 @@ final class AssertNoFieldCheckedRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoFieldChecked() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoFieldChecked() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoFieldChecked('edit-settings-view-mode', 'default');

--- a/src/Rector/Deprecation/AssertNoFieldRector.php
+++ b/src/Rector/Deprecation/AssertNoFieldRector.php
@@ -15,7 +15,7 @@ final class AssertNoFieldRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoField() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoField() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertNoField('files[upload]', 'Found file upload field.');

--- a/src/Rector/Deprecation/AssertNoLinkByHrefRector.php
+++ b/src/Rector/Deprecation/AssertNoLinkByHrefRector.php
@@ -14,7 +14,7 @@ final class AssertNoLinkByHrefRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoLinkByHref() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoLinkByHref() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoLinkByHref('user/2/translations');

--- a/src/Rector/Deprecation/AssertNoLinkRector.php
+++ b/src/Rector/Deprecation/AssertNoLinkRector.php
@@ -14,7 +14,7 @@ final class AssertNoLinkRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoLink() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoLink() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoLink('Anonymous comment title');

--- a/src/Rector/Deprecation/AssertNoOptionRector.php
+++ b/src/Rector/Deprecation/AssertNoOptionRector.php
@@ -14,7 +14,7 @@ final class AssertNoOptionRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoOption() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoOption() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoOption('edit-settings-view-mode', 'default');

--- a/src/Rector/Deprecation/AssertNoPatternRector.php
+++ b/src/Rector/Deprecation/AssertNoPatternRector.php
@@ -14,7 +14,7 @@ final class AssertNoPatternRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoPattern() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoPattern() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoPattern('|<h4[^>]*></h4>|', 'No empty H4 element found.');

--- a/src/Rector/Deprecation/AssertNoRawRector.php
+++ b/src/Rector/Deprecation/AssertNoRawRector.php
@@ -14,7 +14,7 @@ final class AssertNoRawRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoRaw() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoRaw() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNoRaw('bartik/logo.svg');

--- a/src/Rector/Deprecation/AssertNoTextRector.php
+++ b/src/Rector/Deprecation/AssertNoTextRector.php
@@ -19,7 +19,7 @@ final class AssertNoTextRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNoText() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertNoText() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->drupalGet('test-page');

--- a/src/Rector/Deprecation/AssertNoUniqueTextRector.php
+++ b/src/Rector/Deprecation/AssertNoUniqueTextRector.php
@@ -28,7 +28,7 @@ final class AssertNoUniqueTextRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertUniqueText() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertUniqueText() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertUniqueText('Color set');

--- a/src/Rector/Deprecation/AssertNotEqualRector.php
+++ b/src/Rector/Deprecation/AssertNotEqualRector.php
@@ -15,7 +15,7 @@ final class AssertNotEqualRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNotEqual() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assertNotEqual() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNotEqual('Actual', 'Expected', 'Message');

--- a/src/Rector/Deprecation/AssertNotIdenticalRector.php
+++ b/src/Rector/Deprecation/AssertNotIdenticalRector.php
@@ -15,7 +15,7 @@ final class AssertNotIdenticalRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertNotIdentical() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assertNotIdentical() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertNotIdentical('Actual', 'Expected', 'Message');

--- a/src/Rector/Deprecation/AssertOptionByTextRector.php
+++ b/src/Rector/Deprecation/AssertOptionByTextRector.php
@@ -14,7 +14,7 @@ final class AssertOptionByTextRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertOptionByText() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertOptionByText() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertOptionByText('edit-settings-view-mode', 'default');

--- a/src/Rector/Deprecation/AssertOptionRector.php
+++ b/src/Rector/Deprecation/AssertOptionRector.php
@@ -14,7 +14,7 @@ final class AssertOptionRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertOption() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertOption() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertOption('edit-settings-view-mode', 'default');

--- a/src/Rector/Deprecation/AssertOptionSelectedRector.php
+++ b/src/Rector/Deprecation/AssertOptionSelectedRector.php
@@ -12,7 +12,7 @@ final class AssertOptionSelectedRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertOptionSelected() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertOptionSelected() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertOptionSelected('options', 2);

--- a/src/Rector/Deprecation/AssertPatternRector.php
+++ b/src/Rector/Deprecation/AssertPatternRector.php
@@ -14,7 +14,7 @@ final class AssertPatternRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertPattern() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertPattern() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertPattern('|<h4[^>]*></h4>|', 'No empty H4 element found.');

--- a/src/Rector/Deprecation/AssertRawRector.php
+++ b/src/Rector/Deprecation/AssertRawRector.php
@@ -14,7 +14,7 @@ final class AssertRawRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertRaw() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertRaw() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertRaw('bartik/logo.svg');

--- a/src/Rector/Deprecation/AssertRector.php
+++ b/src/Rector/Deprecation/AssertRector.php
@@ -15,7 +15,7 @@ final class AssertRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assert() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assert() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assert($foo);

--- a/src/Rector/Deprecation/AssertResponseRector.php
+++ b/src/Rector/Deprecation/AssertResponseRector.php
@@ -14,7 +14,7 @@ final class AssertResponseRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertResponse() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertResponse() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertResponse(200);

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -19,7 +19,7 @@ final class AssertTextRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertText() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertText() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->drupalGet('test-page');

--- a/src/Rector/Deprecation/AssertTitleRector.php
+++ b/src/Rector/Deprecation/AssertTitleRector.php
@@ -14,7 +14,7 @@ final class AssertTitleRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertTitle() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertTitle() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertTitle('Block layout | Drupal');

--- a/src/Rector/Deprecation/AssertUniqueTextRector.php
+++ b/src/Rector/Deprecation/AssertUniqueTextRector.php
@@ -15,7 +15,7 @@ final class AssertUniqueTextRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertUniqueText() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertUniqueText() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertUniqueText('Color set');

--- a/src/Rector/Deprecation/AssertUrlRector.php
+++ b/src/Rector/Deprecation/AssertUrlRector.php
@@ -14,7 +14,7 @@ final class AssertUrlRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertUrl() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertUrl() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->assertUrl('myrootuser');

--- a/src/Rector/Deprecation/BrowserTestBaseGetMockRector.php
+++ b/src/Rector/Deprecation/BrowserTestBaseGetMockRector.php
@@ -23,7 +23,7 @@ final class BrowserTestBaseGetMockRector extends GetMockBase
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated getMock() calls',[
+        return new RuleDefinition('Fixes deprecated \Drupal\Tests\BrowserTestBase\getMock() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->entityTypeManager = $this->getMock(EntityTypeManagerInterface::class);

--- a/src/Rector/Deprecation/BuildXPathQueryRector.php
+++ b/src/Rector/Deprecation/BuildXPathQueryRector.php
@@ -14,7 +14,7 @@ final class BuildXPathQueryRector extends AssertLegacyTraitBase
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertResponse() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::assertResponse() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $xpath = $this->buildXPathQuery('//select[@name=:name]', [':name' => $name]);

--- a/src/Rector/Deprecation/ConstructFieldXpathRector.php
+++ b/src/Rector/Deprecation/ConstructFieldXpathRector.php
@@ -12,7 +12,7 @@ final class ConstructFieldXpathRector extends AbstractRector {
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::constructFieldXpath() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\FunctionalTests\AssertLegacyTrait::constructFieldXpath() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->constructFieldXpath('id', 'edit-preferred-admin-langcode')

--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -12,7 +12,7 @@ final class PassRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertEqual() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\KernelTests\AssertLegacyTrait::assertEqual() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $this->pass('The whole transaction is rolled back when a duplicate key insert occurs.');

--- a/src/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
+++ b/src/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
@@ -25,7 +25,7 @@ final class UiHelperTraitDrupalPostFormRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+        return new RuleDefinition('Fixes deprecated \Drupal\Tests\UiHelperTrait::drupalPostForm() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $edit = [];


### PR DESCRIPTION
Expands #171 to include fully qualified names, so that we can catch any errors or mis-fixes correctly. (For example, see issue https://www.drupal.org/project/rector/issues/3229883)