### PR TITLE
Fix PHP 8 warnings on `null` to `file_exists`

### DIFF
--- a/config/drupal-phpunit-bootstrap-file.php
+++ b/config/drupal-phpunit-bootstrap-file.php
@@ -88,7 +88,7 @@ function drupal_phpunit_contrib_extension_directory_roots($root) {
     $paths[] = is_dir("$path/profiles") ? realpath("$path/profiles") : NULL;
     $paths[] = is_dir("$path/themes") ? realpath("$path/themes") : NULL;
   }
-  return array_filter($paths, 'file_exists');
+  return array_filter(array_filter($paths), 'file_exists');
 }
 
 /**


### PR DESCRIPTION
## Description

Run on PHP 8.1 Get warnings:

```
PHP Deprecated:  file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in /Users/mglaman/Drupal/sites/canary/vendor/palantirnet/drupal-rector/config/drupal-phpunit-bootstrap-file.php on line 91
Deprecated: file_exists(): Passing null to parameter #1 ($filename) of type string is deprecated in /Users/mglaman/Drupal/sites/canary/vendor/palantirnet/drupal-rector/config/drupal-phpunit-bootstrap-file.php on line 91
```