### PR TITLE
Prevent @doesNotPerformAssertions from being added to tests

### DIFF
--- a/config/drupal-8/drupal-8-all-deprecations.php
+++ b/config/drupal-8/drupal-8-all-deprecations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use DrupalRector\Set\Drupal8SetList;
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Rector\ClassMethod\AddDoesNotPerformAssertionToNonAssertingTestRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
@@ -21,6 +22,10 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal8SetList::DRUPAL_87,
         Drupal8SetList::DRUPAL_88,
     ]);
+
+    // Drupal performs assertions in the ::setUp methods of its test suites,
+    // the following rule adds unneeded annotations.
+    $rectorConfig->services()->remove(AddDoesNotPerformAssertionToNonAssertingTestRector::class);
 
     $rectorConfig->bootstrapFiles([
         __DIR__ . '/../drupal-phpunit-bootstrap-file.php'

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/ConstructFieldXpathTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/ConstructFieldXpathTest.php
@@ -6,9 +6,6 @@ use Drupal\Tests\BrowserTestBase;
 
 class ConstructFieldXpathTest extends BrowserTestBase {
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testExample() {
         $this->drupalGet('/form-test/select');
         $this->getSession()->getPage()->findField('edit-preferred-admin-langcode');

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/GetRawContentTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/GetRawContentTest.php
@@ -6,9 +6,6 @@ use Drupal\Tests\BrowserTestBase;
 
 class GetRawContentTest extends BrowserTestBase {
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testExample() {
         $this->drupalGet('/form-test/select');
         $this->getSession()->getPage()->getContent();

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/PassTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/PassTest.php
@@ -6,9 +6,6 @@ use Drupal\Tests\BrowserTestBase;
 
 class PassTest extends BrowserTestBase {
 
-    /**
-     * @doesNotPerformAssertions
-     */
     public function testExample()
     {
     }


### PR DESCRIPTION
## Description
Removes the AddDoesNotPerformAssertionToNonAssertingTestRector rule to stop adding the `@doesNotPerformAssertion` annotation.

## To Test
see https://www.drupal.org/comment/14568738#comment-14568738

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3291327
