### PR TITLE
Add functional test code samples

### DIFF
--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertElementPresentTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertElementPresentTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertElementPresentTest extends BrowserTestBase {
+
+    public function testAssertElementPresent() {
+        $this->assertSession()->elementExists('css', '.region-content-message.region-empty');
+        $this->assertElementNotPresent('css', '.region-content-message.region-empty');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertEqualTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertEqualTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertEqualTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertEqual('Actual', 'Expected', 'Message');
+        $this->assertNotEqual('Actual', 'Expected', 'Message');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertEscapedTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertEscapedTest.php
@@ -7,8 +7,8 @@ use Drupal\Tests\BrowserTestBase;
 class AssertElementPresentTest extends BrowserTestBase {
 
     public function testAssertElementPresent() {
-        $this->assertElementPresent('css', '.region-content-message.region-empty');
-        $this->assertElementNotPresent('css', '.region-content-message.region-empty');
+        $this->assertEscaped('Demonstrate block regions (<"Cat" & \'Mouse\'>)');
+        $this->assertNoEscaped('<div class="escaped">');
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertEscapedTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertEscapedTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\rector_examples\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 
-class AssertElementPresentTest extends BrowserTestBase {
+class AssertEscapedTest extends BrowserTestBase {
 
     public function testAssertElementPresent() {
         $this->assertEscaped('Demonstrate block regions (<"Cat" & \'Mouse\'>)');

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByIdTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByIdTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldByIdTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertFieldById('edit-name', NULL);
+        $this->assertFieldById('edit-name', 'Test name');
+        $this->assertFieldById('edit-description', NULL);
+        $this->assertFieldById('edit-description');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByIdTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByIdTest.php
@@ -6,11 +6,18 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldByIdTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testFieldById() {
         $this->assertFieldById('edit-name', NULL);
         $this->assertFieldById('edit-name', 'Test name');
         $this->assertFieldById('edit-description', NULL);
         $this->assertFieldById('edit-description');
+    }
+
+    public function testNoFieldById() {
+        $this->assertNoFieldById('name');
+        $this->assertNoFieldById('name', 'not the value');
+        $this->assertNoFieldById('notexisting');
+        $this->assertNoFieldById('notexisting', NULL);
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByNameTest.php
@@ -9,7 +9,7 @@ class AssertFieldByNameTest extends BrowserTestBase {
     public function testExample() {
         $this->assertFieldByName('field_name', 'expected_value');
         $this->assertFieldByName("field_name[0][value][date]", '', 'Date element found.');
-        $this->assertFieldByName("field_name[0][value][time]", null, 'Time element found.');
+        $this->assertFieldByName("field_name[0][value][time]", NULL, 'Time element found.');
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByNameTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldByNameTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertFieldByName('field_name', 'expected_value');
+        $this->assertFieldByName("field_name[0][value][date]", '', 'Date element found.');
+        $this->assertFieldByName("field_name[0][value][time]", null, 'Time element found.');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldByNameTest.php
@@ -6,10 +6,17 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldByNameTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testFieldByName() {
         $this->assertFieldByName('field_name', 'expected_value');
         $this->assertFieldByName("field_name[0][value][date]", '', 'Date element found.');
         $this->assertFieldByName("field_name[0][value][time]", NULL, 'Time element found.');
+    }
+
+    public function testNoFieldByName() {
+        $this->assertNoFieldByName('name');
+        $this->assertNoFieldByName('name', 'not the value');
+        $this->assertNoFieldByName('notexisting');
+        $this->assertNoFieldByName('notexisting', NULL);
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldCheckedTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldCheckedTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldCheckedTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertFieldChecked('edit-settings-view-mode', 'default');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldCheckedTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldCheckedTest.php
@@ -6,8 +6,12 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldCheckedTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testFieldChecked() {
         $this->assertFieldChecked('edit-settings-view-mode', 'default');
+    }
+
+    public function testNoFieldChecked() {
+        $this->assertNoFieldChecked('edit-settings-view-mode', 'default');
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldTest.php
@@ -6,8 +6,12 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testField() {
         $this->assertField('files[upload]', 'Found file upload field.');
+    }
+
+    public function testNoField() {
+        $this->assertNoField('files[upload]', 'Found file upload field.');
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertFieldTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertField('files[upload]', 'Found file upload field.');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertHeaderTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertHeaderTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertHeaderTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertHeader('Foo', 'Bar');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertIdenticalObjectTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertIdenticalObjectTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertIdenticalObjectTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertIdenticalObject('Actual', 'Expected', 'Message');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertIdenticalTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertIdenticalTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertIdenticalTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertIdentical('Actual', 'Expected', 'Message');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertIdenticalTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertIdenticalTest.php
@@ -8,6 +8,8 @@ class AssertIdenticalTest extends BrowserTestBase {
 
     public function testExample() {
         $this->assertIdentical('Actual', 'Expected', 'Message');
+        $this->assertNotIdentical('Actual', 'Expected', 'Message');
+
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertLinkByHrefTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertLinkByHrefTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertLinkByHrefTest extends BrowserTestBase {
+
+    public function testLinkByHref() {
+        $this->assertLinkByHref('user/1/translations');
+    }
+
+    public function testNoLinkByHref() {
+        $this->assertNoLinkByHref('user/2/translations');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertLinkTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertLinkTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertLinkTest extends BrowserTestBase {
+
+    public function testLink() {
+        $this->assertLink('Anonymous comment title');
+    }
+
+    public function testNoLink() {
+        $this->assertNoLink('Anonymous comment title');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertOptionTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertOptionTest.php
@@ -6,9 +6,11 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertOptionTest extends BrowserTestBase {
 
-    public function testAssertElementPresent() {
+    public function testExample() {
         $this->assertOption('edit-settings-view-mode', 'default');
         $this->assertNoOption('edit-settings-view-mode', 'default');
+        $this->assertOptionByText('edit-settings-view-mode', 'default');
+        $this->assertOptionSelected('options', 2);
     }
 
 }

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertOptionTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertOptionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertOptionTest extends BrowserTestBase {
+
+    public function testAssertElementPresent() {
+        $this->assertOption('edit-settings-view-mode', 'default');
+        $this->assertNoOption('edit-settings-view-mode', 'default');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertPatternTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertPatternTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertPatternTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertPattern('|<h4[^>]*></h4>|', 'No empty H4 element found.');
+        $this->assertNoPattern('|<h4[^>]*></h4>|', 'No empty H4 element found.');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertRawTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertRawTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertRawTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertRaw('bartik/logo.svg');
+        $this->assertNoRaw('bartik/logo.svg');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertResponseTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertResponseTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertResponseTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertResponse(200);
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertTest extends BrowserTestBase {
+
+    public function testExample() {
+        $foo = TRUE;
+        $this->assert($foo);
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertTitleTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertTitleTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertTitleTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertTitle('Block layout | Drupal');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertUniqueTextTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertUniqueTextTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertUniqueTextTest extends BrowserTestBase {
+
+    public function testAssertText() {
+        $this->assertUniqueText('Color set');
+        $this->assertNoUniqueText('Duplicated message');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertUrlTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertUrlTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertUrlTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertUrl('myrootuser');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/BuildXpathQueryTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/BuildXpathQueryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class BuildXpathQueryTest extends BrowserTestBase {
+
+    public function testExample() {
+        $xpath = $this->buildXPathQuery('//select[@name=:name]', [':name' => $name]);
+        $fields = $this->xpath($xpath);
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/ConstructFieldXpathTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/ConstructFieldXpathTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class ConstructFieldXpathTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->drupalGet('/form-test/select');
+        $this->constructFieldXpath('id', 'edit-preferred-admin-langcode');
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/DrupalPostFormTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/DrupalPostFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\rector_examples\Functional;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Tests\BrowserTestBase;
 
 class DrupalPostFormTest extends BrowserTestBase {

--- a/fixtures/d9/rector_examples/tests/src/Functional/DrupalPostFormTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/DrupalPostFormTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\rector_examples\Functional;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Tests\BrowserTestBase;
 
-class BrowserTestBaseGetMock extends BrowserTestBase {
+class DrupalPostFormTest extends BrowserTestBase {
 
     /**
      * A simple example using the class property.

--- a/fixtures/d9/rector_examples/tests/src/Functional/GetAllOptionsTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/GetAllOptionsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class GetAllOptionsTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->drupalGet('/form-test/select');
+        $this->assertCount(6, $this->getAllOptions($this->cssSelect('select[name="opt_groups"]')[0]));
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/GetRawContentTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/GetRawContentTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class GetRawContentTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->drupalGet('/form-test/select');
+        $this->getRawContent();
+    }
+
+}

--- a/fixtures/d9/rector_examples/tests/src/Functional/PassTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/PassTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class PassTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->pass('The whole transaction is rolled back when a duplicate key insert occurs.');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertElementPresentTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertElementPresentTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertElementPresentTest extends BrowserTestBase {
+
+    public function testAssertElementPresent() {
+        $this->assertSession()->elementExists('css', '.region-content-message.region-empty');
+        $this->assertSession()->elementNotExists('css', '.region-content-message.region-empty');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertEqualTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertEqualTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertEqualTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertEquals('Actual', 'Expected', 'Message');
+        $this->assertNotEquals('Actual', 'Expected', 'Message');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertEscapedTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertEscapedTest.php
@@ -7,8 +7,8 @@ use Drupal\Tests\BrowserTestBase;
 class AssertElementPresentTest extends BrowserTestBase {
 
     public function testAssertElementPresent() {
-        $this->assertElementPresent('css', '.region-content-message.region-empty');
-        $this->assertElementNotPresent('css', '.region-content-message.region-empty');
+        $this->assertSession()->assertEscaped('Demonstrate block regions (<"Cat" & \'Mouse\'>)');
+        $this->assertSession()->assertNoEscaped('<div class="escaped">');
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertEscapedTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertEscapedTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\rector_examples\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 
-class AssertElementPresentTest extends BrowserTestBase {
+class AssertEscapedTest extends BrowserTestBase {
 
     public function testAssertElementPresent() {
         $this->assertSession()->assertEscaped('Demonstrate block regions (<"Cat" & \'Mouse\'>)');

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByIdTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByIdTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldByIdTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->fieldValueEquals('name', '');
+        $this->assertSession()->fieldValueEquals('name', 'not the value');
+        $this->assertSession()->fieldValueEquals('notexisting', '');
+        $this->assertSession()->fieldExists('notexisting');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByIdTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByIdTest.php
@@ -6,11 +6,18 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldByIdTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testFieldById() {
         $this->assertSession()->fieldExists('edit-name');
         $this->assertSession()->fieldValueEquals('edit-name', 'Test name');
         $this->assertSession()->fieldExists('edit-description');
         $this->assertSession()->fieldValueEquals('edit-description', '');
+    }
+
+    public function testNoFieldById() {
+        $this->assertSession()->fieldValueNotEquals('name', '');
+        $this->assertSession()->fieldValueNotEquals('name', 'not the value');
+        $this->assertSession()->fieldValueNotEquals('notexisting', '');
+        $this->assertSession()->fieldNotExists('notexisting');
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
@@ -16,6 +16,9 @@ class AssertFieldByNameTest extends BrowserTestBase {
         $this->assertSession()->fieldValueNotEquals('name', '');
         $this->assertSession()->fieldValueNotEquals('name', 'not the value');
         $this->assertSession()->fieldValueNotEquals('notexisting', '');
+        // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+        // Verify the assertion: buttonNotExists() if this is for a button.
         $this->assertSession()->fieldNotExists('notexisting');
     }
+
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
@@ -6,10 +6,16 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldByNameTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testFieldByName() {
         $this->assertSession()->fieldValueEquals('field_name', 'expected_value');
         $this->assertSession()->fieldValueEquals("field_name[0][value][date]", '');
         $this->assertSession()->fieldExists("field_name[0][value][time]");
     }
 
+    public function testNoFieldByName() {
+        $this->assertSession()->fieldValueNotEquals('name', '');
+        $this->assertSession()->fieldValueNotEquals('name', 'not the value');
+        $this->assertSession()->fieldValueNotEquals('notexisting', '');
+        $this->assertSession()->fieldNotExists('notexisting');
+    }
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
@@ -8,8 +8,8 @@ class AssertFieldByNameTest extends BrowserTestBase {
 
     public function testExample() {
         $this->assertSession()->fieldValueEquals('field_name', 'expected_value');
-        $this->assertSession()->fieldExists("field_name[0][value][date]", '', 'Date element found.');
-        $this->assertSession()->fieldExists("field_name[0][value][time]", null, 'Time element found.');
+        $this->assertSession()->fieldValueEquals("field_name[0][value][date]", '');
+        $this->assertSession()->fieldExists("field_name[0][value][time]");
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldByNameTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldByNameTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->fieldValueEquals('field_name', 'expected_value');
+        $this->assertSession()->fieldExists("field_name[0][value][date]", '', 'Date element found.');
+        $this->assertSession()->fieldExists("field_name[0][value][time]", null, 'Time element found.');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldCheckedTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldCheckedTest.php
@@ -6,8 +6,12 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldCheckedTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testFieldChecked() {
         $this->assertSession()->checkboxChecked('edit-settings-view-mode', 'default');
+    }
+
+    public function testNoFieldChecked() {
+        $this->assertSession()->checkboxNotChecked('edit-settings-view-mode', 'default');
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldCheckedTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldCheckedTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldCheckedTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->checkboxChecked('edit-settings-view-mode', 'default');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldTest.php
@@ -6,10 +6,16 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertFieldTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testField() {
         // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
         // Change assertion to buttonExists() if checking for a button.
         $this->assertSession()->fieldExists('files[upload]', 'Found file upload field.');
+    }
+
+    public function testNoField() {
+        // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+        // Change assertion to buttonExists() if checking for a button.
+        $this->assertSession()->fieldNotExists('files[upload]', 'Found file upload field.');
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldTest.php
@@ -7,6 +7,8 @@ use Drupal\Tests\BrowserTestBase;
 class AssertFieldTest extends BrowserTestBase {
 
     public function testExample() {
+        // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
+        // Change assertion to buttonExists() if checking for a button.
         $this->assertSession()->fieldExists('files[upload]', 'Found file upload field.');
     }
 

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertFieldTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->fieldExists('files[upload]', 'Found file upload field.');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertHeaderTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertHeaderTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertHeaderTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->responseHeaderEquals('Foo', 'Bar');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertIdenticalObjectTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertIdenticalObjectTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertIdenticalObjectTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertEquals('Actual', 'Expected', 'Message');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertIdenticalTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertIdenticalTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertIdenticalTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSame('Actual', 'Expected', 'Message');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertIdenticalTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertIdenticalTest.php
@@ -8,6 +8,7 @@ class AssertIdenticalTest extends BrowserTestBase {
 
     public function testExample() {
         $this->assertSame('Actual', 'Expected', 'Message');
+        $this->assertNotSame('Actual', 'Expected', 'Message');
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertLinkByHrefTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertLinkByHrefTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertLinkByHrefTest extends BrowserTestBase {
+
+    public function testLinkByHref() {
+        $this->assertSession()->linkByHrefExists('user/1/translations');
+    }
+
+    public function testNoLinkByHref() {
+        $this->assertSession()->linkByHrefNotExists('user/2/translations');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertLinkTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertLinkTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertLinkTest extends BrowserTestBase {
+
+    public function testLink() {
+        $this->assertSession()->linkExists('Anonymous comment title');
+    }
+
+    public function testNoLink() {
+        $this->assertSession()->linkNotExists('Anonymous comment title');
+    }
+
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertOptionTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertOptionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertOptionTest extends BrowserTestBase {
+
+    public function testAssertElementPresent() {
+        $this->assertSession()->optionExists('edit-settings-view-mode', 'default');
+        $this->assertSession()->optionNotExists('edit-settings-view-mode', 'default');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertOptionTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertOptionTest.php
@@ -6,9 +6,11 @@ use Drupal\Tests\BrowserTestBase;
 
 class AssertOptionTest extends BrowserTestBase {
 
-    public function testAssertElementPresent() {
+    public function testExample() {
         $this->assertSession()->optionExists('edit-settings-view-mode', 'default');
         $this->assertSession()->optionNotExists('edit-settings-view-mode', 'default');
+        $this->assertSession()->optionExists('edit-settings-view-mode', 'default');
+        $this->assertTrue($this->assertSession()->optionExists('options', 2)->hasAttribute('selected'));
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertPatternTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertPatternTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertPatternTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->responseMatches('|<h4[^>]*></h4>|', 'No empty H4 element found.');
+        $this->assertSession()->responseNotMatches('|<h4[^>]*></h4>|', 'No empty H4 element found.');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertRawTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertRawTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertRawTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->responseContains('bartik/logo.svg');
+        $this->assertSession()->responseNotContains('bartik/logo.svg');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertResponseTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertResponseTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertResponseTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->statusCodeEquals(200);
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertTest extends BrowserTestBase {
+
+    public function testExample() {
+        $foo = TRUE;
+        $this->assertTrue($foo);
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertTitleTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertTitleTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertTitleTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->titleEquals('Block layout | Drupal');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertUniqueTextTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertUniqueTextTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertUniqueTextTest extends BrowserTestBase {
+
+    public function testAssertText() {
+        $this->assertSession()->pageTextContainsOnce('Color set');
+        $page_text = $this->getSession()->getPage()->getText();
+        $nr_found = substr_count($page_text, 'Duplicated message');
+        $this->assertGreaterThan(1, $nr_found, "'Duplicated message' found more than once on the page");
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertUrlTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertUrlTest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertUrlTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->assertSession()->addressEquals('myrootuser');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/BuildXpathQueryTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/BuildXpathQueryTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class BuildXpathQueryTest extends BrowserTestBase {
+
+    public function testExample() {
+        $xpath = $this->assertSession()->buildXPathQuery('//select[@name=:name]', [':name' => $name]);
+        $fields = $this->xpath($xpath);
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/ConstructFieldXpathTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/ConstructFieldXpathTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class ConstructFieldXpathTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->drupalGet('/form-test/select');
+        $this->getSession()->getPage()->findField('edit-preferred-admin-langcode');
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/DrupalPostFormTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/DrupalPostFormTest.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\Tests\rector_examples\Functional;
 
-use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Tests\BrowserTestBase;
 
 class DrupalPostFormTest extends BrowserTestBase {

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/DrupalPostFormTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/DrupalPostFormTest.php
@@ -5,7 +5,7 @@ namespace Drupal\Tests\rector_examples\Functional;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Tests\BrowserTestBase;
 
-class BrowserTestBaseGetMock extends BrowserTestBase {
+class DrupalPostFormTest extends BrowserTestBase {
 
     /**
      * A simple example using the class property.

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/GetAllOptionsTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/GetAllOptionsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class GetAllOptionsTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->drupalGet('/form-test/select');
+        $this->assertCount(6, $this->cssSelect('select[name="opt_groups"]')[0]->findAll('xpath', '//option'));
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/GetRawContentTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/GetRawContentTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class GetRawContentTest extends BrowserTestBase {
+
+    public function testExample() {
+        $this->drupalGet('/form-test/select');
+        $this->getSession()->getPage()->getContent();
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/PassTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/PassTest.php
@@ -6,7 +6,8 @@ use Drupal\Tests\BrowserTestBase;
 
 class PassTest extends BrowserTestBase {
 
-    public function testExample() {
+    public function testExample()
+    {
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/PassTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/PassTest.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class PassTest extends BrowserTestBase {
+
+    public function testExample() {
+    }
+
+}

--- a/src/Rector/Deprecation/AssertFieldByIdRector.php
+++ b/src/Rector/Deprecation/AssertFieldByIdRector.php
@@ -22,10 +22,10 @@ final class AssertFieldByIdRector extends AbstractRector
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
-    $this->assertSession()->fieldValueEquals('name', '');
-    $this->assertSession()->fieldValueEquals('name', 'not the value');
-    $this->assertSession()->fieldValueEquals('notexisting', '');
-    $this->assertSession()->fieldExists('notexisting');
+    $this->assertSession()->fieldExists('edit-name');
+    $this->assertSession()->fieldValueEquals('edit-name', 'Test name');
+    $this->assertSession()->fieldExists('edit-description');
+    $this->assertSession()->fieldValueEquals('edit-description', '');
 CODE_AFTER
             )
         ]);
@@ -57,7 +57,7 @@ CODE_AFTER
         }
         // Check if argument two is a `null` and convert to fieldExists.
         $arg2 = $args[1]->value;
-        if ($arg2 instanceof Node\Expr\ConstFetch && (string) $arg2->name === 'null') {
+        if ($arg2 instanceof Node\Expr\ConstFetch && strtolower((string) $arg2->name) === 'null') {
             return $this->nodeFactory->createMethodCall($assertSessionNode, 'fieldExists', [$args[0]]);
         }
 

--- a/src/Rector/Deprecation/AssertFieldByNameRector.php
+++ b/src/Rector/Deprecation/AssertFieldByNameRector.php
@@ -22,8 +22,8 @@ CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
 $this->assertSession()->fieldValueEquals('field_name', 'expected_value');
-$this->assertSession()->fieldExists("field_name[0][value][date]", '', 'Date element found.');
-$this->assertSession()->fieldExists("field_name[0][value][time]", null, 'Time element found.');
+$this->assertSession()->fieldValueEquals("field_name[0][value][date]", '');
+$this->assertSession()->fieldExists("field_name[0][value][time]");
 CODE_AFTER
             )
         ]);
@@ -55,7 +55,7 @@ CODE_AFTER
         }
         // Check if argument two is a `null` and convert to fieldExists.
         $arg2 = $args[1]->value;
-        if ($arg2 instanceof Node\Expr\ConstFetch && (string) $arg2->name === 'null') {
+        if ($arg2 instanceof Node\Expr\ConstFetch && strtolower((string) $arg2->name) === 'null') {
             return $this->nodeFactory->createMethodCall($assertSessionNode, 'fieldExists', [$args[0]]);
         }
 

--- a/src/Rector/Deprecation/AssertNoFieldByIdRector.php
+++ b/src/Rector/Deprecation/AssertNoFieldByIdRector.php
@@ -57,7 +57,7 @@ CODE_AFTER
         }
         // Check if argument two is a `null` and convert to fieldExists.
         $arg2 = $args[1]->value;
-        if ($arg2 instanceof Node\Expr\ConstFetch && (string) $arg2->name === 'null') {
+        if ($arg2 instanceof Node\Expr\ConstFetch && strtolower((string) $arg2->name) === 'null') {
             return $this->nodeFactory->createMethodCall($assertSessionNode, 'fieldNotExists', [$args[0]]);
         }
 

--- a/src/Rector/Deprecation/AssertOptionByTextRector.php
+++ b/src/Rector/Deprecation/AssertOptionByTextRector.php
@@ -21,7 +21,7 @@ $this->assertOptionByText('edit-settings-view-mode', 'default');
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
-$this->assertSession()->assertOptionByText('edit-settings-view-mode', 'default');
+$this->assertSession()->optionExists('edit-settings-view-mode', 'default');
 CODE_AFTER
             ),
 

--- a/src/Rector/Deprecation/AssertOptionSelectedRector.php
+++ b/src/Rector/Deprecation/AssertOptionSelectedRector.php
@@ -12,14 +12,14 @@ final class AssertOptionSelectedRector extends AbstractRector
 
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated UiHelperTrait::drupalPostForm() calls', [
+        return new RuleDefinition('Fixes deprecated AssertLegacyTrait::assertOptionSelected() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
     $this->assertOptionSelected('options', 2);
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
-    $this->assertTrue($this->assertSession()->optionExists($id, $option)->hasAttribute('selected'), $message);
+    $this->assertTrue($this->assertSession()->optionExists('options', 2)->hasAttribute('selected'));
 CODE_AFTER
             )
         ]);

--- a/src/Rector/Deprecation/AssertOptionSelectedRector.php
+++ b/src/Rector/Deprecation/AssertOptionSelectedRector.php
@@ -55,6 +55,12 @@ CODE_AFTER
             $this->nodeFactory->createArgs(['selected'])
         );
 
+        if ($message === null) {
+            return $this->nodeFactory->createLocalMethodCall('assertTrue', [
+                $this->nodeFactory->createArg($hasAttributeNode),
+            ]);
+        }
+
         return $this->nodeFactory->createLocalMethodCall('assertTrue', [
             $this->nodeFactory->createArg($hasAttributeNode),
             $this->nodeFactory->createArg($message)

--- a/src/Rector/Deprecation/ConstructFieldXpathRector.php
+++ b/src/Rector/Deprecation/ConstructFieldXpathRector.php
@@ -15,11 +15,11 @@ final class ConstructFieldXpathRector extends AbstractRector {
         return new RuleDefinition('Fixes deprecated AssertLegacyTrait::constructFieldXpath() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
-$this->constructFieldXpath('id', 'edit-preferred-admin-langcode')
+$this->constructFieldXpath('id', 'edit-preferred-admin-langcode');
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
-$this->getSession()->getPage()->findField('edit-preferred-admin-langcode')
+$this->getSession()->getPage()->findField('edit-preferred-admin-langcode');
 CODE_AFTER
             )
         ]);

--- a/src/Rector/Deprecation/GetRawContentRector.php
+++ b/src/Rector/Deprecation/GetRawContentRector.php
@@ -47,7 +47,7 @@ CODE_AFTER
     public function refactor(Node $node): ?Node
     {
         assert($node instanceof Node\Expr\MethodCall);
-        if ($this->getName($node->name) !== 'constructFieldXpath') {
+        if ($this->getName($node->name) !== 'getRawContent') {
             return null;
         }
         // @todo definitely needs tests on \Drupal\FunctionalJavascriptTests\WebDriverTestBase

--- a/src/Rector/Deprecation/GetRawContentRector.php
+++ b/src/Rector/Deprecation/GetRawContentRector.php
@@ -27,11 +27,11 @@ final class GetRawContentRector extends AbstractRector
         return new RuleDefinition('Fixes deprecated AssertLegacyTrait::getRawContent() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
-$this->getRawContent()
+$this->getRawContent();
 CODE_BEFORE
                 ,
                 <<<'CODE_AFTER'
-$this->getSession()->getPage()->getContent()
+$this->getSession()->getPage()->getContent();
 CODE_AFTER
             )
         ]);

--- a/tests/src/Rector/Deprecation/AssertFieldByIdRector/AssertFieldByIdRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertFieldByIdRector/AssertFieldByIdRectorTest.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\AssertFieldByIdRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+class AssertFieldByIdRectorTest extends AbstractRectorTestCase
+{
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/AssertFieldByIdRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertFieldByIdRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\AssertFieldByIdRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->set(AssertFieldByIdRector::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/AssertFieldByIdRector/fixture/sample.php.inc
+++ b/tests/src/Rector/Deprecation/AssertFieldByIdRector/fixture/sample.php.inc
@@ -7,6 +7,24 @@ use Drupal\Tests\BrowserTestBase;
 class AssertFieldByIdTest extends BrowserTestBase {
 
     public function testExample() {
+        $this->assertFieldById('edit-name', NULL);
+        $this->assertFieldById('edit-name', 'Test name');
+        $this->assertFieldById('edit-description', NULL);
+        $this->assertFieldById('edit-description');
+    }
+
+}
+?>
+-----
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class AssertFieldByIdTest extends BrowserTestBase {
+
+    public function testExample() {
         $this->assertSession()->fieldExists('edit-name');
         $this->assertSession()->fieldValueEquals('edit-name', 'Test name');
         $this->assertSession()->fieldExists('edit-description');
@@ -14,3 +32,4 @@ class AssertFieldByIdTest extends BrowserTestBase {
     }
 
 }
+?>

--- a/tests/src/Rector/Deprecation/AssertPatternRector/AssertHeaderRectorTest.php
+++ b/tests/src/Rector/Deprecation/AssertPatternRector/AssertHeaderRectorTest.php
@@ -6,7 +6,7 @@ use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-class AssertPatternRectorTest extends AbstractRectorTestCase {
+class AssertHeaderRectorTest extends AbstractRectorTestCase {
 
     /**
      * @covers ::refactor


### PR DESCRIPTION
## Description
Adds fixtures for

* elementPresent and elementNotPresent
* assertEqual and assertNotEqual
* assertEscaped and assertNoEscaped
* assertFieldById and assertNoFieldById
* assertFieldByName and assertNoFieldByName
* assertField and assertNoField
* assertFieldChecked and assertNoFieldChecked
* assertHeader
* assertIdenticalObject
* assertIdentical and assertNotIdentical
* assertLinkByHref and assertNoLinkByHref
* assertLink and assertNoLink
* assertOption and assertNoOption
* assertPattern and assertNoPattern
* assertRaw and assertNoRaw
* assertOptionByText
* assertOptionSelected
* assert
* assertResponse
* assertTitle
* assertUrl
* pass
* assertUniqueText and assertNOUniqueText
* getAllOptions
* getRawContent

Follow ups

- [ ] Make issue to write PHPUnit tests for AssertOptionSelectedRector

## To Test
- Add steps to test this feature

## Drupal.org issue
Part of https://www.drupal.org/project/rector/issues/3229897
