### PR TITLE
Identify as rector-extension and default config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "palantirnet/drupal-rector",
     "description": "Instant fixes for your Drupal code by using Rector.",
-    "type": "library",
+    "type": "rector-extension",
     "keywords": [
         "code style",
         "rector",
@@ -63,7 +63,12 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
-        "enable-patching": true
+        "enable-patching": true,
+        "rector": {
+            "includes": [
+                "config/config.php"
+            ]
+        }
     },
     "require-dev": {
         "php": "^8.1",

--- a/config/config.php
+++ b/config/config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
+    throw new \RuntimeException('Verifying that config was hit ' . __FILE__);
     $rectorConfig->bootstrapFiles([
         __DIR__ . '/drupal-phpunit-bootstrap-file.php'
     ]);

--- a/config/config.php
+++ b/config/config.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->bootstrapFiles([
+        __DIR__ . '/drupal-phpunit-bootstrap-file.php'
+    ]);
+};

--- a/config/drupal-8/drupal-8-all-deprecations.php
+++ b/config/drupal-8/drupal-8-all-deprecations.php
@@ -26,8 +26,4 @@ return static function (RectorConfig $rectorConfig): void {
     // Drupal performs assertions in the ::setUp methods of its test suites,
     // the following rule adds unneeded annotations.
     $rectorConfig->services()->remove(AddDoesNotPerformAssertionToNonAssertingTestRector::class);
-
-    $rectorConfig->bootstrapFiles([
-        __DIR__ . '/../drupal-phpunit-bootstrap-file.php'
-    ]);
 };

--- a/config/drupal-9/drupal-9-all-deprecations.php
+++ b/config/drupal-9/drupal-9-all-deprecations.php
@@ -12,8 +12,4 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal9SetList::DRUPAL_92,
         Drupal9SetList::DRUPAL_93,
     ]);
-
-    $rectorConfig->bootstrapFiles([
-        __DIR__ . '/../drupal-phpunit-bootstrap-file.php'
-    ]);
 };


### PR DESCRIPTION
## Description
Add `config/config.php` to add default configurations that are required and improve end-user experience.

This will also enable adding services to the service container.

## To Test
Functional run, should provide no changes

## Drupal.org issue
TODO: Needs one
