### PR TITLE
Use this->t instead of t

### DIFF
--- a/src/Rector/BestPractice/UseThisTInsteadOfTRector.php
+++ b/src/Rector/BestPractice/UseThisTInsteadOfTRector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector\BestPractice;
+
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use PhpParser\Node\Expr\FuncCall;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use PhpParser\Node\Stmt\Class_;
+
+/**
+ * Replaces t() with $this->t().
+ */
+final class UseThisTInsteadOfTRector extends AbstractRector
+{
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Turns static t calls into $this->t.',
+            [
+                new ConfiguredCodeSample(
+                    't("Text");',
+                    '$this->t("Text");',
+                    ['t' => '$this->t']
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @return array<class-string<Node>>
+     */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    /**
+     * @param FuncCall $node
+     */
+    public function refactor(Node $node): ?Node
+    {
+        if (!$this->isName($node, 't')) {
+            return null;
+        }
+
+        // not to refactor here
+        $isVirtual = (bool)$node->name->getAttribute(
+            AttributeKey::VIRTUAL_NODE
+        );
+        if ($isVirtual) {
+            return null;
+        }
+
+        $parentFunction = $this->betterNodeFinder->findParentType($node, Node\Stmt\ClassMethod::class);
+        if (!$parentFunction instanceof Node\Stmt\ClassMethod || $parentFunction->isStatic()) {
+            return null;
+        }
+
+        $class = $this->betterNodeFinder->findParentType($node, Class_::class);
+        if (!$class instanceof Class_) {
+            return null;
+        }
+
+        $className = (string) $this->nodeNameResolver->getName($class);
+        if (method_exists($className, 't')) {
+            return new Node\Expr\MethodCall(
+                new Node\Expr\Variable('this'),
+                't',
+                $node->args
+            );
+        }
+        return null;
+    }
+}

--- a/src/Rector/BestPractice/UseThisTInsteadOfTRector.php
+++ b/src/Rector/BestPractice/UseThisTInsteadOfTRector.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace DrupalRector\Rector\BestPractice;
 
 use PhpParser\Node;
-use Rector\Rector\AbstractRector;
-use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
-use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use PhpParser\Node\Expr\FuncCall;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use PhpParser\Node\Stmt\Class_;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * Replaces t() with $this->t().
  */
 final class UseThisTInsteadOfTRector extends AbstractRector
 {
-
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition(
@@ -50,7 +49,7 @@ final class UseThisTInsteadOfTRector extends AbstractRector
         }
 
         // not to refactor here
-        $isVirtual = (bool)$node->name->getAttribute(
+        $isVirtual = (bool) $node->name->getAttribute(
             AttributeKey::VIRTUAL_NODE
         );
         if ($isVirtual) {
@@ -75,6 +74,7 @@ final class UseThisTInsteadOfTRector extends AbstractRector
                 $node->args
             );
         }
+
         return null;
     }
 }

--- a/src/Rector/BestPractice/UseThisTInsteadOfTRector.php
+++ b/src/Rector/BestPractice/UseThisTInsteadOfTRector.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DrupalRector\Rector\BestPractice;
 
 use PhpParser\Node;
-use Rector\Core\Rector\AbstractRector;
+use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use PhpParser\Node\Expr\FuncCall;

--- a/tests/src/Rector/BestPractive/UseThisTInsteadOfTRector/UseThisTInsteadOfTRectorTest.php
+++ b/tests/src/Rector/BestPractive/UseThisTInsteadOfTRector/UseThisTInsteadOfTRectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector\BestPractive\UseThisTInsteadOfTRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class UseThisTInsteadOfTRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @covers ::refactor
+     *
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Rector/BestPractive/UseThisTInsteadOfTRector/config/configured_rule.php
+++ b/tests/src/Rector/BestPractive/UseThisTInsteadOfTRector/config/configured_rule.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(DrupalRector\Rector\BestPractice\UseThisTInsteadOfTRector::class, $rectorConfig, false);
+};

--- a/tests/src/Rector/BestPractive/UseThisTInsteadOfTRector/fixture/fixture.php.inc
+++ b/tests/src/Rector/BestPractive/UseThisTInsteadOfTRector/fixture/fixture.php.inc
@@ -1,0 +1,33 @@
+<?php
+class TestT {
+    public function t($string) {
+        return $string;
+    }
+}
+
+class NoT extends TestT {
+
+    public function doThings() {
+        return t('Hello world');
+    }
+
+}
+
+?>
+-----
+<?php
+class TestT {
+    public function t($string) {
+        return $string;
+    }
+}
+
+class NoT extends TestT {
+
+    public function doThings() {
+        return $this->t('Hello world');
+    }
+
+}
+
+?>


### PR DESCRIPTION
## Description
It checks if a `t()` call can be converted to `$this->t()`

## To Test
- Add steps to test this feature

## Drupal.org issue
Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.
