### PR TITLE
Support providing backward compatibility for Rector rules

### DIFF
--- a/fixtures/d8/rector_examples/user_password.php
+++ b/fixtures/d8/rector_examples/user_password.php
@@ -1,0 +1,10 @@
+<?php
+
+// should not be changed, deprecated in 9.1.0
+function user_functions() {
+    // user_password().
+    $password = user_password();
+    $other_password = user_password(8);
+    $password_length = 12;
+    $last_password = user_password($password_length);
+}

--- a/fixtures/d8/rector_examples_updated/user_password.php
+++ b/fixtures/d8/rector_examples_updated/user_password.php
@@ -1,0 +1,10 @@
+<?php
+
+// should not be changed, deprecated in 9.1.0
+function user_functions() {
+    // user_password().
+    $password = user_password();
+    $other_password = user_password(8);
+    $password_length = 12;
+    $last_password = user_password($password_length);
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="vendor/autoload.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" colors="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" bootstrap="tests/bootstrap.php" executionOrder="depends,defects" beStrictAboutOutputDuringTests="true" colors="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="default">
       <directory suffix="Test.php">tests/src</directory>

--- a/src/Contract/DrupalCoreRectorInterface.php
+++ b/src/Contract/DrupalCoreRectorInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Contract;
+
+use Rector\Core\Contract\Rector\PhpRectorInterface;
+
+interface DrupalCoreRectorInterface extends PhpRectorInterface
+{
+
+    public function getVersion(): string;
+
+}

--- a/src/Rector/AbstractDrupalCoreRector.php
+++ b/src/Rector/AbstractDrupalCoreRector.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector;
+
+use DrupalRector\Contract\DrupalCoreRectorInterface;
+use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
+
+abstract class AbstractDrupalCoreRector extends AbstractRector implements DrupalCoreRectorInterface
+{
+
+    public function refactor(Node $node)
+    {
+        if (version_compare(\Drupal::VERSION, $this->getVersion(), '<')) {
+            return null;
+        }
+        $result = $this->doRefactor($node);
+        if ($result === null) {
+            return $result;
+        }
+        // TODO: add BC compatibility layer here
+        return $result;
+    }
+
+    /**
+     * Process Node of matched type
+     * @return Node|Node[]|null
+     */
+    abstract protected function doRefactor(Node $node);
+
+}

--- a/src/Rector/Deprecation/UserPasswordRector.php
+++ b/src/Rector/Deprecation/UserPasswordRector.php
@@ -2,12 +2,12 @@
 
 namespace DrupalRector\Rector\Deprecation;
 
+use DrupalRector\Rector\AbstractDrupalCoreRector;
 use PhpParser\Node;
-use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class UserPasswordRector extends AbstractRector
+final class UserPasswordRector extends AbstractDrupalCoreRector
 {
     /**
      * @inheritdoc
@@ -39,10 +39,15 @@ CODE_AFTER
         ];
     }
 
+    public function getVersion(): string
+    {
+        return '9.1.0';
+    }
+
     /**
      * @inheritdoc
      */
-    public function refactor(Node $node): ?Node
+    public function doRefactor(Node $node): ?Node
     {
         assert($node instanceof Node\Expr\FuncCall);
         if ($this->getName($node->name) !== 'user_password') {

--- a/src/Rector/Deprecation/UserPasswordRector.php
+++ b/src/Rector/Deprecation/UserPasswordRector.php
@@ -2,12 +2,12 @@
 
 namespace DrupalRector\Rector\Deprecation;
 
+use DrupalRector\Rector\AbstractDrupalCoreRector;
 use PhpParser\Node;
-use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class UserPasswordRector extends AbstractRector
+final class UserPasswordRector extends AbstractDrupalCoreRector
 {
     /**
      * @inheritdoc
@@ -42,11 +42,6 @@ CODE_AFTER
     public function getVersion(): string
     {
         return '9.1.0';
-    }
-
-    public function refactor(Node $node)
-    {
-        return $this->doRefactor($node);
     }
 
     /**

--- a/src/Rector/Deprecation/UserPasswordRector.php
+++ b/src/Rector/Deprecation/UserPasswordRector.php
@@ -2,12 +2,12 @@
 
 namespace DrupalRector\Rector\Deprecation;
 
-use DrupalRector\Rector\AbstractDrupalCoreRector;
 use PhpParser\Node;
+use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class UserPasswordRector extends AbstractDrupalCoreRector
+final class UserPasswordRector extends AbstractRector
 {
     /**
      * @inheritdoc
@@ -42,6 +42,11 @@ CODE_AFTER
     public function getVersion(): string
     {
         return '9.1.0';
+    }
+
+    public function refactor(Node $node)
+    {
+        return $this->doRefactor($node);
     }
 
     /**

--- a/stubs/Drupal/Drupal.php
+++ b/stubs/Drupal/Drupal.php
@@ -1,0 +1,9 @@
+<?php
+
+if (class_exists(\Drupal::class)) {
+    return;
+}
+
+class Drupal {
+    const VERSION = '10.1.0-dev';
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+// performance boost
+gc_disable();

--- a/tests/src/Rector/Deprecation/UserPasswordRector/UserPasswordRectorTest.php
+++ b/tests/src/Rector/Deprecation/UserPasswordRector/UserPasswordRectorTest.php
@@ -4,7 +4,6 @@ namespace DrupalRector\Tests\Rector\Deprecation\UserPasswordRector;
 
 use Iterator;
 use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-use Symplify\SmartFileSystem\SmartFileInfo;
 
 class UserPasswordRectorTest extends AbstractRectorTestCase {
 

--- a/tests/src/Rector/Deprecation/UserPasswordRector/fixture/user_password.php.inc
+++ b/tests/src/Rector/Deprecation/UserPasswordRector/fixture/user_password.php.inc
@@ -11,9 +11,24 @@ function simple_example() {
 <?php
 
 function simple_example() {
-    $password = \Drupal::service('password_generator')->generate();
-    $other_password = \Drupal::service('password_generator')->generate(8);
+    if (version_compare(\Drupal::VERSION, '9.1.0', '>=')) {
+        $password = \Drupal::service('password_generator')->generate();
+    }
+    else {
+        $password = user_password();
+    }
+    if (version_compare(\Drupal::VERSION, '9.1.0', '>=')) {
+        $other_password = \Drupal::service('password_generator')->generate(8);
+    }
+    else {
+        $other_password = user_password(8);
+    }
     $password_length = 12;
-    $last_password = \Drupal::service('password_generator')->generate($password_length);
+    if (version_compare(\Drupal::VERSION, '9.1.0', '>=')) {
+        $last_password = \Drupal::service('password_generator')->generate($password_length);
+    }
+    else {
+        $last_password = user_password($password_length);
+    }
 }
 ?>


### PR DESCRIPTION
## Description
Adds AbstractDrupalCoreRector base class to enable backward compatibility. It also skips Rector rules if the current Drupal version is less than the introduced change.

## To Test
Functional test

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3350886
