### PR TITLE
module_load_install() is deprecated

### DIFF
--- a/config/drupal-8/drupal-8-all-deprecations.php
+++ b/config/drupal-8/drupal-8-all-deprecations.php
@@ -27,7 +27,7 @@ return static function (RectorConfig $rectorConfig): void {
     // the following rule adds unneeded annotations.
     $rectorConfig->services()->remove(AddDoesNotPerformAssertionToNonAssertingTestRector::class);
 
-    $rectorConfig->bootstrapFiles([
-        __DIR__ . '/../drupal-phpunit-bootstrap-file.php'
-    ]);
+//    $rectorConfig->bootstrapFiles([
+//        __DIR__ . '/../drupal-phpunit-bootstrap-file.php'
+//    ]);
 };

--- a/config/drupal-9/drupal-9-all-deprecations.php
+++ b/config/drupal-9/drupal-9-all-deprecations.php
@@ -11,6 +11,7 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal9SetList::DRUPAL_91,
         Drupal9SetList::DRUPAL_92,
         Drupal9SetList::DRUPAL_93,
+        Drupal9SetList::DRUPAL_94,
     ]);
 
     $rectorConfig->bootstrapFiles([

--- a/config/drupal-9/drupal-9.4-deprecations.php
+++ b/config/drupal-9/drupal-9.4-deprecations.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Rector\FuncCall\ModuleLoadInstallRector;
+
+return static function (\Rector\Config\RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(ModuleLoadInstallRector::class);
+};

--- a/fixtures/d9/rector_examples/rector_examples.module
+++ b/fixtures/d9/rector_examples/rector_examples.module
@@ -13,3 +13,7 @@ function rector_examples_with_render() {
     $build = [];
     $output = render($build);
 }
+
+function rector_examples_module_load_install() {
+    module_load_install('foo');
+}

--- a/fixtures/d9/rector_examples_updated/rector_examples.module
+++ b/fixtures/d9/rector_examples_updated/rector_examples.module
@@ -13,3 +13,7 @@ function rector_examples_with_render() {
     $build = [];
     $output = \Drupal::service('renderer')->render($build);
 }
+
+function rector_examples_module_load_install() {
+    \Drupal::moduleHandler()->loadInclude('foo', 'install');
+}

--- a/src/Rector/FuncCall/ModuleLoadInstallRector.php
+++ b/src/Rector/FuncCall/ModuleLoadInstallRector.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector\FuncCall;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://www.drupal.org/node/3220952
+ *
+ * @see \DrupalRector\Tests\Rector\FuncCall\ModuleLoadInstallRector\ModuleLoadInstallRectorTest
+ */
+final class ModuleLoadInstallRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('"module_load_install() replaced with ModuleHandler::loadInclude"', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        module_load_install('node');
+    }
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public function run()
+    {
+        \Drupal::moduleHandler()->loadInclude('node', 'install');
+    }
+}
+CODE_SAMPLE
+
+            )
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [\PhpParser\Node\Expr\FuncCall::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if ($this->nodeNameResolver->getName($node) !== 'module_load_install') {
+            return null;
+        }
+        $args = $node->getArgs();
+        $args[] = new Node\Arg(new Node\Scalar\String_('install'));
+
+        $moduleHandlerCall = new Node\Expr\StaticCall(
+            new Node\Name\FullyQualified('Drupal'),
+            'moduleHandler'
+        );
+
+        return new Node\Expr\MethodCall(
+            $moduleHandlerCall,
+            new Node\Identifier('loadInclude'),
+            $args
+        );
+    }
+}

--- a/src/Set/Drupal9SetList.php
+++ b/src/Set/Drupal9SetList.php
@@ -11,4 +11,5 @@ final class Drupal9SetList implements SetListInterface
     public const DRUPAL_91 = __DIR__ . '/../../config/drupal-9/drupal-9.1-deprecations.php';
     public const DRUPAL_92 = __DIR__ . '/../../config/drupal-9/drupal-9.2-deprecations.php';
     public const DRUPAL_93 = __DIR__ . '/../../config/drupal-9/drupal-9.3-deprecations.php';
+    public const DRUPAL_94 = __DIR__ . '/../../config/drupal-9/drupal-9.4-deprecations.php';
 }

--- a/tests/src/Rector/FuncCall/ModuleLoadInstallRector/Fixture/some_class.php.inc
+++ b/tests/src/Rector/FuncCall/ModuleLoadInstallRector/Fixture/some_class.php.inc
@@ -1,0 +1,27 @@
+<?php
+
+namespace Rector\Tests\DrupalRector\Rector\FuncCall\ModuleLoadInstallRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        module_load_install('node');
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DrupalRector\Rector\FuncCall\ModuleLoadInstallRector\Fixture;
+
+class SomeClass
+{
+    public function run()
+    {
+        \Drupal::moduleHandler()->loadInclude('node', 'install');
+    }
+}
+
+?>

--- a/tests/src/Rector/FuncCall/ModuleLoadInstallRector/ModuleLoadInstallRectorTest.php
+++ b/tests/src/Rector/FuncCall/ModuleLoadInstallRector/ModuleLoadInstallRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\FuncCall\ModuleLoadInstallRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class ModuleLoadInstallRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(\Symplify\SmartFileSystem\SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/src/Rector/FuncCall/ModuleLoadInstallRector/config/configured_rule.php
+++ b/tests/src/Rector/FuncCall/ModuleLoadInstallRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(\DrupalRector\Rector\FuncCall\ModuleLoadInstallRector::class);
+};


### PR DESCRIPTION
## Description
Replaces module_load_install with \Drupal::moduleHandler()->loadInclude


## To Test
- Add steps to test this feature

## Drupal.org issue
[Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.](https://www.drupal.org/project/rector/issues/3304329)
