### PR TITLE
MetadataBag::clearCsrfTokenSeed replaced by stampNew

### DIFF
--- a/fixtures/d9/rector_examples/metadatabag.php
+++ b/fixtures/d9/rector_examples/metadatabag.php
@@ -1,0 +1,9 @@
+<?php
+
+use Drupal\Core\Session\MetadataBag;
+use Drupal\Core\Site\Settings;
+
+function simple_example() {
+    $metadata_bag = new MetadataBag(new Settings([]));
+    $metadata_bag->clearCsrfTokenSeed();
+}

--- a/fixtures/d9/rector_examples_updated/metadatabag.php
+++ b/fixtures/d9/rector_examples_updated/metadatabag.php
@@ -1,0 +1,9 @@
+<?php
+
+use Drupal\Core\Session\MetadataBag;
+use Drupal\Core\Site\Settings;
+
+function simple_example() {
+    $metadata_bag = new MetadataBag(new Settings([]));
+    $metadata_bag->stampNew();
+}

--- a/src/Rector/Deprecation/ClearCsrfTokenSeed.php
+++ b/src/Rector/Deprecation/ClearCsrfTokenSeed.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\MethodToMethodBase;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class ClearCsrfTokenSeed extends MethodToMethodBase {
+
+    protected $deprecatedMethodName = 'clearCsrfTokenSeed';
+
+    protected $methodName = 'stampNew';
+
+    protected $className = 'Drupal\Core\Session\MetadataBag';
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated MetadataBag::clearCsrfTokenSeed() calls',[
+            new CodeSample(
+                <<<'CODE_BEFORE'
+$metadata_bag = new \Drupal\Core\Session\MetadataBag(new \Drupal\Core\Site\Settings([]));
+$metadata_bag->clearCsrfTokenSeed();
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+$metadata_bag = new \Drupal\Core\Session\MetadataBag(new \Drupal\Core\Site\Settings([]));
+$metadata_bag->stampNew();
+CODE_AFTER
+            )
+        ]);
+    }
+
+}

--- a/stubs/Drupal/Session/MetadataBag.php
+++ b/stubs/Drupal/Session/MetadataBag.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\Core\Session;
+
+use Drupal\Core\Site\Settings;
+
+if (class_exists('Drupal\Core\Session\MetadataBag')) {
+    return;
+}
+
+class MetadataBag {
+    public function __construct(Settings $settings) {
+
+    }
+
+    public function stampNew($lifetime = NULL) {
+
+    }
+
+    public function clearCsrfTokenSeed() {
+
+    }
+}

--- a/stubs/Drupal/Site/Settings.php
+++ b/stubs/Drupal/Site/Settings.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\Core\Site;
+
+
+if (class_exists('Drupal\Core\Site\Settings')) {
+    return;
+}
+
+final class Settings {
+
+    public function __construct(array $settings) {
+
+    }
+}

--- a/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/ClearCsrfTokenSeedRectorTest.php
+++ b/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/ClearCsrfTokenSeedRectorTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\ClearCsrfTokenSeedRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+class ClearCsrfTokenSeedRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/config/configured_rule.php
@@ -1,16 +1,13 @@
-<?php
-
-declare(strict_types=1);
+<?php declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\ClearCsrfTokenSeed;
-use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_91);
-
     $services = $containerConfigurator->services();
 
-    // Change record: https://www.drupal.org/node/3187914
     $services->set(ClearCsrfTokenSeed::class);
+
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
 };

--- a/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/fixture/basic.php.inc
+++ b/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/fixture/basic.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+function simple_example() {
+    $metadata_bag = new \Drupal\Core\Session\MetadataBag(new \Drupal\Core\Site\Settings([]));
+    $metadata_bag->clearCsrfTokenSeed();
+}
+?>
+-----
+<?php
+
+function simple_example() {
+    $metadata_bag = new \Drupal\Core\Session\MetadataBag(new \Drupal\Core\Site\Settings([]));
+    $metadata_bag->stampNew();
+}
+?>


### PR DESCRIPTION
## Description
MetadataBag::clearCsrfTokenSeed replaced by stampNew


## To Test
- Add steps to test this feature

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3264310
