### PR TITLE
Scope may not be available when detecting delcaring source

### DIFF
--- a/src/Utility/GetDeclaringSourceTrait.php
+++ b/src/Utility/GetDeclaringSourceTrait.php
@@ -22,7 +22,9 @@ trait GetDeclaringSourceTrait
     protected function getDeclaringSource(Node\Expr $expr): ?string
     {
         $scope = $expr->getAttribute(AttributeKey::SCOPE);
-        assert($scope instanceof Scope);
+        if (!$scope instanceof Scope) {
+            return null;
+        }
         $classReflection = $scope->getClassReflection();
         assert($classReflection !== null);
 


### PR DESCRIPTION
## Description
Use if instanceof over assert, since scope may be null.

## To Test
Scan one of the modules in referenced issue

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3292943
