### PR TITLE
Update rector.php so we do not use FQCN's in method arguments

### DIFF
--- a/fixtures/d9/rector_examples_updated/src/DispatchingService.php
+++ b/fixtures/d9/rector_examples_updated/src/DispatchingService.php
@@ -8,7 +8,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 final class DispatchingService {
 
     /**
-     * @var EventDispatcherInterface
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
      */
     private $eventDispatcher;
 

--- a/rector.php
+++ b/rector.php
@@ -30,7 +30,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);
     $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
-    $rectorConfig->importNames();
+    $rectorConfig->importNames(true, false);
     $rectorConfig->importShortClasses(false);
     $parameters->set('drupal_rector_notices_as_comments', true);
 };


### PR DESCRIPTION
## Description
This fixed the FQCN's rector adds to methods without breaking our docblocks. Not sure how this functionality found its way back into rector, but yay!

## To Test
Tested in projectupdatebot, see referenced isue.

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3296372
