### PR TITLE
Usage of symfony-cmf/routing dependency deprecated

### DIFF
--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Rector\ConstFetch\SymfonyCmfRouteObjectInterfaceConstantsRector;
 use DrupalRector\Rector\Deprecation\AssertCacheTagRector;
 use DrupalRector\Rector\Deprecation\AssertElementNotPresentRector;
 use DrupalRector\Rector\Deprecation\AssertElementPresentRector;
@@ -182,4 +183,5 @@ return static function (\Rector\Config\RectorConfig $rectorConfig): void {
     $rectorConfig->rule(GetRawContentRector::class);
     $rectorConfig->rule(GetAllOptionsRector::class);
     $rectorConfig->rule(UserPasswordRector::class);
+    $rectorConfig->rule(SymfonyCmfRouteObjectInterfaceConstantsRector::class);
 };

--- a/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector.php
+++ b/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector\ConstFetch;
+
+use PhpParser\Node;
+use PhpParser\Node\Name\FullyQualified;
+use PHPStan\Type\ObjectType;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * @changelog https://www.drupal.org/node/3151009
+ *
+ * @see \Rector\Tests\DrupalRector\Rector\ConstFetch\SymfonyCmfRouteObjectInterfaceConstantsRector\SymfonyCmfRouteObjectInterfaceConstantsRectorTest
+ */
+final class SymfonyCmfRouteObjectInterfaceConstantsRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('"Replaces constant calls on \Symfony\Cmf\Component\Routing\RouteObjectInterface	to \Drupal\Core\Routing\RouteObjectInterface"', [
+            new CodeSample(
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public const NAME = \Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_NAME;
+    public const OBJECT = \Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_OBJECT;
+    public const CONTROLLER = \Symfony\Cmf\Component\Routing\RouteObjectInterface::CONTROLLER_NAME;
+}
+CODE_SAMPLE
+
+                ,
+                <<<'CODE_SAMPLE'
+class SomeClass
+{
+    public const NAME = \Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME;
+    public const OBJECT = \Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT;
+    public const CONTROLLER = \Drupal\Core\Routing\RouteObjectInterface::CONTROLLER_NAME;
+}
+CODE_SAMPLE
+
+            )
+        ]);
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [\PhpParser\Node\Expr\ClassConstFetch::class];
+    }
+
+    /**
+     * @param \PhpParser\Node\Expr\ClassConstFetch $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        $cmfRouteObjectInterfaceType = new ObjectType(\Symfony\Cmf\Component\Routing\RouteObjectInterface::class);
+        if (!$this->isObjectType($node->class, $cmfRouteObjectInterfaceType)) {
+            return $node;
+        }
+
+        $node->class = new FullyQualified(\Drupal\Core\Routing\RouteObjectInterface::class);
+        return $node;
+    }
+}

--- a/tests/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector/Fixture/some_class.php.inc
+++ b/tests/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector/Fixture/some_class.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+namespace Rector\Tests\DrupalRector\Rector\ConstFetch\SymfonyCmfRouteObjectInterfaceConstantsRector\Fixture;
+
+class SomeClass
+{
+    public const NAME = \Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_NAME;
+    public const OBJECT = \Symfony\Cmf\Component\Routing\RouteObjectInterface::ROUTE_OBJECT;
+    public const CONTROLLER = \Symfony\Cmf\Component\Routing\RouteObjectInterface::CONTROLLER_NAME;
+}
+
+?>
+-----
+<?php
+
+namespace Rector\Tests\DrupalRector\Rector\ConstFetch\SymfonyCmfRouteObjectInterfaceConstantsRector\Fixture;
+
+class SomeClass
+{
+    public const NAME = \Drupal\Core\Routing\RouteObjectInterface::ROUTE_NAME;
+    public const OBJECT = \Drupal\Core\Routing\RouteObjectInterface::ROUTE_OBJECT;
+    public const CONTROLLER = \Drupal\Core\Routing\RouteObjectInterface::CONTROLLER_NAME;
+}
+
+?>

--- a/tests/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector/SymfonyCmfRouteObjectInterfaceConstantsRectorTest.php
+++ b/tests/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector/SymfonyCmfRouteObjectInterfaceConstantsRectorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Tests\DrupalRector\Rector\ConstFetch\SymfonyCmfRouteObjectInterfaceConstantsRector;
+
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class SymfonyCmfRouteObjectInterfaceConstantsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @dataProvider provideData()
+     */
+    public function test(\Symplify\SmartFileSystem\SmartFileInfo $fileInfo): void
+    {
+        $this->doTestFileInfo($fileInfo);
+    }
+
+    /**
+     * @return \Iterator<\Symplify\SmartFileSystem\SmartFileInfo>
+     */
+    public function provideData(): \Iterator
+    {
+        return $this->yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}

--- a/tests/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector/config/configured_rule.php
+++ b/tests/src/Rector/ConstFetch/SymfonyCmfRouteObjectInterfaceConstantsRector/config/configured_rule.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(\DrupalRector\Rector\ConstFetch\SymfonyCmfRouteObjectInterfaceConstantsRector::class);
+};


### PR DESCRIPTION
## Description
Replaces calls to symfony-cmf/routing interfaces or classes per https://www.drupal.org/node/3151009


## To Test
- Add steps to test this feature

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3294535