### PR TITLE
Use PHPStan 1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "~0.11.53",
+        "rector/rector": "~0.12",
         "webflo/drupal-finder": "^1.2"
     },
     "license": "MIT",
@@ -60,10 +60,10 @@
     "require-dev": {
         "php": "^8.0",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^0.12.82",
-        "phpstan/phpstan-deprecation-rules": "^0.12.6",
+        "phpstan/phpstan": "^1.0",
+        "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "rector/rector-src": "~0.11.39",
+        "rector/rector-src": "~0.12",
         "symfony/yaml": "^5"
     }
 }


### PR DESCRIPTION
## Description

When using PHP 8 and PHPStan 1, impossible to get the latest versions of rector/rector and palantirnet/drupal-rector which prevents rector from working.

I tried updating to PHP 8 because on PHP 7.4, it is drupal-rector 0.5.6 that is downloaded, and so does not work, old yml config files, etc.

## Drupal.org issue

https://www.drupal.org/project/rector/issues/3248684
