### PR TITLE
Issue #3354343: Add TwigSetList::TWIG_240 to D9 deprecations.

### DIFF
--- a/config/drupal-9/drupal-9.0-deprecations.php
+++ b/config/drupal-9/drupal-9.0-deprecations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use DrupalRector\Rector\Property\ProtectedStaticModulesPropertyRector;
 use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Symfony\Set\SymfonySetList;
+use Rector\Symfony\Set\TwigSetList;
 
 return static function (\Rector\Config\RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
@@ -13,7 +14,8 @@ return static function (\Rector\Config\RectorConfig $rectorConfig): void {
         SymfonySetList::SYMFONY_41,
         SymfonySetList::SYMFONY_42,
         SymfonySetList::SYMFONY_43,
-        SymfonySetList::SYMFONY_44
+        SymfonySetList::SYMFONY_44,
+        TwigSetList::TWIG_240
     ]);
     $rectorConfig->rule(ProtectedStaticModulesPropertyRector::class);
 };

--- a/fixtures/d9/rector_examples/src/TwigExtension.php
+++ b/fixtures/d9/rector_examples/src/TwigExtension.php
@@ -2,20 +2,17 @@
 
 namespace Drupal\twig_tweak;
 
-use Twig\Extension\AbstractExtension;
-use Twig\TwigFunction;
-use Twig\TwigFilter;
 /**
  * Twig extension with some useful functions and filters.
  */
-class TwigExtension extends AbstractExtension {
+class TwigExtension extends \Twig_Extension {
 
     /**
      * {@inheritdoc}
      */
     public function getFunctions() {
         return [
-            new TwigFunction('drupal_config', [$this, 'drupalConfig']),
+            new \Twig_SimpleFunction('drupal_config', [$this, 'drupalConfig']),
         ];
     }
 
@@ -24,7 +21,7 @@ class TwigExtension extends AbstractExtension {
      */
     public function getFilters() {
         return [
-            new TwigFilter('token_replace', [$this, 'tokenReplaceFilter']),
+            new \Twig_SimpleFilter('token_replace', [$this, 'tokenReplaceFilter']),
         ];
     }
 

--- a/fixtures/d9/rector_examples_updated/src/TwigExtension.php
+++ b/fixtures/d9/rector_examples_updated/src/TwigExtension.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\twig_tweak;
+
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Component\Utility\Unicode;
+use Drupal\Component\Uuid\Uuid;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Block\TitleBlockPluginInterface;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
+use Drupal\Core\Field\FieldItemInterface;
+use Drupal\Core\Field\FieldItemListInterface;
+use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
+use Drupal\Core\Link;
+use Drupal\Core\Plugin\ContextAwarePluginInterface;
+use Drupal\Core\Render\Element;
+use Drupal\Core\Render\Markup;
+use Drupal\Core\Site\Settings;
+use Drupal\Core\Url;
+use Drupal\file\Entity\File;
+use Drupal\file\FileInterface;
+use Drupal\image\Entity\ImageStyle;
+use Drupal\media\MediaInterface;
+use Drupal\media\Plugin\media\Source\OEmbedInterface;
+use Symfony\Cmf\Component\Routing\RouteObjectInterface;
+
+/**
+ * Twig extension with some useful functions and filters.
+ *
+ * Dependencies are not injected for performance reason.
+ */
+class TwigExtension extends \Twig_Extension {
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions() {
+        return [
+            new \Twig_SimpleFunction('drupal_config', [$this, 'drupalConfig']),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFilters() {
+        return [
+            new \Twig_SimpleFilter('token_replace', [$this, 'tokenReplaceFilter']),
+        ];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName() {
+        return 'twig_tweak';
+    }
+
+    /**
+     * Replaces all tokens in a given string with appropriate values.
+     *
+     * Example:
+     * @code
+     *   # Basic usage.
+     *   {{ '<h1>[site:name]</h1><div>[site:slogan]</div>'|token_replace }}
+     *
+     *   # This is more suited to large markup (requires Twig >= 1.41).
+     *   {% apply token_replace %}
+     *     <h1>[site:name]</h1>
+     *     <div>[site:slogan]</div>
+     *   {% endapply %}
+     * @endcode
+     *
+     * @param string $text
+     *   An HTML string containing replaceable tokens.
+     *
+     * @return string
+     *   The entered HTML text with tokens replaced.
+     */
+    public function tokenReplaceFilter($text) {
+        return \Drupal::token()->replace($text);
+    }
+
+    /**
+     * Retrieves data from a given configuration object.
+     *
+     * Example:
+     * @code
+     *   {{ drupal_config('system.site', 'name') }}
+     * @endcode
+     *
+     * @param string $name
+     *   The name of the configuration object to construct.
+     * @param string $key
+     *   A string that maps to a key within the configuration data.
+     *
+     * @return mixed
+     *   The data that was requested.
+     */
+    public function drupalConfig($name, $key) {
+        return \Drupal::config($name)->get($key);
+    }
+
+}

--- a/fixtures/d9/rector_examples_updated/src/TwigExtension.php
+++ b/fixtures/d9/rector_examples_updated/src/TwigExtension.php
@@ -2,33 +2,8 @@
 
 namespace Drupal\twig_tweak;
 
-use Drupal\Component\Utility\NestedArray;
-use Drupal\Component\Utility\Unicode;
-use Drupal\Component\Uuid\Uuid;
-use Drupal\Core\Block\BlockPluginInterface;
-use Drupal\Core\Block\TitleBlockPluginInterface;
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Field\EntityReferenceFieldItemListInterface;
-use Drupal\Core\Field\FieldItemInterface;
-use Drupal\Core\Field\FieldItemListInterface;
-use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
-use Drupal\Core\Link;
-use Drupal\Core\Plugin\ContextAwarePluginInterface;
-use Drupal\Core\Render\Element;
-use Drupal\Core\Render\Markup;
-use Drupal\Core\Site\Settings;
-use Drupal\Core\Url;
-use Drupal\file\Entity\File;
-use Drupal\file\FileInterface;
-use Drupal\image\Entity\ImageStyle;
-use Drupal\media\MediaInterface;
-use Drupal\media\Plugin\media\Source\OEmbedInterface;
-use Symfony\Cmf\Component\Routing\RouteObjectInterface;
-
 /**
  * Twig extension with some useful functions and filters.
- *
- * Dependencies are not injected for performance reason.
  */
 class TwigExtension extends \Twig_Extension {
 


### PR DESCRIPTION
## Description
Resolves [Issue #3354343](https://dgo.to/3354343).


## To Test
- Using the [rector standbox](https://github.com/palantirnet/drupal-rector-sandbox/blob/main/README.md#developing-with-drupal-rector), checkout this branch and run the following:
```
ddev . vendor/bin/rector process drupal-rector/fixtures/d9/rector_examples_updated/src/TwigExtension.php --dry-run
```
- The underscore Twig classes should be replaced with their up to date equivalent. See https://twig.symfony.com/doc/2.x/deprecated.html#miscellaneous

## Drupal.org issue
[Issue #3354343](https://dgo.to/3354343)
