### PR TITLE
Fix/find parent by type

### DIFF
--- a/src/Rector/Deprecation/DrupalSetMessageRector.php
+++ b/src/Rector/Deprecation/DrupalSetMessageRector.php
@@ -3,6 +3,7 @@
 namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Utility\AddCommentTrait;
+use DrupalRector\Utility\FindParentByTypeTrait;
 use DrupalRector\Utility\TraitsByClassHelperTrait;
 use PhpParser\Comment;
 use PhpParser\Node;
@@ -36,6 +37,7 @@ final class DrupalSetMessageRector extends AbstractRector implements Configurabl
 {
     use TraitsByClassHelperTrait;
     use AddCommentTrait;
+    use FindParentByTypeTrait;
 
     public function configure(array $configuration): void
     {
@@ -77,7 +79,7 @@ CODE_AFTER
     {
         /** @var Node\Expr\FuncCall $node */
         if ($this->getName($node->name) === 'drupal_set_message') {
-            $class = $this->betterNodeFinder->findParentType($node, Node\Stmt\Class_::class);
+            $class = $this->findParentType($node, Node\Stmt\Class_::class);
             if ($this->checkClassTypeHasTrait($class, 'Drupal\Core\Messenger\MessengerTrait')) {
                 $messenger_service = new Node\Expr\MethodCall(
                     new Node\Expr\Variable('this'),

--- a/src/Rector/Deprecation/LinkGeneratorTraitLRector.php
+++ b/src/Rector/Deprecation/LinkGeneratorTraitLRector.php
@@ -3,6 +3,7 @@
 namespace DrupalRector\Rector\Deprecation;
 
 use DrupalRector\Utility\AddCommentTrait;
+use DrupalRector\Utility\FindParentByTypeTrait;
 use DrupalRector\Utility\TraitsByClassHelperTrait;
 use PhpParser\Node;
 use Rector\Core\Contract\Rector\ConfigurableRectorInterface;
@@ -27,6 +28,7 @@ final class LinkGeneratorTraitLRector extends AbstractRector implements Configur
 {
     use TraitsByClassHelperTrait;
     use AddCommentTrait;
+    use FindParentByTypeTrait;
 
     public function configure(array $configuration): void
     {
@@ -68,7 +70,7 @@ CODE_AFTER
     {
         /** @var Node\Expr\MethodCall $node */
           if ($this->getName($node->name) === 'l') {
-              $class = $this->betterNodeFinder->findParentType($node, Node\Stmt\Class_::class);
+            $class = $this->findParentType($node, Node\Stmt\Class_::class);
 
             // Check if class has LinkGeneratorTrait.
             if ($this->checkClassTypeHasTrait($class, 'Drupal\Core\Routing\LinkGeneratorTrait')) {

--- a/src/Utility/FindParentByTypeTrait.php
+++ b/src/Utility/FindParentByTypeTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DrupalRector\Utility;
+
+use PhpParser\Node;
+use Rector\NodeTypeResolver\Node\AttributeKey;
+use Webmozart\Assert\Assert;
+
+trait FindParentByTypeTrait
+{
+    /**
+     * @param Node $node
+     * @param class-string<T> $type
+     * @return Node|null
+     * @template T of Node
+     */
+    public function findParentType(Node $node, string $type): ?Node
+    {
+        $parentNode = $node->getAttribute('parent');
+
+        while ($parentNode instanceof Node) {
+            if ($parentNode instanceof $type) {
+                return $parentNode;
+            }
+
+            $parentNode = $parentNode->getAttribute('parent');
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
## Description
This moves a deprecated function into a local trait to allow finding parent by class. Feels wrong, but if we keep using parent for nodes, we might as well keep this as its just looping up parents until we hit the class.

## To Test
Run functional tests, it should work

## Drupal.org issue
No link, just working on fixing deprecations.
