### PR TITLE
Remove remaining Rector conflicts up to 0.12.21

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "~0.12.20",
+        "rector/rector": "~0.12.21",
         "webflo/drupal-finder": "^1.2"
     },
     "conflict": {
-        "rector/rector": ">0.12.20"
+        "rector/rector": ">0.12.21"
     },
     "license": "MIT",
     "authors": [
@@ -65,20 +65,24 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "extra": {
+        "enable-patching-note": "We need the following to allow rector/rector-src to patch dependencies.",
+        "enable-patching": true
+    },
     "require-dev": {
         "php": "^8.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "rector/rector-src": "dev-main#be530c5e2f56190f5fe1813ae4344cdaf3f75d7f",
+        "rector/rector-src": "dev-main#11fdd74f8abe3deefbb2492c00868c57184fd484",
         "rector/rector-cakephp": "dev-main#d1fa93dbf332a0170deaf37467b40735727003fb",
-        "rector/rector-doctrine": "dev-main#07a8a64857c82c511c3aa18636ad44e784636f15",
-        "rector/rector-laravel": "dev-main#31d9892d1f2abd41a118589ad76a065bb24150ea",
-        "rector/rector-nette": "dev-main#1c9a431e806e0214cb38ffd33bbd225bbf34ee42",
-        "rector/rector-phpoffice": "dev-main#1e12437861bb9e06f776b9f9be5811a7bf219729",
-        "rector/rector-phpunit": "dev-main#9706d8b89c53e35b02dc5b72fc909117ae0b7aac",
-        "rector/rector-symfony": "dev-main#d8dd12294481b10836fd0ea3532a0a81e0b9cdb3",
+        "rector/rector-doctrine": "dev-main#ae06e92e71b741f43906374a699eb041882259c3",
+        "rector/rector-laravel": "dev-main#48a1f3458dc9536a32dae0507ba53fc2d3d28f01",
+        "rector/rector-nette": "dev-main#e01d41e5caa10ff5057d3b922c95ba4f15d41657",
+        "rector/rector-phpoffice": "dev-main#4b9837410f4b1f2002693d94a0c4c483abf37e7f",
+        "rector/rector-phpunit": "dev-main#41775450593f1a94c30a562865c5340f4118880c",
+        "rector/rector-symfony": "dev-main#6e679917c27895e94314c436b44821e091384e8e",
         "symfony/yaml": "^5 || ^6"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "~0.12.19",
+        "rector/rector": "~0.12.20",
         "webflo/drupal-finder": "^1.2"
     },
     "conflict": {
-        "rector/rector": ">0.12.19"
+        "rector/rector": ">0.12.20"
     },
     "license": "MIT",
     "authors": [
@@ -71,14 +71,14 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "rector/rector-src": "dev-main#cbefb243e25ad213b187a55e5e50ec34b627b547",
+        "rector/rector-src": "dev-main#be530c5e2f56190f5fe1813ae4344cdaf3f75d7f",
         "rector/rector-cakephp": "dev-main#d1fa93dbf332a0170deaf37467b40735727003fb",
-        "rector/rector-doctrine": "dev-main#96ff8cbaf186e5d89a88a3ff49b55cb15d04519f",
-        "rector/rector-laravel": "dev-main#6bee4284d50e84eb5d027ff266801b2a1c903a33",
-        "rector/rector-nette": "dev-main#0aaf0a6d587b387982a6844538bce58c96cda86f",
-        "rector/rector-phpoffice": "dev-main#f23c4bf79c1f8a18349ab0b96bba8333dd7b823b",
-        "rector/rector-phpunit": "dev-main#5952218df3e5240c6e0f67ea8e7b5e004b575e8b",
-        "rector/rector-symfony": "dev-main#d0a6487e51d4959f4d2d6e0b3e8fa541505309ce",
+        "rector/rector-doctrine": "dev-main#07a8a64857c82c511c3aa18636ad44e784636f15",
+        "rector/rector-laravel": "dev-main#31d9892d1f2abd41a118589ad76a065bb24150ea",
+        "rector/rector-nette": "dev-main#1c9a431e806e0214cb38ffd33bbd225bbf34ee42",
+        "rector/rector-phpoffice": "dev-main#1e12437861bb9e06f776b9f9be5811a7bf219729",
+        "rector/rector-phpunit": "dev-main#9706d8b89c53e35b02dc5b72fc909117ae0b7aac",
+        "rector/rector-symfony": "dev-main#d8dd12294481b10836fd0ea3532a0a81e0b9cdb3",
         "symfony/yaml": "^5 || ^6"
     }
 }

