### PR TITLE
Issue #3228110: Improve AssertNoUniqueTextRector documentation and scope

### DIFF
--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -2,17 +2,17 @@
 
 namespace DrupalRector\Rector\Deprecation;
 
+use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
-use PHPStan\Analyser\Scope;
-use PHPStan\Reflection\Php\PhpMethodReflection;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class PassRector extends AbstractRector
 {
+
+    use GetDeclaringSourceTrait;
 
     /**
      * @var ParentClassScopeResolver
@@ -52,20 +52,7 @@ CODE_AFTER
             return null;
         }
 
-        // @todo Maybe make this a service? Definitely needed in AssertLegacyTraitBase.
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-        assert($scope instanceof Scope);
-        $classReflection = $scope->getClassReflection();
-        assert($classReflection !== null);
-        $passReflection = $classReflection->getMethod('pass', $scope);
-        if (!$passReflection instanceof PhpMethodReflection) {
-            return null;
-        }
-        $declaringTrait = $passReflection->getDeclaringTrait();
-        if ($declaringTrait === null) {
-            return null;
-        }
-        if ($declaringTrait->getName() === 'Drupal\KernelTests\AssertLegacyTrait') {
+        if ($this->getDeclaringSource($node) === 'Drupal\KernelTests\AssertLegacyTrait') {
             $this->removeNode($node);
         }
 

--- a/src/Utility/GetDeclaringSourceTrait.php
+++ b/src/Utility/GetDeclaringSourceTrait.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Utility;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+
+trait GetDeclaringSourceTrait
+{
+
+    /**
+     * Gets a method or property's declaring source (trait or class.)
+     *
+     * @param Node\Expr\MethodCall|Node\Expr\PropertyFetch $expr
+     *   The expression.
+     *
+     * @return string|null
+     *   The declaring source (trait or class.)
+     */
+    protected function getDeclaringSource(Node\Expr $expr): ?string
+    {
+        $scope = $expr->getAttribute(AttributeKey::SCOPE);
+        assert($scope instanceof Scope);
+        $classReflection = $scope->getClassReflection();
+        assert($classReflection !== null);
+
+        $name = $this->getName($expr->name);
+        if ($expr instanceof Node\Expr\MethodCall) {
+            $exprReflection = $classReflection->getMethod($name, $scope);
+        } elseif ($expr instanceof Node\Expr\PropertyFetch) {
+            $exprReflection = $classReflection->getProperty($name, $scope);
+        } else {
+            throw new \InvalidArgumentException(
+                "Can only call getDeclaringSource on MethodCall or PropertyFetch. Received: " . get_class($expr)
+            );
+        }
+
+        $declaringTrait = $exprReflection->getDeclaringTrait();
+        if ($declaringTrait !== null) {
+            return $declaringTrait->getName();
+        }
+        $declaringClass = $exprReflection->getDeclaringClass();
+        if ($declaringClass !== null) {
+            return $declaringClass->getName();
+        }
+        return null;
+    }
+
+}

--- a/stubs/Drupal/FunctionalTests/AssertLegacyTrait.php
+++ b/stubs/Drupal/FunctionalTests/AssertLegacyTrait.php
@@ -12,4 +12,9 @@ if (class_exists('Drupal\FunctionalTests\AssertLegacyTrait')) {
 
 trait AssertLegacyTrait {
     use BaseAssertLegacyTrait;
+
+    protected function assertNoUniqueText($text, $message = '') {
+        $this->assertTrue(TRUE, $message);
+    }
+
 }

--- a/stubs/Drupal/KernelTests/AssertContentTrait.php
+++ b/stubs/Drupal/KernelTests/AssertContentTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\KernelTests;
+
+if (class_exists('Drupal\KernelTests\AssertContentTrait')) {
+    return;
+}
+
+trait AssertContentTrait {
+
+    protected function assertNoUniqueText($text, $message = '', $group = 'Other') {
+        return $this->assertUniqueTextHelper($text, $message, $group, FALSE);
+    }
+
+    protected function assertUniqueTextHelper($text, $message = '', $group = 'Other', $be_unique = FALSE) {
+        $this->assertTrue(TRUE, $message);
+    }
+
+}

--- a/stubs/Drupal/KernelTests/KernelTestBase.php
+++ b/stubs/Drupal/KernelTests/KernelTestBase.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\KernelTests;
+
+use PHPUnit\Framework\TestCase;
+
+if (class_exists('Drupal\KernelTests\KernelTestBase')) {
+    return;
+}
+
+abstract class KernelTestBase extends TestCase {
+
+    use AssertLegacyTrait;
+    use AssertContentTrait;
+
+}

--- a/tests/src/Rector/Deprecation/AssertUniqueTextRector/fixture/kerneltest_assert_no_unique_text.php.inc
+++ b/tests/src/Rector/Deprecation/AssertUniqueTextRector/fixture/kerneltest_assert_no_unique_text.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+class KernelTestExampleTest extends \Drupal\KernelTests\KernelTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->assertNoUniqueText('Duplicated message');
+    }
+}
+?>
+-----
+<?php
+
+class KernelTestExampleTest extends \Drupal\KernelTests\KernelTestBase {
+
+    /**
+     * A simple example using the class property.
+     */
+    public function example() {
+        $this->assertNoUniqueText('Duplicated message');
+    }
+}
+?>


### PR DESCRIPTION
## Description
Updates documentation on the Rector rule. Ensures that the refactoring is scoped to usages of the FunctionalTests deprecated trait. This moved logic inside of the PassRector to a trait to make it easier to re-use (see https://www.drupal.org/project/rector/issues/3229883)


## To Test


## Drupal.org issue
https://www.drupal.org/project/rector/issues/3228110