### PR TITLE
Issue #3282217: file_build_uri() is deprecated

### DIFF
--- a/config/drupal-9/drupal-9.3-deprecations.php
+++ b/config/drupal-9/drupal-9.3-deprecations.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\DrupalGetFilenameRector;
 use DrupalRector\Rector\Deprecation\DrupalGetPathRector;
-use DrupalRector\Rector\Deprecation\FileBuildUrlRector;
+use DrupalRector\Rector\Deprecation\FileBuildUriRector;
 use DrupalRector\Rector\Deprecation\FileUrlGenerator;
 use DrupalRector\Rector\Deprecation\RenderRector;
 use DrupalRector\Rector\Deprecation\FileCopyRector;
@@ -34,5 +34,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FileCopyRector::class);
 
     // Change record: https://www.drupal.org/node/3223091.
-    $services->set(FileBuildUrlRector::class);
+    $services->set(FileBuildUriRector::class);
 };

--- a/config/drupal-9/drupal-9.3-deprecations.php
+++ b/config/drupal-9/drupal-9.3-deprecations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\DrupalGetFilenameRector;
 use DrupalRector\Rector\Deprecation\DrupalGetPathRector;
+use DrupalRector\Rector\Deprecation\FileBuildUrlRector;
 use DrupalRector\Rector\Deprecation\FileUrlGenerator;
 use DrupalRector\Rector\Deprecation\RenderRector;
 use DrupalRector\Rector\Deprecation\FileCopyRector;
@@ -31,4 +32,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FileSaveDataRector::class);
     $services->set(FileMoveRector::class);
     $services->set(FileCopyRector::class);
+
+    // Change record: https://www.drupal.org/node/3223091.
+    $services->set(FileBuildUrlRector::class);
 };

--- a/fixtures/d9/rector_examples/file_functions.php
+++ b/fixtures/d9/rector_examples/file_functions.php
@@ -4,4 +4,7 @@ function file_functions() {
     file_copy();
     file_move();
     file_save_data();
+    $uri1 = file_build_uri('path/to/file.txt');
+    $path = 'path/to/other/file.png';
+    $uri2 = file_build_uri($path);
 }

--- a/fixtures/d9/rector_examples_updated/file_functions.php
+++ b/fixtures/d9/rector_examples_updated/file_functions.php
@@ -4,4 +4,7 @@ function file_functions() {
     \Drupal::service('file.repository')->copy();
     \Drupal::service('file.repository')->move();
     \Drupal::service('file.repository')->writeData();
+    $uri1 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . 'path/to/file.txt'));
+    $path = 'path/to/other/file.png';
+    $uri2 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . $path));
 }

