### PR TITLE
Use dev-main for rector-src

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -12,7 +12,7 @@ jobs:
             -   uses: actions/checkout@v2
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.0
+                    php-version: 8.1
                     coverage: none # disable xdebug, pcov
                     tools: composer:v2
                     extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,6 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
         "rector/rector-src": "dev-main",
-        "symfony/yaml": "^5"
+        "symfony/yaml": "^5 || ^6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "rector/rector-src": "~0.12",
+        "rector/rector-src": "dev-main",
         "symfony/yaml": "^5"
     }
 }

--- a/rector.php
+++ b/rector.php
@@ -28,7 +28,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
-    $parameters->set(Option::IMPORT_DOC_BLOCKS, false);
 
     $parameters->set('drupal_rector_notices_as_comments', true);
 };

--- a/rector.php
+++ b/rector.php
@@ -28,6 +28,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
+    // @phpstan-ignore-next-line
+    $parameters->set(Option::IMPORT_DOC_BLOCKS, false);
 
     $parameters->set('drupal_rector_notices_as_comments', true);
 };


### PR DESCRIPTION
## Description
Follow the pattern of other Rector packages

See https://github.com/rectorphp/rector-symfony/blob/main/composer.json#L14

```json
    "require-dev": {
        "phpunit/phpunit": "^9.5",
        "phpstan/phpstan": "^1.3",
        "rector/rector-src": "dev-main",
```

## Drupal.org issue
None