### PR TITLE
PHPUnit deprecations should be checked in Drupal 9 to 10

### DIFF
--- a/config/drupal-9/drupal-9-all-deprecations.php
+++ b/config/drupal-9/drupal-9-all-deprecations.php
@@ -19,7 +19,6 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal9SetList::DRUPAL_93,
         Drupal9SetList::DRUPAL_94,
         PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
-        PHPUnitSetList::PHPUNIT_CODE_QUALITY,
     ]);
 
     $rectorConfig->bootstrapFiles([

--- a/config/drupal-9/drupal-9-all-deprecations.php
+++ b/config/drupal-9/drupal-9-all-deprecations.php
@@ -6,6 +6,7 @@ use DrupalRector\Set\Drupal9SetList;
 use DrupalRector\Services\AddCommentService;
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(AddCommentService::class, function() {
@@ -18,6 +19,7 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal9SetList::DRUPAL_93,
         Drupal9SetList::DRUPAL_94,
         PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_CODE_QUALITY,
     ]);
 
     $rectorConfig->bootstrapFiles([

--- a/config/drupal-9/drupal-9-all-deprecations.php
+++ b/config/drupal-9/drupal-9-all-deprecations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use DrupalRector\Set\Drupal9SetList;
 use DrupalRector\Services\AddCommentService;
 use Rector\Config\RectorConfig;
+use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(AddCommentService::class, function() {
@@ -16,6 +17,7 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal9SetList::DRUPAL_92,
         Drupal9SetList::DRUPAL_93,
         Drupal9SetList::DRUPAL_94,
+        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
     ]);
 
     $rectorConfig->bootstrapFiles([


### PR DESCRIPTION
## Description
I was missing a lot of fixes in regards to phpunit createMock. The new setup now includes phpunit up to 9 for Drupal 9 -> 10 fixes.


## To Test
- Hard, trust me? 

## Drupal.org issue
no issue
