### PR TITLE
Link packagist version shield to package on packagist.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Automate fixing deprecated Drupal code.
 
 
 
-![Packagist Version](https://img.shields.io/packagist/v/palantirnet/drupal-rector) ![Functional test: Rector examples](https://img.shields.io/github/actions/workflow/status/palantirnet/drupal-rector/functional_test__rector_examples.yml?logo=github&label=Functional%20tests) ![Unit tests](https://img.shields.io/github/actions/workflow/status/palantirnet/drupal-rector/phpunit.yml?logo=github&label=Unit%20tests)  ![PHPStan](https://img.shields.io/github/actions/workflow/status/palantirnet/drupal-rector/phpstan.yml?logo=github&label=PHPStan)
+[![Packagist Version](https://img.shields.io/packagist/v/palantirnet/drupal-rector)](https://packagist.org/packages/palantirnet/drupal-rector) ![Functional test: Rector examples](https://img.shields.io/github/actions/workflow/status/palantirnet/drupal-rector/functional_test__rector_examples.yml?logo=github&label=Functional%20tests) ![Unit tests](https://img.shields.io/github/actions/workflow/status/palantirnet/drupal-rector/phpunit.yml?logo=github&label=Unit%20tests)  ![PHPStan](https://img.shields.io/github/actions/workflow/status/palantirnet/drupal-rector/phpstan.yml?logo=github&label=PHPStan)
 
 ## Latest release
 


### PR DESCRIPTION
## Description

This seems to be a pretty standard approach. Other projects using the same approach include:

- https://github.com/laravel/laravel
- https://github.com/sebastianbergmann/phpunit


## To Test
- Check the rich diff in the PR
- See that the Packagist shield links to the package on Drupal.org.
   
## Drupal.org issue
This seems to be GitHub only. Is a Drupal.org issue necessary here?