### PR TITLE
Issue #3331851: Upgrade rector version to 0.15.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "~0.13.8",
+        "rector/rector": "~0.15.2",
         "webflo/drupal-finder": "^1.2"
     },
     "license": "MIT",


### PR DESCRIPTION
## Description
Upgrade rector version to be compatible with latest versions of PHPStan extensions.

## To Test
With the following require-dev in the composer.json of a project, try to scan code with Rector.
```
        "palantirnet/drupal-rector": "0.*",
        "phpstan/extension-installer": "1.*",
        "phpstan/phpstan-deprecation-rules": "1.*",
        "phpstan/phpstan-phpunit": "1.*",
```

Without PR:
```
Fatal error: Uncaught _PHPStan_9a6ded56a\Nette\Schema\ValidationException: Unexpected item 'parameters › deprecationRulesInstalled'. in phar:///project/vendor/rector/rector/vendor/phpstan/phpstan/phpstan.phar/vendor/nette/schema/src/Schema/Processor.php:75
```

With PR it should be ok.

Note: I have not been able to test locally, I expect CI on Github to ensure drupal-rector will still be ok.

## Drupal.org issue

https://www.drupal.org/project/rector/issues/3331851