### PR TITLE
user_password() deprecation

### DIFF
--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -48,6 +48,7 @@ use DrupalRector\Rector\Deprecation\GetAllOptionsRector;
 use DrupalRector\Rector\Deprecation\GetRawContentRector;
 use DrupalRector\Rector\Deprecation\PassRector;
 use DrupalRector\Rector\Deprecation\UiHelperTraitDrupalPostFormRector;
+use DrupalRector\Rector\Deprecation\UserPasswordRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -108,4 +109,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(ConstructFieldXpathRector::class);
     $services->set(GetRawContentRector::class);
     $services->set(GetAllOptionsRector::class);
+    $services->set(UserPasswordRector::class);
 };

--- a/src/Rector/Deprecation/UserPasswordRector.php
+++ b/src/Rector/Deprecation/UserPasswordRector.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace DrupalRector\Rector\Deprecation;
+
+use DrupalRector\Rector\Deprecation\Base\FunctionToServiceBase;
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class UserPasswordRector extends AbstractRector
+{
+    /**
+     * @inheritdoc
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated user_password() calls',[
+            new CodeSample(
+              <<<'CODE_BEFORE'
+$pass = user_password();
+$shorter_pass = user_password(8);
+CODE_BEFORE
+              ,
+              <<<'CODE_AFTER'
+$pass = \Drupal::service('password_generator')->generate();
+$shorter_pass = \Drupal::service('password_generator')->generate(8);
+CODE_AFTER
+            )
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\FuncCall);
+        if ($this->getName($node->name) !== 'user_password') {
+            return null;
+        }
+
+        $service = new Node\Expr\StaticCall(
+            new Node\Name\FullyQualified('Drupal'),
+            'service',
+            [new Node\Arg(new Node\Scalar\String_('password_generator'))]
+        );
+        $methodName = new Node\Identifier('generate');
+        return new Node\Expr\MethodCall($service, $methodName, $node->getArgs());
+    }
+
+
+}

--- a/tests/src/Rector/Deprecation/UserPasswordRector/UserPasswordRectorTest.php
+++ b/tests/src/Rector/Deprecation/UserPasswordRector/UserPasswordRectorTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\UserPasswordRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+class UserPasswordRectorTest extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData()
+     */
+    public function test(SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return Iterator<SmartFileInfo>
+     */
+    public function provideData(): Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/UserPasswordRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/UserPasswordRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\UserPasswordRector;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+    $services->set(UserPasswordRector::class);
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('drupal_rector_notices_as_comments', true);
+};

--- a/tests/src/Rector/Deprecation/UserPasswordRector/fixture/user_password.php.inc
+++ b/tests/src/Rector/Deprecation/UserPasswordRector/fixture/user_password.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+function simple_example() {
+    $password = user_password();
+    $other_password = user_password(8);
+    $password_length = 12;
+    $last_password = user_password($password_length);
+}
+?>
+-----
+<?php
+
+function simple_example() {
+    $password = \Drupal::service('password_generator')->generate();
+    $other_password = \Drupal::service('password_generator')->generate(8);
+    $password_length = 12;
+    $last_password = \Drupal::service('password_generator')->generate($password_length);
+}
+?>


### PR DESCRIPTION
## Description

`user_password()` is deprecated in Drupal 9.

## Drupal.org issue

https://www.drupal.org/project/rector/issues/3280326