--- a/src/Rector/Deprecation/FileBuildUriRector.php
+++ b/src/Rector/Deprecation/FileBuildUriRector.php
@@ -7,7 +7,7 @@ use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class FileBuildUrlRector extends AbstractRector
+final class FileBuildUriRector extends AbstractRector
 {
     /**
      * @inheritdoc

--- a/src/Rector/Deprecation/FileBuildUrlRector.php
+++ b/src/Rector/Deprecation/FileBuildUrlRector.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace DrupalRector\Rector\Deprecation;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+final class FileBuildUrlRector extends AbstractRector
+{
+    /**
+     * @inheritdoc
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated file_build_uri() calls',[
+            new CodeSample(
+              <<<'CODE_BEFORE'
+$uri1 = file_build_uri('path/to/file.txt');
+$path = 'path/to/other/file.png';
+$uri2 = file_build_uri($path);
+CODE_BEFORE
+              ,
+              <<<'CODE_AFTER'
+$uri1 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . 'path/to/file.txt'));
+$path = 'path/to/other/file.png';
+$uri2 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . $path));
+CODE_AFTER
+            )
+        ]);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\FuncCall);
+        if ($this->getName($node->name) !== 'file_build_uri') {
+            return null;
+        }
+
+        assert(count($node->getArgs()) === 1);
+
+        $config = new Node\Expr\StaticCall(
+            new Node\Name\FullyQualified('Drupal'),
+            'config',
+            [new Node\Arg(new Node\Scalar\String_('system.file'))]
+        );
+        $scheme = new Node\Expr\MethodCall($config, new Node\Identifier('get'), [new Node\Scalar\String_('default_scheme')]);
+
+        $arg = new Node\Expr\BinaryOp\Concat(
+            $scheme,
+            // The nested concatenation is enclosed in parentheses.
+            // @see https://github.com/rectorphp/rector/issues/7188
+            new Node\Expr\BinaryOp\Concat(
+                new Node\Scalar\String_('://'),
+                $node->getArgs()[0]->value
+            )
+        );
+
+        $service = new Node\Expr\StaticCall(
+            new Node\Name\FullyQualified('Drupal'),
+            'service',
+            [new Node\Arg(new Node\Scalar\String_('stream_wrapper_manager'))]
+        );
+        $methodName = new Node\Identifier('normalizeUri');
+
+        return new Node\Expr\MethodCall($service, $methodName, [$arg]);
+    }
+}

--- a/tests/src/Rector/Deprecation/FileFunctionRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FileFunctionRector/config/configured_rule.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-use DrupalRector\Rector\Deprecation\FileBuildUrlRector;
+use DrupalRector\Rector\Deprecation\FileBuildUriRector;
 use DrupalRector\Rector\Deprecation\FileCopyRector;
 use DrupalRector\Rector\Deprecation\FileMoveRector;
 use DrupalRector\Rector\Deprecation\FileSaveDataRector;
@@ -12,5 +12,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FileSaveDataRector::class);
     $services->set(FileMoveRector::class);
     $services->set(FileCopyRector::class);
-    $services->set(FileBuildUrlRector::class);
+    $services->set(FileBuildUriRector::class);
 };

--- a/tests/src/Rector/Deprecation/FileFunctionRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FileFunctionRector/config/configured_rule.php
@@ -1,5 +1,6 @@
 <?php declare(strict_types=1);
 
+use DrupalRector\Rector\Deprecation\FileBuildUrlRector;
 use DrupalRector\Rector\Deprecation\FileCopyRector;
 use DrupalRector\Rector\Deprecation\FileMoveRector;
 use DrupalRector\Rector\Deprecation\FileSaveDataRector;
@@ -11,4 +12,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->set(FileSaveDataRector::class);
     $services->set(FileMoveRector::class);
     $services->set(FileCopyRector::class);
+    $services->set(FileBuildUrlRector::class);
 };

--- a/tests/src/Rector/Deprecation/FileFunctionRector/fixture/file_build_uri.php.inc
+++ b/tests/src/Rector/Deprecation/FileFunctionRector/fixture/file_build_uri.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+function file_functions()
+{
+    $uri1 = file_build_uri('path/to/file.txt');
+    $path = 'path/to/other/file.png';
+    $uri2 = file_build_uri($path);
+    $dir = 'path/to';
+    $uri3 = file_build_uri("$dir/file.jpg");
+    $uri4 = file_build_uri($dir . '/' . 'file1.jpg');
+}
+?>
+-----
+<?php
+
+function file_functions()
+{
+    $uri1 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . 'path/to/file.txt'));
+    $path = 'path/to/other/file.png';
+    $uri2 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . $path));
+    $dir = 'path/to';
+    $uri3 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . "$dir/file.jpg"));
+    $uri4 = \Drupal::service('stream_wrapper_manager')->normalizeUri(\Drupal::config('system.file')->get('default_scheme') . ('://' . ($dir . '/' . 'file1.jpg')));
+}
+?>


### PR DESCRIPTION
## Description

`file_build_uri()` is deprecated in Drupal 9.3. See https://www.drupal.org/node/3223091

## To Test

Run Rector on a code-base that includes `file_build_uri()`

## Drupal.org issue

https://www.drupal.org/project/rector/issues/3282217