### PR TITLE
Rector-src should not be needed anymore

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,6 +22,7 @@ jobs:
             # END: SHARED SETUP
 
             # We cannot have rector/rector in require and rector/rector-src in require-dev, they conflict.
+            - run: composer install rector/rector-src --no-update
             - run: composer remove rector/rector --no-update
             - run: composer install
             - run: php vendor/bin/phpstan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,8 +21,6 @@ jobs:
             #     uses: mxschmitt/action-tmate@v2
             # END: SHARED SETUP
 
-            # We cannot have rector/rector in require and rector/rector-src in require-dev, they conflict.
-            - run: composer require rector/rector-src --no-update
-            - run: composer remove rector/rector --no-update
+            - run: composer require rector/rector-src
             - run: composer install
             - run: php vendor/bin/phpstan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,7 @@ jobs:
             # END: SHARED SETUP
 
             # We cannot have rector/rector in require and rector/rector-src in require-dev, they conflict.
-            - run: composer install rector/rector-src --no-install
+            - run: composer require rector/rector-src --no-update
             - run: composer remove rector/rector --no-update
             - run: composer install
             - run: php vendor/bin/phpstan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -20,7 +20,5 @@ jobs:
             # -   name: Debugging with tmate
             #     uses: mxschmitt/action-tmate@v2
             # END: SHARED SETUP
-
-            - run: composer require rector/rector-src
             - run: composer install
             - run: php vendor/bin/phpstan

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -22,7 +22,7 @@ jobs:
             # END: SHARED SETUP
 
             # We cannot have rector/rector in require and rector/rector-src in require-dev, they conflict.
-            - run: composer install rector/rector-src --no-update
+            - run: composer install rector/rector-src --no-install
             - run: composer remove rector/rector --no-update
             - run: composer install
             - run: php vendor/bin/phpstan

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,5 @@ jobs:
                     php-version: ${{ matrix.php-version }}
                     coverage: none
                     tools: composer:v2
-            # We cannot have rector/rector in require and rector/rector-src in require-dev, they conflict.
-            - run: composer remove rector/rector --no-update
             - run: composer install
             - run: vendor/bin/phpunit --testdox

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,6 @@
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^10.0",
-        "rector/rector-src": "dev-main",
         "symplify/vendor-patches": "^11.0",
         "symfony/yaml": "^5 || ^6"
     }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,11 @@ parameters:
 		- config
 		- src
 		- rector.php
+	bootstrapFiles:
+	    - vendor/rector/rector/vendor/autoload.php
 # See https://phpstan.org/blog/preprocessing-ast-for-custom-rules
 # Changing this in phpstan 1.6 means refactoring calls to getAttribute('parent')
 conditionalTags:
     PhpParser\NodeVisitor\NodeConnectingVisitor:
         phpstan.parser.richParserNodeVisitor: true
+


### PR DESCRIPTION
## Description
This removes the rector-src dependency, this should make development a lot easier. Lets see if tests are still green

## To Test
See tests running correctly.

## Drupal.org issue
Nope.
