### PR TITLE
Support for Drupal 10 deprecations and testing

### DIFF
--- a/.github/workflows/functional_test__rector_examples.yml
+++ b/.github/workflows/functional_test__rector_examples.yml
@@ -19,6 +19,9 @@ jobs:
                     - php-version: "8.0"
                       drupal: "^9.2"
                       fixture: "d9"
+                    - php-version: "8.1"
+                      drupal: "^10.0"
+                      fixture: "d10"
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3

--- a/config/drupal-10/drupal-10-all-deprecations.php
+++ b/config/drupal-10/drupal-10-all-deprecations.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Set\Drupal10SetList;
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+use Rector\Symfony\Set\TwigLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        Drupal10SetList::DRUPAL_100,
+        Drupal10SetList::DRUPAL_101,
+    ]);
+
+    $rectorConfig->bootstrapFiles([
+        __DIR__ . '/../drupal-phpunit-bootstrap-file.php'
+    ]);
+};

--- a/config/drupal-10/drupal-10.0-deprecations.php
+++ b/config/drupal-10/drupal-10.0-deprecations.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Set\Drupal10SetList;
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+use Rector\Symfony\Set\TwigLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        SymfonyLevelSetList::UP_TO_SYMFONY_62,
+        TwigLevelSetList::UP_TO_TWIG_240,
+    ]);
+};

--- a/config/drupal-10/drupal-10.1-deprecations.php
+++ b/config/drupal-10/drupal-10.1-deprecations.php
@@ -11,9 +11,7 @@ use Rector\Symfony\Set\TwigLevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
         SymfonyLevelSetList::UP_TO_SYMFONY_63,
-        TwigLevelSetList::UP_TO_TWIG_240,
     ]);
 
     // https://www.drupal.org/node/3244583

--- a/config/drupal-10/drupal-10.1-deprecations.php
+++ b/config/drupal-10/drupal-10.1-deprecations.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
-use DrupalRector\Set\Drupal10SetList;
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\Symfony\Set\SymfonyLevelSetList;

--- a/config/drupal-10/drupal-10.1-deprecations.php
+++ b/config/drupal-10/drupal-10.1-deprecations.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
+use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
+use DrupalRector\Set\Drupal10SetList;
+use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+use Rector\Symfony\Set\TwigLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        SymfonyLevelSetList::UP_TO_SYMFONY_63,
+        TwigLevelSetList::UP_TO_TWIG_240,
+    ]);
+
+    // https://www.drupal.org/node/3244583
+    $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
+        new FunctionToStaticConfiguration('drupal_rewrite_settings', 'Drupal\Core\Site\SettingsEditor', 'rewrite', [0 => 1, 1 => 0]),
+    ]);
+};

--- a/fixtures/d10/rector_examples/function_to_static_call.php
+++ b/fixtures/d10/rector_examples/function_to_static_call.php
@@ -1,0 +1,7 @@
+<?php
+
+function simple_example() {
+    $settings = [];
+    $filename = 'simple_filename.yaml';
+    drupal_rewrite_settings($settings, $filename);
+}

--- a/fixtures/d10/rector_examples_updated/function_to_static_call.php
+++ b/fixtures/d10/rector_examples_updated/function_to_static_call.php
@@ -1,0 +1,7 @@
+<?php
+
+function simple_example() {
+    $settings = [];
+    $filename = 'simple_filename.yaml';
+    \Drupal\Core\Site\SettingsEditor::rewrite($filename, $settings);
+}

--- a/fixtures/d10/rector_examples_updated/function_to_static_call.php
+++ b/fixtures/d10/rector_examples_updated/function_to_static_call.php
@@ -1,7 +1,8 @@
 <?php
 
+use Drupal\Core\Site\SettingsEditor;
 function simple_example() {
     $settings = [];
     $filename = 'simple_filename.yaml';
-    \Drupal\Core\Site\SettingsEditor::rewrite($filename, $settings);
+    SettingsEditor::rewrite($filename, $settings);
 }

--- a/rector.php
+++ b/rector.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinder;
+use DrupalRector\Set\Drupal10SetList;
 use DrupalRector\Set\Drupal8SetList;
 use DrupalRector\Set\Drupal9SetList;
 use Rector\Config\RectorConfig;
@@ -14,6 +15,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         Drupal8SetList::DRUPAL_8,
         Drupal9SetList::DRUPAL_9,
+        Drupal10SetList::DRUPAL_10,
     ]);
 
     $drupalFinder = new DrupalFinder();

