### PR TITLE
Remove NodesToAddCollector 

### DIFF
--- a/src/Rector/Deprecation/AssertNoUniqueTextRector.php
+++ b/src/Rector/Deprecation/AssertNoUniqueTextRector.php
@@ -40,9 +40,6 @@ CODE_AFTER
     public function refactor(Node $node)
     {
         assert($node instanceof Node\Stmt\Expression);
-
-
-
         if (!($node->expr instanceof Node\Expr\MethodCall)) {
             return null;
         }
@@ -64,7 +61,6 @@ CODE_AFTER
         $getTextNode = $this->nodeFactory->createMethodCall($getPageNode, 'getText');
         $pageTextVar = new Node\Expr\Variable('page_text');
 
-
         $assign = new Node\Expr\Assign($pageTextVar, $getTextNode);
         $nodes[] = new Node\Stmt\Expression($assign);
 
@@ -83,7 +79,6 @@ CODE_AFTER
         } elseif (!$assertedText instanceof Node\Expr\Variable) {
             throw new \RuntimeException(__CLASS__ . ' cannot handle argument of type ' . get_class($assertedText));
         }
-
 
         $methodCall = $this->nodeFactory->createLocalMethodCall(
             'assertGreaterThan',

--- a/src/Rector/Deprecation/AssertNoUniqueTextRector.php
+++ b/src/Rector/Deprecation/AssertNoUniqueTextRector.php
@@ -6,24 +6,11 @@ use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\Core\Exception\ShouldNotHappenException;
 use Rector\Core\Rector\AbstractRector;
-use Rector\PostRector\Collector\NodesToAddCollector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class AssertNoUniqueTextRector extends AbstractRector
 {
-
-    /**
-     * @readonly
-     * @var \Rector\PostRector\Collector\NodesToAddCollector
-     */
-    private $nodesToAddCollector;
-
-    public function __construct(NodesToAddCollector $nodesToAddCollector)
-    {
-        $this->nodesToAddCollector = $nodesToAddCollector;
-    }
-
     use GetDeclaringSourceTrait;
 
     public function getRuleDefinition(): RuleDefinition
@@ -46,48 +33,59 @@ CODE_AFTER
     public function getNodeTypes(): array
     {
         return [
-            Node\Expr\MethodCall::class,
+            Node\Stmt\Expression::class,
         ];
     }
 
     public function refactor(Node $node)
     {
-        assert($node instanceof Node\Expr\MethodCall);
-        if ($this->getName($node->name) !== 'assertNoUniqueText') {
+        assert($node instanceof Node\Stmt\Expression);
+
+
+
+        if (!($node->expr instanceof Node\Expr\MethodCall)) {
             return null;
         }
-        if ($this->getDeclaringSource($node) !== 'Drupal\FunctionalTests\AssertLegacyTrait') {
+
+        if ($this->getName($node->expr->name) !== 'assertNoUniqueText') {
             return null;
         }
-        if (count($node->args) === 0) {
+        if ($this->getDeclaringSource($node->expr) !== 'Drupal\FunctionalTests\AssertLegacyTrait') {
+            return null;
+        }
+        if (count($node->expr->args) === 0) {
             throw new ShouldNotHappenException('assertNoUniqueText had no arguments');
         }
 
+        /** @var Node\Stmt[] $nodes */
         $nodes = [];
-
         $getSessionNode = $this->nodeFactory->createLocalMethodCall('getSession');
         $getPageNode = $this->nodeFactory->createMethodCall($getSessionNode, 'getPage');
         $getTextNode = $this->nodeFactory->createMethodCall($getPageNode, 'getText');
         $pageTextVar = new Node\Expr\Variable('page_text');
-        // @phpstan-ignore-next-line
-        $this->nodesToAddCollector->addNodeBeforeNode(new Node\Expr\Assign($pageTextVar, $getTextNode), $node);
+
+
+        $assign = new Node\Expr\Assign($pageTextVar, $getTextNode);
+        $nodes[] = new Node\Stmt\Expression($assign);
 
         $nrFoundVar = new Node\Expr\Variable('nr_found');
         $substrCountNode = $this->nodeFactory->createFuncCall(
             'substr_count',
-            [new Node\Arg($pageTextVar), $node->args[0]]
+            [new Node\Arg($pageTextVar), $node->expr->args[0]]
         );
-        // @phpstan-ignore-next-line
-        $this->nodesToAddCollector->addNodeBeforeNode(new Node\Expr\Assign($nrFoundVar, $substrCountNode), $node);
 
-        $assertedText = $node->args[0]->value;
+        $assignSubStrCount = new Node\Expr\Assign($nrFoundVar, $substrCountNode);
+        $nodes[] = new Node\Stmt\Expression($assignSubStrCount);
+
+        $assertedText = $node->expr->args[0]->value;
         if ($assertedText instanceof Node\Scalar\String_) {
             $assertedText = new Node\Scalar\EncapsedStringPart($assertedText->value);
         } elseif (!$assertedText instanceof Node\Expr\Variable) {
             throw new \RuntimeException(__CLASS__ . ' cannot handle argument of type ' . get_class($assertedText));
         }
 
-        return $this->nodeFactory->createLocalMethodCall(
+
+        $methodCall = $this->nodeFactory->createLocalMethodCall(
             'assertGreaterThan',
             [
                 new Node\Arg(new Node\Scalar\LNumber(1)),
@@ -100,5 +98,8 @@ CODE_AFTER
                 ]))
             ]
         );
+        $nodes[] = new Node\Stmt\Expression($methodCall);
+
+        return $nodes;
     }
 }

--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -5,7 +5,6 @@ namespace DrupalRector\Rector\Deprecation;
 use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
-use PhpParser\NodeVisitor;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -52,7 +51,7 @@ CODE_AFTER
             if (method_exists($this, 'removeNode')) {
                 $this->removeNode($node);
             } else {
-                return NodeVisitor::REMOVE_NODE;
+                return NodeTraverser::REMOVE_NODE;
             }
         }
 

--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -6,7 +6,6 @@ use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use Rector\Core\Rector\AbstractRector;
-use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -14,16 +13,6 @@ final class PassRector extends AbstractRector
 {
 
     use GetDeclaringSourceTrait;
-
-    /**
-     * @var ParentClassScopeResolver
-     */
-    protected $parentClassScopeResolver;
-
-    public function __construct(ParentClassScopeResolver $parentClassScopeResolver)
-    {
-        $this->parentClassScopeResolver = $parentClassScopeResolver;
-    }
 
     public function getRuleDefinition(): RuleDefinition
     {
@@ -59,7 +48,7 @@ CODE_AFTER
         }
 
         if ($this->getDeclaringSource($node->expr) === 'Drupal\KernelTests\AssertLegacyTrait') {
-            return NodeTraverser::REMOVE_NODE;
+            $this->removeNode($node);
         }
 
         return $node;

--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -4,6 +4,7 @@ namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
+use PhpParser\NodeTraverser;
 use Rector\Core\Rector\AbstractRector;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -41,19 +42,19 @@ CODE_AFTER
     public function getNodeTypes(): array
     {
         return [
-            Node\Expr\MethodCall::class,
+            Node\Stmt\Expression::class,
         ];
     }
 
     public function refactor(Node $node)
     {
-        assert($node instanceof Node\Expr\MethodCall);
-        if ($this->getName($node->name) !== 'pass') {
+        assert($node instanceof Node\Stmt\Expression);
+        if ($this->getName($node->expr->name) !== 'pass') {
             return null;
         }
 
-        if ($this->getDeclaringSource($node) === 'Drupal\KernelTests\AssertLegacyTrait') {
-            $this->removeNode($node);
+        if ($this->getDeclaringSource($node->expr) === 'Drupal\KernelTests\AssertLegacyTrait') {
+            return NodeTraverser::REMOVE_NODE;
         }
 
         return $node;

--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -5,6 +5,7 @@ namespace DrupalRector\Rector\Deprecation;
 use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use Rector\Core\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
@@ -48,7 +49,11 @@ CODE_AFTER
         }
 
         if ($this->getDeclaringSource($node->expr) === 'Drupal\KernelTests\AssertLegacyTrait') {
-            $this->removeNode($node);
+            if (method_exists($this, 'removeNode')) {
+                $this->removeNode($node);
+            } else {
+                return NodeVisitor::REMOVE_NODE;
+            }
         }
 
         return $node;

--- a/src/Rector/Deprecation/PassRector.php
+++ b/src/Rector/Deprecation/PassRector.php
@@ -49,6 +49,11 @@ CODE_AFTER
     public function refactor(Node $node)
     {
         assert($node instanceof Node\Stmt\Expression);
+
+        if (!($node->expr instanceof Node\Expr\MethodCall)) {
+            return null;
+        }
+
         if ($this->getName($node->expr->name) !== 'pass') {
             return null;
         }


### PR DESCRIPTION
NodesToAddCollector should not be used. Is it possible to do without. Yay. See this discussion by @mglaman from earlier.

https://github.com/rectorphp/rector/discussions/6538

## Description
Refactor 2 rules to create a new list of expressions and replace them in the function instead of using NodesToAddCollector  to add them before the node currently beoing processed.

## To Test
Run the tests.

## Drupal.org issue
[Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.](https://www.drupal.org/project/rector/issues/3373115)
