### PR TITLE
Handle custom message types

### DIFF
--- a/fixtures/d8/rector_examples_updated/drupal_set_message.php
+++ b/fixtures/d8/rector_examples_updated/drupal_set_message.php
@@ -39,8 +39,5 @@ function message_type_as_variable() {
 
   $type = 'warning';
 
-  // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
-  // This needs to be replaced, but Rector was not yet able to replace this because the type of message was set with a variable. If you need to continue to use a variable, you might consider using a switch statement.
-  // @noRector
-  drupal_set_message($message, $type);
+  \Drupal::messenger()->addWarning($message);
 }

--- a/fixtures/d8/rector_examples_updated/src/DrupalSetMessageStatic.php
+++ b/fixtures/d8/rector_examples_updated/src/DrupalSetMessageStatic.php
@@ -42,10 +42,7 @@ class DrupalSetMessageStatic {
 
     $type = 'warning';
 
-    // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
-    // This needs to be replaced, but Rector was not yet able to replace this because the type of message was set with a variable. If you need to continue to use a variable, you might consider using a switch statement.
-    // @noRector
-    drupal_set_message($message, $type);
+    \Drupal::messenger()->addWarning($message);
   }
 
 }

--- a/fixtures/d8/rector_examples_updated/src/DrupalSetMessageWithTrait.php
+++ b/fixtures/d8/rector_examples_updated/src/DrupalSetMessageWithTrait.php
@@ -48,10 +48,7 @@ class DrupalSetMessageWithTrait {
 
     $type = 'warning';
 
-    // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
-    // This needs to be replaced, but Rector was not yet able to replace this because the type of message was set with a variable. If you need to continue to use a variable, you might consider using a switch statement.
-    // @noRector
-    drupal_set_message($message, $type);
+    $this->messenger()->addWarning($message);
   }
 
 }

--- a/tests/src/Rector/Deprecation/DrupalSetMessageRector/fixture/info_type.php.inc
+++ b/tests/src/Rector/Deprecation/DrupalSetMessageRector/fixture/info_type.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * A simple example using the minimum number of arguments.
+ */
+function simple_example() {
+    drupal_set_message('some message', 'info');
+}
+?>
+-----
+<?php
+
+/**
+ * A simple example using the minimum number of arguments.
+ */
+function simple_example() {
+    \Drupal::messenger()->addMessage('some message', 'info');
+}
+?>

--- a/tests/src/Rector/Deprecation/DrupalSetMessageRector/fixture/type_as_variable.php.inc
+++ b/tests/src/Rector/Deprecation/DrupalSetMessageRector/fixture/type_as_variable.php.inc
@@ -26,9 +26,6 @@ function message_type_as_variable() {
 
     $type = 'warning';
 
-    // TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes.
-    // This needs to be replaced, but Rector was not yet able to replace this because the type of message was set with a variable. If you need to continue to use a variable, you might consider using a switch statement.
-    // @noRector
-    drupal_set_message($message, $type);
+    \Drupal::messenger()->addWarning($message);
 }
 ?>


### PR DESCRIPTION
## Description
Falls back to addMessage when an unknown message type is specified. Also fixes resolving the type from a variable in normal use cases!

## To Test
- Add steps to test this feature

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3241156