--- a/src/Rector/ValueObject/FunctionToStaticConfiguration.php
+++ b/src/Rector/ValueObject/FunctionToStaticConfiguration.php
@@ -11,14 +11,21 @@ class FunctionToStaticConfiguration {
     protected string $methodName;
 
     /**
+     * @var array|int[] Reorder arguments array[old_position] = new_position
+     */
+    private array $argumentReorder;
+
+    /**
      * @param string $deprecatedFunctionName Deprecated function name
      * @param string $className Class to call static method on
      * @param string $methodName Method to call statically
+     * @param array|int[] $argumentReorder Reorder arguments array[old_position] = new_position
      */
-    public function __construct(string $deprecatedFunctionName, string $className, string $methodName) {
+    public function __construct(string $deprecatedFunctionName, string $className, string $methodName, array $argumentReorder = []) {
         $this->deprecatedFunctionName = $deprecatedFunctionName;
         $this->className = $className;
         $this->methodName = $methodName;
+        $this->argumentReorder = $argumentReorder;
     }
 
     public function getDeprecatedFunctionName(): string {
@@ -32,4 +39,12 @@ class FunctionToStaticConfiguration {
     public function getMethodName(): string {
         return $this->methodName;
     }
+
+    /**
+     * @return array|int[] Reorder arguments array[old_position] = new_position
+     */
+    public function getArgumentReorder(): array {
+        return $this->argumentReorder;
+    }
+
 }

--- a/src/Set/Drupal10SetList.php
+++ b/src/Set/Drupal10SetList.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Set;
+
+use Rector\Set\Contract\SetListInterface;
+
+final class Drupal10SetList implements SetListInterface
+{
+    public const DRUPAL_10 = __DIR__ . '/../../config/drupal-10/drupal-10-all-deprecations.php';
+    public const DRUPAL_100 = __DIR__ . '/../../config/drupal-10/drupal-10.0-deprecations.php';
+    public const DRUPAL_101 = __DIR__ . '/../../config/drupal-10/drupal-10.1-deprecations.php';
+}

--- a/stubs/Drupal/Site/SettingsEditor.php
+++ b/stubs/Drupal/Site/SettingsEditor.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\Core\Site;
+
+if (class_exists('Drupal\Core\Site\Settings')) {
+    return;
+}
+
+final class SettingsEditor {
+
+  private function __construct() {}
+
+  public static function rewrite(string $settings_file, array $settings = []): void {
+
+  }
+}

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/FunctionToStaticRector.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/FunctionToStaticRector.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\FunctionToStaticRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+use Symplify\SmartFileSystem\SmartFileInfo;
+
+class FunctionToStaticRector extends AbstractRectorTestCase {
+
+    /**
+     * @covers ::refactor
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<<string>>
+     */
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__ . '/config/configured_rule.php';
+    }
+
+}

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
+use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(FunctionToStaticRector::class, $rectorConfig, FALSE, [
+        new FunctionToStaticConfiguration('file_directory_os_temp', 'Drupal\Component\FileSystem\FileSystem', 'getOsTemporaryDirectory'),
+        new FunctionToStaticConfiguration('drupal_rewrite_settings', 'Drupal\Core\Site\SettingsEditor', 'rewrite', [0 => 1, 1 => 0]),
+    ]);
+};

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+function simple_example() {
+    $settings = [];
+    $filename = 'simple_filename.yaml';
+    drupal_rewrite_settings($settings, $filename);
+}
+
+/**
+ * A simple example.
+ */
+function simple_example_os_temp() {
+    $x = file_directory_os_temp();
+}
+?>
+-----
+<?php
+
+function simple_example() {
+    $settings = [];
+    $filename = 'simple_filename.yaml';
+    \Drupal\Core\Site\SettingsEditor::rewrite($filename, $settings);
+}
+
+/**
+ * A simple example.
+ */
+function simple_example_os_temp() {
+    $x = \Drupal\Component\FileSystem\FileSystem::getOsTemporaryDirectory();
+}
+?>

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
@@ -16,10 +16,11 @@ function simple_example_os_temp() {
 -----
 <?php
 
+use Drupal\Core\Site\SettingsEditor;
 function simple_example() {
     $settings = [];
     $filename = 'simple_filename.yaml';
-    \Drupal\Core\Site\SettingsEditor::rewrite($filename, $settings);
+    SettingsEditor::rewrite($filename, $settings);
 }
 
 /**


### PR DESCRIPTION
## Description
For now only run this in tests until we figure out how to also apply the deprecation helper. We need to decide how we handle the fact that this helper is only implemented in Drupal 10.1, perhaps we should not support Drupal 10.0 and only support Drupal 10.1 and up?

This adds:
1. Deprecation files for Drupal 10
2. Correct setlists for Symfony for 10.0 and 10.0
3. First deprecation (10.1 though): https://www.drupal.org/node/3244583
4. GitHub action configuration for Drupal 10 functional testing.

We need to decide the following:
1. How to handle what rules are ran on the project. We don't want D10 stuff running on D9. We could detect the version, or perhaps have some other way to influence what rector.php is used. (less copying, more configuring by the user maybe?)
2. This does not include the Deprecation helper for now, that is only  Drupal 10.1, which means we need to choose if we even support Drupal 10.0, since that will complicate things a lot. And to include https://packagist.org/packages/drupal/core-utility#10.1.0 is not really realistic, so we are in a bit of a conundrum here.

## To Test
- Unit tests
- Functional tests

## Drupal.org issue
[Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.](https://www.drupal.org/project/rector/issues/3384046)
