### PR TITLE
Remove unneeded assert for $pathValue

### DIFF
--- a/src/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
+++ b/src/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
@@ -94,7 +94,6 @@ CODE_AFTER
 
             $pathValue = $path->value;
             if (!$pathValue instanceof Node\Expr\ConstFetch || strtolower((string) $pathValue->name) !== 'null') {
-                assert($pathValue instanceof Node\Scalar\String_);
                 if ($options === null) {
                     $drupalGetNode = $this->nodeFactory->createLocalMethodCall('drupalGet', [$path]);
                 } else {


### PR DESCRIPTION
## Description
Removes unneeded assert on the $pathValue object, which causes crashes.

## To Test
Test scanning a module in linked reference

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3292939