--- a/config/drupal-8/drupal-8.0-deprecations.php
+++ b/config/drupal-8/drupal-8.0-deprecations.php
@@ -30,15 +30,30 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(DBInsertRector::class);
+    $services->set(DBInsertRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(DBSelectRector::class);
+    $services->set(DBSelectRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(DBQueryRector::class);
+    $services->set(DBQueryRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(DBDeleteRector::class);
+    $services->set(DBDeleteRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(DBUpdateRector::class);
+    $services->set(DBUpdateRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $services->set(DrupalRenderRector::class);
 
@@ -54,25 +69,49 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(EntityDeleteMultipleRector::class);
 
-    $services->set(EntityInterfaceLinkRector::class);
+    $services->set(EntityInterfaceLinkRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(EntityInterfaceUrlInfoRector::class);
+    $services->set(EntityInterfaceUrlInfoRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(EntityLoadRector::class);
+    $services->set(EntityLoadRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $services->set(EntityViewRector::class);
 
-    $services->set(EntityManagerRector::class);
+    $services->set(EntityManagerRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $services->set(FormatDateRector::class);
 
-    $services->set(FileLoadRector::class);
+    $services->set(FileLoadRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(LinkGeneratorTraitLRector::class);
+    $services->set(LinkGeneratorTraitLRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
-    $services->set(NodeLoadRector::class);
+    $services->set(NodeLoadRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $services->set(SafeMarkupFormatRector::class);
 
-    $services->set(UserLoadRector::class);
+    $services->set(UserLoadRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 };

--- a/config/drupal-8/drupal-8.5-deprecations.php
+++ b/config/drupal-8/drupal-8.5-deprecations.php
@@ -11,7 +11,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(DrupalSetMessageRector::class);
+    $services->set(DrupalSetMessageRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $services->set(DatetimeDateStorageFormatRector::class);
 

--- a/config/drupal-8/drupal-8.8-deprecations.php
+++ b/config/drupal-8/drupal-8.8-deprecations.php
@@ -35,7 +35,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(EntityGetFormDisplayRector::class);
 
-    $services->set(EntityTypeGetLowercaseLabelRector::class);
+    $services->set(EntityTypeGetLowercaseLabelRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $services->set(FileScanDirectoryRector::class);
 

--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -61,51 +61,159 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // AssertLegacyTrait items
     // @see https://www.drupal.org/project/rector/issues/3222671
     // @see https://www.drupal.org/node/3129738
-    $services->set(AssertRector::class);
-    $services->set(AssertEqualRector::class);
-    $services->set(AssertNotEqualRector::class);
-    $services->set(AssertIdenticalRector::class);
-    $services->set(AssertNotIdenticalRector::class);
-    $services->set(AssertIdenticalObjectRector::class);
+    $services->set(AssertRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertEqualRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNotEqualRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertIdenticalRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNotIdenticalRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertIdenticalObjectRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(PassRector::class);
-    $services->set(AssertElementPresentRector::class);
-    $services->set(AssertElementNotPresentRector::class);
-    $services->set(AssertTextRector::class);
-    $services->set(AssertNoTextRector::class);
-    $services->set(AssertUniqueTextRector::class);
+    $services->set(AssertElementPresentRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertElementNotPresentRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertTextRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoTextRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertUniqueTextRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(AssertNoUniqueTextRector::class);
-    $services->set(AssertResponseRector::class);
+    $services->set(AssertResponseRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(AssertFieldByNameRector::class);
-    $services->set(AssertNoFieldByNameRector::class);
+    $services->set(AssertNoFieldByNameRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(AssertFieldByIdRector::class);
-    $services->set(AssertFieldRector::class);
-    $services->set(AssertNoFieldRector::class);
-    $services->set(AssertRawRector::class);
-    $services->set(AssertNoRawRector::class);
-    $services->set(AssertTitleRector::class);
-    $services->set(AssertLinkRector::class);
-    $services->set(AssertNoLinkRector::class);
-    $services->set(AssertLinkByHrefRector::class);
-    $services->set(AssertNoLinkByHrefRector::class);
+    $services->set(AssertFieldRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoFieldRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertRawRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoRawRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertTitleRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertLinkRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoLinkRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertLinkByHrefRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoLinkByHrefRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(AssertNoFieldByIdRector::class);
-    $services->set(AssertUrlRector::class);
-    $services->set(AssertOptionRector::class);
-    $services->set(AssertOptionByTextRector::class);
-    $services->set(AssertNoOptionRector::class);
+    $services->set(AssertUrlRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertOptionRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertOptionByTextRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoOptionRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(AssertOptionSelectedRector::class);
-    $services->set(AssertFieldCheckedRector::class);
-    $services->set(AssertNoFieldCheckedRector::class);
+    $services->set(AssertFieldCheckedRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoFieldCheckedRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     // @todo AssertFieldByXPathRector
     // @todo AssertNoFieldByXPathRector
     // @todo AssertFieldsByValueRector
-    $services->set(AssertEscapedRector::class);
-    $services->set(AssertNoEscapedRector::class);
-    $services->set(AssertPatternRector::class);
-    $services->set(AssertNoPatternRector::class);
-    $services->set(AssertCacheTagRector::class);
-    $services->set(AssertNoCacheTagRector::class);
-    $services->set(AssertHeaderRector::class);
-    $services->set(BuildXPathQueryRector::class);
+    $services->set(AssertEscapedRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoEscapedRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertPatternRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoPatternRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertCacheTagRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoCacheTagRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertHeaderRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(BuildXPathQueryRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $services->set(ConstructFieldXpathRector::class);
     $services->set(GetRawContentRector::class);
     $services->set(GetAllOptionsRector::class);

--- a/config/drupal-9/drupal-9.2-deprecations.php
+++ b/config/drupal-9/drupal-9.2-deprecations.php
@@ -12,5 +12,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     // Change record: https://www.drupal.org/node/3187914
-    $services->set(ClearCsrfTokenSeed::class);
+    $services->set(ClearCsrfTokenSeed::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 };

--- a/config/drupal-9/drupal-9.3-deprecations.php
+++ b/config/drupal-9/drupal-9.3-deprecations.php
@@ -15,8 +15,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     // Change record: https://www.drupal.org/node/2940438.
-    $services->set(DrupalGetPathRector::class);
-    $services->set(DrupalGetFilenameRector::class);
+    $services->set(DrupalGetPathRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(DrupalGetFilenameRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     // Change record: https://www.drupal.org/node/2939099.
     $services->set(RenderRector::class);

--- a/rector.php
+++ b/rector.php
@@ -28,8 +28,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters->set(Option::FILE_EXTENSIONS, ['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
     $parameters->set(Option::AUTO_IMPORT_NAMES, true);
     $parameters->set(Option::IMPORT_SHORT_CLASSES, false);
-    // @phpstan-ignore-next-line
-    $parameters->set(Option::IMPORT_DOC_BLOCKS, false);
 
     $parameters->set('drupal_rector_notices_as_comments', true);
 };

--- a/src/Rector/Deprecation/AssertNoTextRector.php
+++ b/src/Rector/Deprecation/AssertNoTextRector.php
@@ -3,13 +3,11 @@
 namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
-use DrupalRector\Utility\AddCommentTrait;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class AssertNoTextRector extends AssertLegacyTraitBase
 {
-    use AddCommentTrait;
 
     // @codingStandardsIgnoreLine
     protected $comment = 'Verify the assertion: pageTextNotContains() for HTML responses, responseNotContains() for non-HTML responses.' .

--- a/src/Rector/Deprecation/AssertTextRector.php
+++ b/src/Rector/Deprecation/AssertTextRector.php
@@ -3,13 +3,11 @@
 namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Rector\Deprecation\Base\AssertLegacyTraitBase;
-use DrupalRector\Utility\AddCommentTrait;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class AssertTextRector extends AssertLegacyTraitBase
 {
-    use AddCommentTrait;
 
     // @codingStandardsIgnoreLine
     protected $comment = 'Verify the assertion: pageTextContains() for HTML responses, responseContains() for non-HTML responses.' .

--- a/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
+++ b/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
@@ -5,10 +5,10 @@ namespace DrupalRector\Rector\Deprecation\Base;
 use DrupalRector\Utility\AddCommentTrait;
 use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
-abstract class AssertLegacyTraitBase extends AbstractRector
+abstract class AssertLegacyTraitBase extends AbstractRector implements ConfigurableRectorInterface
 {
 
     use AddCommentTrait;
@@ -20,16 +20,9 @@ abstract class AssertLegacyTraitBase extends AbstractRector
     protected $isAssertSessionMethod = true;
     protected $declaringSource = 'Drupal\FunctionalTests\AssertLegacyTrait';
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     public function getNodeTypes(): array

--- a/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
+++ b/src/Rector/Deprecation/Base/AssertLegacyTraitBase.php
@@ -6,6 +6,7 @@ use DrupalRector\Utility\AddCommentTrait;
 use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 abstract class AssertLegacyTraitBase extends AbstractRector
 {
@@ -18,6 +19,18 @@ abstract class AssertLegacyTraitBase extends AbstractRector
     protected $methodName;
     protected $isAssertSessionMethod = true;
     protected $declaringSource = 'Drupal\FunctionalTests\AssertLegacyTrait';
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     public function getNodeTypes(): array
     {

--- a/src/Rector/Deprecation/Base/DBBase.php
+++ b/src/Rector/Deprecation/Base/DBBase.php
@@ -4,6 +4,7 @@ namespace DrupalRector\Rector\Deprecation\Base;
 
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
@@ -30,7 +31,7 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
  * - Inject the database connection
  * - Use calls to Database::getConnection() if the container is not yet available
  */
-abstract class DBBase extends AbstractRector
+abstract class DBBase extends AbstractRector implements ConfigurableRectorInterface
 {
     use AddCommentTrait;
 
@@ -50,16 +51,9 @@ abstract class DBBase extends AbstractRector
      */
     protected $optionsArgumentPosition;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/Base/DBBase.php
+++ b/src/Rector/Deprecation/Base/DBBase.php
@@ -5,6 +5,7 @@ namespace DrupalRector\Rector\Deprecation\Base;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * Base class for replacing deprecated db_*() calls.
@@ -48,6 +49,18 @@ abstract class DBBase extends AbstractRector
      * @var int
      */
     protected $optionsArgumentPosition;
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     /**
      * Return the name of the new method.

--- a/src/Rector/Deprecation/Base/EntityLoadBase.php
+++ b/src/Rector/Deprecation/Base/EntityLoadBase.php
@@ -5,6 +5,7 @@ namespace DrupalRector\Rector\Deprecation\Base;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * Replaced deprecated entity_load() calls.
@@ -21,110 +22,127 @@ use Rector\Core\Rector\AbstractRector;
 abstract class EntityLoadBase extends AbstractRector
 {
 
-  use AddCommentTrait;
+    use AddCommentTrait;
 
-  /**
-   * The entity type to load.
-   *
-   * If this is not set, we assume we need to get it passed to entity_load().
-   *
-   * @var string $entityType
-   */
-  protected $entityType;
+    /**
+     * The entity type to load.
+     *
+     * If this is not set, we assume we need to get it passed to entity_load().
+     *
+     * @var string $entityType
+     */
+    protected $entityType;
 
-  /**
-   * @inheritdoc
-   */
-  public function getNodeTypes(): array
-  {
-    return [
-      Node\Expr\FuncCall::class,
-    ];
-  }
+    private $parameterProvider;
 
-  /**
-   * @inheritdoc
-   */
-  public function refactor(Node $node): ?Node
-  {
-
-    $is_rector_rule_entity_load = is_null($this->entityType);
-
-    if ($is_rector_rule_entity_load) {
-        $method_name = 'entity_load';
-    }
-    else {
-        // This will work for node_load, etc.
-        $method_name = $this->entityType . '_load';
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
     }
 
-    /** @var Node\Expr\FuncCall $node */
-    if ($this->getName($node->name) === $method_name) {
-        // We are doing this here, because we know we have access to arguments since we have already checked the method name.
-        if ($is_rector_rule_entity_load) {
-            // Since we have one more argument, all the array keys are one greater.
-            $argument_offset = 1;
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
-            /* @var Node\Arg $entity_type. */
-            $entity_type = $node->args[0];
-        }
-        // If we do not set entityType, we are using entity_load().
-        else {
-            $argument_offset = 0;
-
-            // Create an argument, like that which is passed by entity_load().
-            $entity_type = new Node\Arg(new Node\Scalar\String_($this->entityType));
-        }
-
-        /* @var Node\Arg $entity_id. */
-        $entity_id = $node->args[0 + $argument_offset];
-
-        $name = new Node\Name\FullyQualified('Drupal');
-
-        $call = new Node\Identifier('service');
-
-        $entity_type_manager_args = [
-            new Node\Arg(new Node\Scalar\String_('entity_type.manager')),
+    /**
+     * @inheritdoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\FuncCall::class,
         ];
+    }
 
-        $var = new Node\Expr\StaticCall($name, $call, $entity_type_manager_args);
+    /**
+     * @inheritdoc
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $is_rector_rule_entity_load = is_null($this->entityType);
 
-        $getStorage_method_name = new Node\Identifier('getStorage');
+        if ($is_rector_rule_entity_load) {
+            $method_name = 'entity_load';
+        } else {
+            // This will work for node_load, etc.
+            $method_name = $this->entityType.'_load';
+        }
 
-        // Start to build the new node.
-        $getStorage_node = new Node\Expr\MethodCall($var, $getStorage_method_name, [$entity_type]);
+        /** @var Node\Expr\FuncCall $node */
+        if ($this->getName($node->name) === $method_name) {
+            // We are doing this here, because we know we have access to arguments since we have already checked the method name.
+            if ($is_rector_rule_entity_load) {
+                // Since we have one more argument, all the array keys are one greater.
+                $argument_offset = 1;
 
-        // Create the simple version of the entity load.
-        $load_method_name = new Node\Identifier('load');
+                /* @var Node\Arg $entity_type . */
+                $entity_type = $node->args[0];
+            } // If we do not set entityType, we are using entity_load().
+            else {
+                $argument_offset = 0;
 
-        $new_node = new Node\Expr\MethodCall($getStorage_node, $load_method_name, [$entity_id]);
+                // Create an argument, like that which is passed by entity_load().
+                $entity_type = new Node\Arg(new Node\Scalar\String_($this->entityType));
+            }
 
-        // We need to account for the `reset` option which adds a method to the chain.
-        // We will replace the original method with a ternary to evaluate and provide both options.
-        if (count($node->args) == (2 + $argument_offset)) {
-            $this->addDrupalRectorComment($node, 'A ternary operator is used here to keep the conditional contained within this part of the expression. Consider wrapping this statement in an `if / else` statement.');
+            /* @var Node\Arg $entity_id . */
+            $entity_id = $node->args[0 + $argument_offset];
 
-            /* @var Node\Arg $reset_flag. */
-            $reset_flag = $node->args[1 + $argument_offset];
+            $name = new Node\Name\FullyQualified('Drupal');
 
-            $resetCache_method_name = new Node\Identifier('resetCache');
+            $call = new Node\Identifier('service');
 
-            $reset_args = [
-                // This creates a new argument that wraps the entity ID in an array.
-                new Node\Arg(new Node\Expr\Array_([new Node\Expr\ArrayItem($entity_id->value)])),
+            $entity_type_manager_args = [
+                new Node\Arg(new Node\Scalar\String_('entity_type.manager')),
             ];
 
-            $entity_load_reset_node = new Node\Expr\MethodCall($getStorage_node, $resetCache_method_name, $reset_args);
+            $var = new Node\Expr\StaticCall($name, $call,
+                $entity_type_manager_args);
 
-            $entity_load_reset_node = new Node\Expr\MethodCall($entity_load_reset_node, $load_method_name, [$entity_id]);
+            $getStorage_method_name = new Node\Identifier('getStorage');
 
-            // Replace the new_node with a ternary.
-            $new_node = new Node\Expr\Ternary($reset_flag->value, $entity_load_reset_node, $new_node);
+            // Start to build the new node.
+            $getStorage_node = new Node\Expr\MethodCall($var,
+                $getStorage_method_name, [$entity_type]);
+
+            // Create the simple version of the entity load.
+            $load_method_name = new Node\Identifier('load');
+
+            $new_node = new Node\Expr\MethodCall($getStorage_node,
+                $load_method_name, [$entity_id]);
+
+            // We need to account for the `reset` option which adds a method to the chain.
+            // We will replace the original method with a ternary to evaluate and provide both options.
+            if (count($node->args) == (2 + $argument_offset)) {
+                $this->addDrupalRectorComment($node,
+                    'A ternary operator is used here to keep the conditional contained within this part of the expression. Consider wrapping this statement in an `if / else` statement.');
+
+                /* @var Node\Arg $reset_flag . */
+                $reset_flag = $node->args[1 + $argument_offset];
+
+                $resetCache_method_name = new Node\Identifier('resetCache');
+
+                $reset_args = [
+                    // This creates a new argument that wraps the entity ID in an array.
+                    new Node\Arg(new Node\Expr\Array_([new Node\Expr\ArrayItem($entity_id->value)])),
+                ];
+
+                $entity_load_reset_node = new Node\Expr\MethodCall($getStorage_node,
+                    $resetCache_method_name, $reset_args);
+
+                $entity_load_reset_node = new Node\Expr\MethodCall($entity_load_reset_node,
+                    $load_method_name, [$entity_id]);
+
+                // Replace the new_node with a ternary.
+                $new_node = new Node\Expr\Ternary($reset_flag->value,
+                    $entity_load_reset_node, $new_node);
+            }
+
+            return $new_node;
         }
 
-        return $new_node;
+        return null;
     }
 
-    return null;
-  }
 }

--- a/src/Rector/Deprecation/Base/EntityLoadBase.php
+++ b/src/Rector/Deprecation/Base/EntityLoadBase.php
@@ -4,6 +4,7 @@ namespace DrupalRector\Rector\Deprecation\Base;
 
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
@@ -19,7 +20,7 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
  * Improvement opportunities
  * - Dependency injection
  */
-abstract class EntityLoadBase extends AbstractRector
+abstract class EntityLoadBase extends AbstractRector implements ConfigurableRectorInterface
 {
 
     use AddCommentTrait;
@@ -33,16 +34,9 @@ abstract class EntityLoadBase extends AbstractRector
      */
     protected $entityType;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/Base/ExtensionPathBase.php
+++ b/src/Rector/Deprecation/Base/ExtensionPathBase.php
@@ -6,6 +6,7 @@ use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use PHPStan\Type\Constant\ConstantStringType;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 abstract class ExtensionPathBase extends AbstractRector
 {
@@ -14,6 +15,18 @@ abstract class ExtensionPathBase extends AbstractRector
     protected $functionName;
 
     protected $methodName;
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     public function getNodeTypes(): array
     {

--- a/src/Rector/Deprecation/Base/ExtensionPathBase.php
+++ b/src/Rector/Deprecation/Base/ExtensionPathBase.php
@@ -5,10 +5,10 @@ namespace DrupalRector\Rector\Deprecation\Base;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use PHPStan\Type\Constant\ConstantStringType;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
-abstract class ExtensionPathBase extends AbstractRector
+abstract class ExtensionPathBase extends AbstractRector implements ConfigurableRectorInterface
 {
     use AddCommentTrait;
 
@@ -16,16 +16,9 @@ abstract class ExtensionPathBase extends AbstractRector
 
     protected $methodName;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     public function getNodeTypes(): array

--- a/src/Rector/Deprecation/Base/MethodToMethodBase.php
+++ b/src/Rector/Deprecation/Base/MethodToMethodBase.php
@@ -6,6 +6,7 @@ use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use PHPStan\Type\ObjectType;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * Replaces deprecated method calls with a new method.
@@ -41,6 +42,18 @@ abstract class MethodToMethodBase extends AbstractRector
      * @var string
      */
     protected $className;
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     /**
      * @inheritdoc

--- a/src/Rector/Deprecation/Base/MethodToMethodBase.php
+++ b/src/Rector/Deprecation/Base/MethodToMethodBase.php
@@ -5,6 +5,7 @@ namespace DrupalRector\Rector\Deprecation\Base;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use PHPStan\Type\ObjectType;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
@@ -18,7 +19,7 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
  * - Checks the variable has a certain class.
  *
  */
-abstract class MethodToMethodBase extends AbstractRector
+abstract class MethodToMethodBase extends AbstractRector implements ConfigurableRectorInterface
 {
     use AddCommentTrait;
 
@@ -43,16 +44,9 @@ abstract class MethodToMethodBase extends AbstractRector
      */
     protected $className;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/DrupalSetMessageRector.php
+++ b/src/Rector/Deprecation/DrupalSetMessageRector.php
@@ -12,10 +12,9 @@ use PHPStan\Type\Constant\ConstantStringType;
 use PHPStan\Type\Generic\GenericClassStringType;
 use PHPStan\Type\StringType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
-use Rector\Core\Exception\ShouldNotHappenException;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Core\Rector\AbstractRector;
-use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -34,21 +33,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Add trait for classes
  *   - `use MessengerTrait;`
  */
-final class DrupalSetMessageRector extends AbstractRector
+final class DrupalSetMessageRector extends AbstractRector implements ConfigurableRectorInterface
 {
     use TraitsByClassHelperTrait;
     use AddCommentTrait;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/DrupalSetMessageRector.php
+++ b/src/Rector/Deprecation/DrupalSetMessageRector.php
@@ -15,6 +15,7 @@ use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -37,6 +38,18 @@ final class DrupalSetMessageRector extends AbstractRector
 {
     use TraitsByClassHelperTrait;
     use AddCommentTrait;
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     /**
      * @inheritdoc

--- a/src/Rector/Deprecation/EntityInterfaceLinkRector.php
+++ b/src/Rector/Deprecation/EntityInterfaceLinkRector.php
@@ -3,6 +3,7 @@
 namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Utility\AddCommentTrait;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -20,21 +21,14 @@ use Rector\Core\Rector\AbstractRector;
  * Improvement opportunities:
  * - Checks the variable has a certain class.
  */
-final class EntityInterfaceLinkRector extends AbstractRector
+final class EntityInterfaceLinkRector extends AbstractRector implements ConfigurableRectorInterface
 {
 
     use AddCommentTrait;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/EntityInterfaceLinkRector.php
+++ b/src/Rector/Deprecation/EntityInterfaceLinkRector.php
@@ -3,6 +3,7 @@
 namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Utility\AddCommentTrait;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use PhpParser\Node;
@@ -21,14 +22,27 @@ use Rector\Core\Rector\AbstractRector;
  */
 final class EntityInterfaceLinkRector extends AbstractRector
 {
+
     use AddCommentTrait;
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     /**
      * @inheritdoc
      */
     public function getRuleDefinition(): RuleDefinition
     {
-        return new RuleDefinition('Fixes deprecated link() calls',[
+        return new RuleDefinition('Fixes deprecated link() calls', [
             new CodeSample(
                 <<<'CODE_BEFORE'
 $url = $entity->link();
@@ -37,43 +51,45 @@ CODE_BEFORE
                 <<<'CODE_AFTER'
 $url = $entity->toLink()->toString();
 CODE_AFTER
-        )
-      ]);
+            ),
+        ]);
     }
 
-  /**
-   * @inheritdoc
-   */
-  public function getNodeTypes(): array
-  {
-      return [
-          Node\Expr\MethodCall::class,
-      ];
-  }
+    /**
+     * @inheritdoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\MethodCall::class,
+        ];
+    }
 
-  /**
-   * @inheritdoc
-   */
-  public function refactor(Node $node): ?Node
-  {
-      /** @var Node\Expr\MethodCall $node */
-      // TODO: Check the class to see if it implements Drupal\Core\Entity\EntityInterface.
-      if ($this->getName($node->name) === 'link') {
-          $node_class_name = $this->getName($node->var);
+    /**
+     * @inheritdoc
+     */
+    public function refactor(Node $node): ?Node
+    {
+        /** @var Node\Expr\MethodCall $node */
+        // TODO: Check the class to see if it implements Drupal\Core\Entity\EntityInterface.
+        if ($this->getName($node->name) === 'link') {
+            $node_class_name = $this->getName($node->var);
 
-          $this->addDrupalRectorComment($node, "Please confirm that `$$node_class_name` is an instance of `\Drupal\Core\Entity\EntityInterface`. Only the method name and not the class name was checked for this replacement, so this may be a false positive.");
+            $this->addDrupalRectorComment($node,
+                "Please confirm that `$$node_class_name` is an instance of `\Drupal\Core\Entity\EntityInterface`. Only the method name and not the class name was checked for this replacement, so this may be a false positive.");
 
-          $toLink_node = $node;
+            $toLink_node = $node;
 
-          $toLink_node->name = new Node\Name('toLink');
+            $toLink_node->name = new Node\Name('toLink');
 
-          // Add ->toString();
-          $new_node = new Node\Expr\MethodCall($toLink_node, new Node\Identifier('toString'));
+            // Add ->toString();
+            $new_node = new Node\Expr\MethodCall($toLink_node,
+                new Node\Identifier('toString'));
 
-          return $new_node;
-      }
+            return $new_node;
+        }
 
-      return null;
-  }
+        return null;
+    }
 
 }

--- a/src/Rector/Deprecation/EntityManagerRector.php
+++ b/src/Rector/Deprecation/EntityManagerRector.php
@@ -8,208 +8,235 @@ use PHPStan\Analyser\Scope;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * Replaces deprecated `\Drupal::entityManager()` calls.
- * Replaces deprecated `$this->entityManager()` calls in classes that extend `ControllerBase`.
+ * Replaces deprecated `$this->entityManager()` calls in classes that extend
+ * `ControllerBase`.
  *
  * See https://www.drupal.org/node/2549139 for change record.
  *
  * What is covered:
  * - Static replacement
- * - Dependency injection when class extends `ControllerBase` and uses `entityTypeManager`
+ * - Dependency injection when class extends `ControllerBase` and uses
+ * `entityTypeManager`
  *
  * Improvement opportunities
  * - Dependency injection
- * - Dependency injection when class extends `ControllerBase` and does not use `entityTypeManager`
- * - Complex use case handling when a different service is needed and the method does not directly call the service
+ * - Dependency injection when class extends `ControllerBase` and does not use
+ * `entityTypeManager`
+ * - Complex use case handling when a different service is needed and the
+ * method does not directly call the service
  */
-final class EntityManagerRector extends AbstractRector {
+final class EntityManagerRector extends AbstractRector
+{
 
-  use AddCommentTrait;
+    use AddCommentTrait;
 
-  /**
-   * @var ParentClassScopeResolver
-   */
-  protected $parentClassScopeResolver;
+    /**
+     * @var ParentClassScopeResolver
+     */
+    protected $parentClassScopeResolver;
 
-  public function __construct(ParentClassScopeResolver $parentClassScopeResolver) {
-    $this->parentClassScopeResolver = $parentClassScopeResolver;
-  }
+    private $parameterProvider;
 
-  /**
-   * @inheritdoc
-   */
-  public function getRuleDefinition(): RuleDefinition {
-    return new RuleDefinition('Fixes deprecated \Drupal::entityManager() calls',[
-      new CodeSample(
-        <<<'CODE_BEFORE'
+
+    public function __construct(
+        ParentClassScopeResolver $parentClassScopeResolver,
+        ParameterProvider $parameterProvider
+    ) {
+        $this->parentClassScopeResolver = $parentClassScopeResolver;
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated \Drupal::entityManager() calls',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
 $entity_manager = \Drupal::entityManager();
 CODE_BEFORE
-        ,
-        <<<'CODE_AFTER'
+                    ,
+                    <<<'CODE_AFTER'
 $entity_manager = \Drupal::entityTypeManager();
 CODE_AFTER
-      )
-    ]);
-  }
+                ),
+            ]);
+    }
 
-  /**
-   * @inheritdoc
-   */
-  public function getNodeTypes(): array {
-    return [
-      Node\Expr\StaticCall::class,
-      Node\Expr\MethodCall::class,
-    ];
-  }
+    /**
+     * @inheritdoc
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\StaticCall::class,
+            Node\Expr\MethodCall::class,
+        ];
+    }
 
-  /**
-   * @inheritdoc
-   */
-  public function refactor(Node $node): ?Node {
+    /**
+     * @inheritdoc
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->getName($node->name) === 'entityManager') {
+            if ($node instanceof Node\Expr\StaticCall && $this->getName($node->class) === 'Drupal') {
+                $service = 'entity_type.manager';
 
-    if ($this->getName($node->name) === 'entityManager') {
-      if ($node instanceof Node\Expr\StaticCall && $this->getName($node->class) === 'Drupal') {
-        $service = 'entity_type.manager';
-
-        // If we call a method on `entityManager`, we need to check that method and we can call the correct service that the method uses.
-        if ($node->hasAttribute(AttributeKey::NEXT_NODE)) {
-          $next_node = $node->getAttribute(AttributeKey::NEXT_NODE);
-
-          $service = $this->getServiceByMethodName($this->getName($next_node));
-        }
-        else {
-          $this->addDrupalRectorComment($node, 'We are assuming that we want to use the `entity_type.manager` service since no method was called here directly. Please confirm this is the case. See https://www.drupal.org/node/2549139 for more information.');
-        }
-
-        // This creates a service call like `\Drupal::service('entity_type.manager').
-        // This doesn't use dependency injection, but it should work.
-        $node = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'), 'service', [new Node\Arg(new Node\Scalar\String_($service))]);
-
-        return $node;
-      }
-
-        $scope = $node->getAttribute(AttributeKey::SCOPE);
-        if ($scope instanceof Scope) {
-            $parentClassName = $this->parentClassScopeResolver->resolveParentClassName($scope);
-            if ($node instanceof Node\Expr\MethodCall && $parentClassName === 'Drupal\Core\Controller\ControllerBase') {
                 // If we call a method on `entityManager`, we need to check that method and we can call the correct service that the method uses.
-                $next_node = $node->getAttribute(AttributeKey::NEXT_NODE);
+                if ($node->hasAttribute(AttributeKey::NEXT_NODE)) {
+                    $next_node = $node->getAttribute(AttributeKey::NEXT_NODE);
 
-                if (!is_null($next_node)) {
                     $service = $this->getServiceByMethodName($this->getName($next_node));
-
-                    // This creates a service call like `\Drupal::service('entity_type.manager').
-                    // This doesn't use dependency injection, but it should work.
-                    $node = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'), 'service', [new Node\Arg(new Node\Scalar\String_($service))]);
+                } else {
+                    $this->addDrupalRectorComment($node,
+                        'We are assuming that we want to use the `entity_type.manager` service since no method was called here directly. Please confirm this is the case. See https://www.drupal.org/node/2549139 for more information.');
                 }
-                else {
-                    // If we are making a direct call to ->entityManager(), we can assume the new class will also have entityTypeManager.
-                    $this->addDrupalRectorComment($node, 'We are assuming that we want to use the `$this->entityTypeManager` injected service since no method was called here directly. Please confirm this is the case. If another service is needed, you may need to inject that yourself. See https://www.drupal.org/node/2549139 for more information.');
 
-                    $node = new Node\Expr\MethodCall(new Node\Expr\Variable('this'), new Node\Identifier('entityTypeManager'));
-                }
+                // This creates a service call like `\Drupal::service('entity_type.manager').
+                // This doesn't use dependency injection, but it should work.
+                $node = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'),
+                    'service',
+                    [new Node\Arg(new Node\Scalar\String_($service))]);
 
                 return $node;
             }
+
+            $scope = $node->getAttribute(AttributeKey::SCOPE);
+            if ($scope instanceof Scope) {
+                $parentClassName = $this->parentClassScopeResolver->resolveParentClassName($scope);
+                if ($node instanceof Node\Expr\MethodCall && $parentClassName === 'Drupal\Core\Controller\ControllerBase') {
+                    // If we call a method on `entityManager`, we need to check that method and we can call the correct service that the method uses.
+                    $next_node = $node->getAttribute(AttributeKey::NEXT_NODE);
+
+                    if (!is_null($next_node)) {
+                        $service = $this->getServiceByMethodName($this->getName($next_node));
+
+                        // This creates a service call like `\Drupal::service('entity_type.manager').
+                        // This doesn't use dependency injection, but it should work.
+                        $node = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'),
+                            'service',
+                            [new Node\Arg(new Node\Scalar\String_($service))]);
+                    } else {
+                        // If we are making a direct call to ->entityManager(), we can assume the new class will also have entityTypeManager.
+                        $this->addDrupalRectorComment($node,
+                            'We are assuming that we want to use the `$this->entityTypeManager` injected service since no method was called here directly. Please confirm this is the case. If another service is needed, you may need to inject that yourself. See https://www.drupal.org/node/2549139 for more information.');
+
+                        $node = new Node\Expr\MethodCall(new Node\Expr\Variable('this'),
+                            new Node\Identifier('entityTypeManager'));
+                    }
+
+                    return $node;
+                }
+            }
         }
 
+        return null;
     }
 
-    return null;
-  }
+    private function getServiceByMethodName(string $method_name)
+    {
+        switch ($method_name) {
+            case 'getEntityTypeLabels':
+            case 'getEntityTypeFromClass':
+                $service = 'entity_type.repository';
+                break;
 
-  private function getServiceByMethodName(string $method_name) {
-      switch ($method_name) {
-          case 'getEntityTypeLabels':
-          case 'getEntityTypeFromClass':
-              $service = 'entity_type.repository';
-              break;
+            case 'getAllBundleInfo':
+            case 'getBundleInfo':
+            case 'clearCachedBundles':
+                $service = 'entity_type.bundle.info';
+                break;
 
-          case 'getAllBundleInfo':
-          case 'getBundleInfo':
-          case 'clearCachedBundles':
-              $service = 'entity_type.bundle.info';
-              break;
+            case 'getAllViewModes':
+            case 'getViewModes':
+            case 'getAllFormModes':
+            case 'getFormModes':
+            case 'getViewModeOptions':
+            case 'getFormModeOptions':
+            case 'getViewModeOptionsByBundle':
+            case 'getFormModeOptionsByBundle':
+            case 'clearDisplayModeInfo':
+                $service = 'entity_display.repository';
+                break;
 
-          case 'getAllViewModes':
-          case 'getViewModes':
-          case 'getAllFormModes':
-          case 'getFormModes':
-          case 'getViewModeOptions':
-          case 'getFormModeOptions':
-          case 'getViewModeOptionsByBundle':
-          case 'getFormModeOptionsByBundle':
-          case 'clearDisplayModeInfo':
-              $service = 'entity_display.repository';
-              break;
+            case 'getBaseFieldDefinitions':
+            case 'getFieldDefinitions':
+            case 'getFieldStorageDefinitions':
+            case 'getFieldMap':
+            case 'setFieldMap':
+            case 'getFieldMapByFieldType':
+            case 'clearCachedFieldDefinitions':
+            case 'useCaches':
+            case 'getExtraFields':
+                $service = 'entity_field.manager';
+                break;
 
-          case 'getBaseFieldDefinitions':
-          case 'getFieldDefinitions':
-          case 'getFieldStorageDefinitions':
-          case 'getFieldMap':
-          case 'setFieldMap':
-          case 'getFieldMapByFieldType':
-          case 'clearCachedFieldDefinitions':
-          case 'useCaches':
-          case 'getExtraFields':
-              $service = 'entity_field.manager';
-              break;
+            case 'onEntityTypeCreate':
+            case 'onEntityTypeUpdate':
+            case 'onEntityTypeDelete':
+                $service = 'entity_type.listener';
+                break;
 
-          case 'onEntityTypeCreate':
-          case 'onEntityTypeUpdate':
-          case 'onEntityTypeDelete':
-              $service = 'entity_type.listener';
-              break;
+            case 'getLastInstalledDefinition':
+            case 'getLastInstalledFieldStorageDefinitions':
+                $service = 'entity_definition.repository';
+                break;
 
-          case 'getLastInstalledDefinition':
-          case 'getLastInstalledFieldStorageDefinitions':
-              $service = 'entity_definition.repository';
-              break;
+            case 'loadEntityByUuid':
+            case 'loadEntityByConfigTarget':
+            case 'getTranslationFromContext':
+                $service = 'entity.repository';
+                break;
 
-          case 'loadEntityByUuid':
-          case 'loadEntityByConfigTarget':
-          case 'getTranslationFromContext':
-              $service = 'entity.repository';
-              break;
+            case 'onBundleCreate':
+            case 'onBundleRename':
+            case 'onBundleDelete':
+                $service = 'entity_bundle.listener';
+                break;
 
-          case 'onBundleCreate':
-          case 'onBundleRename':
-          case 'onBundleDelete':
-              $service = 'entity_bundle.listener';
-              break;
+            case 'onFieldStorageDefinitionCreate':
+            case 'onFieldStorageDefinitionUpdate':
+            case 'onFieldStorageDefinitionDelete':
+                $service = 'field_storage_definition.listener';
+                break;
 
-          case 'onFieldStorageDefinitionCreate':
-          case 'onFieldStorageDefinitionUpdate':
-          case 'onFieldStorageDefinitionDelete':
-              $service = 'field_storage_definition.listener';
-              break;
+            case 'onFieldDefinitionCreate':
+            case 'onFieldDefinitionUpdate':
+            case 'onFieldDefinitionDelete':
+                $service = 'field_definition.listener';
+                break;
 
-          case 'onFieldDefinitionCreate':
-          case 'onFieldDefinitionUpdate':
-          case 'onFieldDefinitionDelete':
-              $service = 'field_definition.listener';
-              break;
+            case 'getAccessControlHandler':
+            case 'getStorage':
+            case 'getViewBuilder':
+            case 'getListBuilder':
+            case 'getFormObject':
+            case 'getRouteProviders':
+            case 'hasHandler':
+            case 'getHandler':
+            case 'createHandlerInstance':
+            case 'getDefinition':
+            case 'getDefinitions':
+            default:
+                $service = 'entity_type.manager';
+                break;
+        }
 
-          case 'getAccessControlHandler':
-          case 'getStorage':
-          case 'getViewBuilder':
-          case 'getListBuilder':
-          case 'getFormObject':
-          case 'getRouteProviders':
-          case 'hasHandler':
-          case 'getHandler':
-          case 'createHandlerInstance':
-          case 'getDefinition':
-          case 'getDefinitions':
-          default:
-              $service = 'entity_type.manager';
-              break;
-      }
+        return $service;
+    }
 
-      return $service;
-  }
 }

--- a/src/Rector/Deprecation/EntityManagerRector.php
+++ b/src/Rector/Deprecation/EntityManagerRector.php
@@ -5,6 +5,7 @@ namespace DrupalRector\Rector\Deprecation;
 use DrupalRector\Utility\AddCommentTrait;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -31,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Complex use case handling when a different service is needed and the
  * method does not directly call the service
  */
-final class EntityManagerRector extends AbstractRector
+final class EntityManagerRector extends AbstractRector implements ConfigurableRectorInterface
 {
 
     use AddCommentTrait;
@@ -41,20 +42,15 @@ final class EntityManagerRector extends AbstractRector
      */
     protected $parentClassScopeResolver;
 
-    private $parameterProvider;
-
-
     public function __construct(
-        ParentClassScopeResolver $parentClassScopeResolver,
-        ParameterProvider $parameterProvider
+        ParentClassScopeResolver $parentClassScopeResolver
     ) {
         $this->parentClassScopeResolver = $parentClassScopeResolver;
-        $this->parameterProvider = $parameterProvider;
     }
 
-    protected function getParameterProvider(): ParameterProvider
+    public function configure(array $configuration): void
     {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/LinkGeneratorTraitLRector.php
+++ b/src/Rector/Deprecation/LinkGeneratorTraitLRector.php
@@ -5,6 +5,7 @@ namespace DrupalRector\Rector\Deprecation;
 use DrupalRector\Utility\AddCommentTrait;
 use DrupalRector\Utility\TraitsByClassHelperTrait;
 use PhpParser\Node;
+use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
@@ -22,21 +23,14 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Remove link generator trait.
  */
-final class LinkGeneratorTraitLRector extends AbstractRector
+final class LinkGeneratorTraitLRector extends AbstractRector implements ConfigurableRectorInterface
 {
     use TraitsByClassHelperTrait;
     use AddCommentTrait;
 
-    private $parameterProvider;
-
-    public function __construct(ParameterProvider $parameterProvider)
+    public function configure(array $configuration): void
     {
-        $this->parameterProvider = $parameterProvider;
-    }
-
-    protected function getParameterProvider(): ParameterProvider
-    {
-        return $this->parameterProvider;
+        $this->configureNoticesAsComments($configuration);
     }
 
     /**

--- a/src/Rector/Deprecation/LinkGeneratorTraitLRector.php
+++ b/src/Rector/Deprecation/LinkGeneratorTraitLRector.php
@@ -7,6 +7,7 @@ use DrupalRector\Utility\TraitsByClassHelperTrait;
 use PhpParser\Node;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Core\Rector\AbstractRector;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,6 +26,18 @@ final class LinkGeneratorTraitLRector extends AbstractRector
 {
     use TraitsByClassHelperTrait;
     use AddCommentTrait;
+
+    private $parameterProvider;
+
+    public function __construct(ParameterProvider $parameterProvider)
+    {
+        $this->parameterProvider = $parameterProvider;
+    }
+
+    protected function getParameterProvider(): ParameterProvider
+    {
+        return $this->parameterProvider;
+    }
 
     /**
      * @inheritdoc

--- a/src/Utility/AddCommentTrait.php
+++ b/src/Utility/AddCommentTrait.php
@@ -5,12 +5,15 @@ namespace DrupalRector\Utility;
 use PhpParser\Comment;
 use PhpParser\Node;
 use Rector\NodeTypeResolver\Node\AttributeKey;
+use Symplify\PackageBuilder\Parameter\ParameterProvider;
 
 /**
  * Provides an easy way to add a comment to a statement.
  */
 trait AddCommentTrait
 {
+    abstract protected function getParameterProvider(): ParameterProvider;
+
     /**
      * Get the closest statement for the node.
      *
@@ -44,7 +47,7 @@ trait AddCommentTrait
         // great idea since we are assuming the property exists, but it does in
         // `AbstractRector` which all of our rules extend in some form or
         // another.
-        if ($this->parameterProvider->provideParameter('drupal_rector_notices_as_comments')) {
+        if ($this->getParameterProvider()->provideParameter('drupal_rector_notices_as_comments')) {
             $comment_with_wrapper = "// TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes." . PHP_EOL
                 . "// $comment";
 

--- a/src/Utility/AddCommentTrait.php
+++ b/src/Utility/AddCommentTrait.php
@@ -12,7 +12,13 @@ use Symplify\PackageBuilder\Parameter\ParameterProvider;
  */
 trait AddCommentTrait
 {
-    abstract protected function getParameterProvider(): ParameterProvider;
+
+    protected $noticesAsComments = false;
+
+    protected function configureNoticesAsComments(array $configuration): void
+    {
+        $this->noticesAsComments = $configuration['drupal_rector_notices_as_comments'] ?? false;
+    }
 
     /**
      * Get the closest statement for the node.
@@ -47,7 +53,7 @@ trait AddCommentTrait
         // great idea since we are assuming the property exists, but it does in
         // `AbstractRector` which all of our rules extend in some form or
         // another.
-        if ($this->getParameterProvider()->provideParameter('drupal_rector_notices_as_comments')) {
+        if ($this->noticesAsComments) {
             $comment_with_wrapper = "// TODO: Drupal Rector Notice: Please delete the following comment after you've made any necessary changes." . PHP_EOL
                 . "// $comment";
 

--- a/tests/src/Rector/Deprecation/AssertCacheTagRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertCacheTagRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertCacheTagRector::class);
-    $services->set(AssertNoCacheTagRector::class);
+    $services->set(AssertCacheTagRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoCacheTagRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertElementPresentRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertElementPresentRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertElementPresentRector::class);
-    $services->set(AssertElementNotPresentRector::class);
+    $services->set(AssertElementPresentRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertElementNotPresentRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertEqualRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertEqualRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertEqualRector::class);
-    $services->set(AssertNotEqualRector::class);
+    $services->set(AssertEqualRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNotEqualRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertEscapedRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertEscapedRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertEscapedRector::class);
-    $services->set(AssertNoEscapedRector::class);
+    $services->set(AssertEscapedRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoEscapedRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertHeaderRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertHeaderRector/config/configured_rule.php
@@ -6,7 +6,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertHeaderRector::class);
+    $services->set(AssertHeaderRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertIdenticalRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertIdenticalRector/config/configured_rule.php
@@ -8,9 +8,18 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertIdenticalRector::class);
-    $services->set(AssertNotIdenticalRector::class);
-    $services->set(AssertIdenticalObjectRector::class);
+    $services->set(AssertIdenticalRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNotIdenticalRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertIdenticalObjectRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertLinkByHrefRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertLinkByHrefRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertLinkByHrefRector::class);
-    $services->set(AssertNoLinkByHrefRector::class);
+    $services->set(AssertLinkByHrefRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoLinkByHrefRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertLinkRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertLinkRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertLinkRector::class);
-    $services->set(AssertNoLinkRector::class);
+    $services->set(AssertLinkRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoLinkRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertNoFieldByNameRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertNoFieldByNameRector/config/configured_rule.php
@@ -6,8 +6,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertNoFieldByNameRector::class);
-
+    $services->set(AssertNoFieldByNameRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);
 };

--- a/tests/src/Rector/Deprecation/AssertPatternRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertPatternRector/config/configured_rule.php
@@ -8,8 +8,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertPatternRector::class);
-    $services->set(AssertNoPatternRector::class);
+    $services->set(AssertPatternRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoPatternRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/AssertTextRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/AssertTextRector/config/configured_rule.php
@@ -7,8 +7,14 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(AssertTextRector::class);
-    $services->set(AssertNoTextRector::class);
+    $services->set(AssertTextRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
+    $services->set(AssertNoTextRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/ClearCsrfTokenSeedRector/config/configured_rule.php
@@ -6,7 +6,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(ClearCsrfTokenSeed::class);
+    $services->set(ClearCsrfTokenSeed::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/DrupalGetFilenameRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/DrupalGetFilenameRector/config/configured_rule.php
@@ -6,7 +6,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(DrupalGetFilenameRector::class);
+    $services->set(DrupalGetFilenameRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/DrupalGetPathRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/DrupalGetPathRector/config/configured_rule.php
@@ -6,7 +6,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(DrupalGetPathRector::class);
+    $services->set(DrupalGetPathRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);

--- a/tests/src/Rector/Deprecation/DrupalSetMessageRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/DrupalSetMessageRector/config/configured_rule.php
@@ -6,7 +6,10 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-    $services->set(DrupalSetMessageRector::class);
+    $services->set(DrupalSetMessageRector::class)
+        ->configure([
+            'drupal_rector_notices_as_comments' => '%drupal_rector_notices_as_comments%',
+        ]);
 
     $parameters = $containerConfigurator->parameters();
     $parameters->set('drupal_rector_notices_as_comments', true);


### PR DESCRIPTION
## Description
Removes remaining Rector conflicts, up to 0.12.21. Turns out the improvements to Rector config are not breaking changes. The reason we had failures was to:

* Removal of constant Option::IMPORT_DOC_BLOCKS 
* PHPUnit failed due to missing patches on Rector -dev dependencies
* ParameterProvider property removed from abstract rector rule base class.

Tried bumping to https://github.com/rectorphp/rector/releases/tag/0.12.22, but then we hit deprecated option calls and must update to the new configuration format. Ran out of time to work on that. Maybe this is the next best "hop" to allow Rector updates and include provided Rector rule fixes like https://github.com/palantirnet/drupal-rector/pull/202 and https://github.com/palantirnet/drupal-rector/pull/201

## To Test
- Add steps to test this feature

## Drupal.org issue
Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.
