### PR TITLE
Update composer.json for allow-plugins

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -10,7 +10,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.0"
+                    - "8.1"
         steps:
             -   uses: actions/checkout@v2
             -   uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,12 @@
         "optimize-autoloader": true,
         "update-with-dependencies": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "phpstan/extension-installer": true,
+            "rector/extension-installer": true,
+            "cweagans/composer-patches": true
+        }
     },
     "replace": {
         "palantirnet/drupal8-rector": "*",


### PR DESCRIPTION
## Description
House cleaning, add Composer 2.2 `allow-plugins` entry and bump PHPUnit CI job to PHP 8.1, which is used by `rector-src` (not Rector itself.)
