### PR TITLE
ProtectedStaticModulesProperty rule

### DIFF
--- a/config/drupal-9/drupal-9.0-deprecations.php
+++ b/config/drupal-9/drupal-9.0-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Rector\Property\ProtectedStaticModulesPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Symfony\Set\SymfonySetList;
 
@@ -14,4 +15,5 @@ return static function (\Rector\Config\RectorConfig $rectorConfig): void {
         SymfonySetList::SYMFONY_43,
         SymfonySetList::SYMFONY_44
     ]);
+    $rectorConfig->rule(ProtectedStaticModulesPropertyRector::class);
 };

--- a/fixtures/d9/rector_examples/tests/src/Functional/PublicStaticModulesTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/PublicStaticModulesTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class PublicStaticModulesTest extends BrowserTestBase {
+    public static $modules = [];
+}

--- a/fixtures/d9/rector_examples/tests/src/Kernel/PublicStaticModulesTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Kernel/PublicStaticModulesTest.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\rector_examples\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class PublicStaticModulesTest extends KernelTestBase {
+    public static $modules = [];
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/PublicStaticModulesTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/PublicStaticModulesTest.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Drupal\Tests\rector_examples\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+class PublicStaticModulesTest extends BrowserTestBase {
+    protected static $modules = [];
+}

--- a/fixtures/d9/rector_examples_updated/tests/src/Kernel/PublicStaticModulesTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Kernel/PublicStaticModulesTest.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\rector_examples\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class PublicStaticModulesTest extends KernelTestBase {
+    protected static $modules = [];
+}

--- a/src/Rector/Property/ProtectedStaticModulesPropertyRector.php
+++ b/src/Rector/Property/ProtectedStaticModulesPropertyRector.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector\Property;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Rector\Privatization\NodeManipulator\VisibilityManipulator;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://www.drupal.org/node/2909426
+ */
+final class ProtectedStaticModulesPropertyRector extends AbstractRector
+{
+    private $visibilityManipulator;
+
+    public function __construct(VisibilityManipulator $visibilityManipulator)
+    {
+        $this->visibilityManipulator = $visibilityManipulator;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('"public static $modules" will have its visibility changed to protected.', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClassTest {
+  public static $modules = [];
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClassTest {
+  protected static $modules = [];
+}
+CODE_SAMPLE
+
+            )
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [Node\Stmt\Property::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Stmt\Property $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Stmt\Property);
+        if (!$this->isName($node, 'modules')) {
+            return $node;
+        }
+        if ($node->isPublic()) {
+            $this->visibilityManipulator->makeProtected($node);
+        }
+
+        return $node;
+    }
+}

--- a/tests/src/Rector/Property/ProtectedStaticModulesPropertyRector/Fixture/some_class.php.inc
+++ b/tests/src/Rector/Property/ProtectedStaticModulesPropertyRector/Fixture/some_class.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+namespace Rector\Tests\DrupalRector\Rector\Property\ProtectedStaticModulesPropertyRector\Fixture;
+
+class SomeClassTest {
+  public static $modules = [];
+  public static $foo = [];
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DrupalRector\Rector\Property\ProtectedStaticModulesPropertyRector\Fixture;
+
+class SomeClassTest {
+  protected static $modules = [];
+  public static $foo = [];
+}
+
+?>

--- a/tests/src/Rector/Property/ProtectedStaticModulesPropertyRector/ProtectedStaticModulesPropertyRectorTest.php
+++ b/tests/src/Rector/Property/ProtectedStaticModulesPropertyRector/ProtectedStaticModulesPropertyRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Property\ProtectedStaticModulesPropertyRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ProtectedStaticModulesPropertyRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(\Symplify\SmartFileSystem\SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__.'/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Rector/Property/ProtectedStaticModulesPropertyRector/config/configured_rule.php
+++ b/tests/src/Rector/Property/ProtectedStaticModulesPropertyRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(\DrupalRector\Rector\Property\ProtectedStaticModulesPropertyRector::class);
+};


### PR DESCRIPTION
## Description
Converts `public static $modules` to `protected static $modules`

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3291993
