### PR TITLE
Issue #3277704: Remove PHPUNIT_75 constant in Rector

### DIFF
--- a/config/drupal-8/drupal-8-all-deprecations.php
+++ b/config/drupal-8/drupal-8-all-deprecations.php
@@ -11,7 +11,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_60);
     $containerConfigurator->import(PHPUnitSetList::PHPUNIT_70);
-    $containerConfigurator->import(PHPUnitSetList::PHPUNIT_75);
 
     $parameters = $containerConfigurator->parameters();
 


### PR DESCRIPTION
## Description
Remove usage of non-existing constant in rector 0.12.22

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3277704