### PR TITLE
PHPUnit: Rector to fix missing parent::setUp and parent::tearDown methods

### DIFF
--- a/config/drupal-10/drupal-10.0-deprecations.php
+++ b/config/drupal-10/drupal-10.0-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\Symfony\Set\SymfonyLevelSetList;
@@ -13,4 +14,6 @@ return static function (RectorConfig $rectorConfig): void {
         SymfonyLevelSetList::UP_TO_SYMFONY_62,
         TwigLevelSetList::UP_TO_TWIG_240,
     ]);
+
+    $rectorConfig->rule(ShouldCallParentMethodsRector::class);
 };

--- a/config/drupal-9/drupal-9.0-deprecations.php
+++ b/config/drupal-9/drupal-9.0-deprecations.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use DrupalRector\Drupal9\Rector\Property\ProtectedStaticModulesPropertyRector;
+use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
 use DrupalRector\Services\AddCommentService;
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
@@ -24,4 +25,6 @@ return static function (RectorConfig $rectorConfig): void {
         TwigSetList::TWIG_240,
     ]);
     $rectorConfig->rule(ProtectedStaticModulesPropertyRector::class);
+
+    $rectorConfig->rule(ShouldCallParentMethodsRector::class);
 };

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,4 +1,4 @@
-# 51 Rules Overview
+# 52 Rules Overview
 
 <br>
 
@@ -10,7 +10,7 @@
 
 - [Drupal9](#drupal9) (26)
 
-- [DrupalRector](#drupalrector) (4)
+- [DrupalRector](#drupalrector) (5)
 
 <br>
 
@@ -1055,6 +1055,36 @@ Fixes deprecated `MetadataBag::clearCsrfTokenSeed()` calls, used in Drupal 8 and
  $entity_type = $node->getEntityType();
 -$entity_type->getLowercaseLabel();
 +$entity_type->getSingularLabel();
+```
+
+<br>
+
+### ShouldCallParentMethodsRector
+
+PHPUnit based tests should call parent methods (setUp, tearDown)
+
+- class: [`DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector`](../src/Rector/PHPUnit/ShouldCallParentMethodsRector.php)
+
+```diff
+ namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\fixture;
+
+ use Drupal\KernelTests\KernelTestBase;
+
+ final class SetupVoidTest extends KernelTestBase {
+
+     protected function setUp(): void
+     {
++        parent::setUp();
+         $test = 'doing things';
+     }
+
+     protected function tearDown(): void
+     {
++        parent::tearDown();
+         $test = 'doing things';
+     }
+
+ }
 ```
 
 <br>

--- a/fixtures/d10/rector_examples/tests/src/Kernel/MissingSetupTest.php
+++ b/fixtures/d10/rector_examples/tests/src/Kernel/MissingSetupTest.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\rector_examples\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+    }
+
+}

--- a/fixtures/d10/rector_examples_updated/tests/src/Kernel/MissingSetupTest.php
+++ b/fixtures/d10/rector_examples_updated/tests/src/Kernel/MissingSetupTest.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Drupal\Tests\rector_examples\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+}

--- a/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
+++ b/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
@@ -43,12 +43,6 @@ class ShouldCallParentMethodsRector extends AbstractScopeAwareRector
             return null;
         }
 
-        $parentClassesNames = $scope->getClassReflection()
-            ->getParentClassesNames();
-        if (!in_array(\PHPUnit\Framework\TestCase::class, $parentClassesNames)) {
-            return null;
-        }
-
         if (!in_array(strtolower($node->name->name), ['setup', 'teardown'], true)) {
             return null;
         }

--- a/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
+++ b/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace DrupalRector\Rector\PHPUnit;
 
 use PhpParser\Node;
-use PhpParser\NodeDumper;
 use PHPStan\Analyser\Scope;
 use Rector\Core\Rector\AbstractScopeAwareRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -53,8 +52,6 @@ class ShouldCallParentMethodsRector extends AbstractScopeAwareRector
         if (!in_array(strtolower($node->name->name), ['setup', 'teardown'], true)) {
             return null;
         }
-
-        echo (new NodeDumper())->dump($node);
 
         $hasParentCall = $this->hasParentClassCall($node->getStmts());
 

--- a/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
+++ b/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
@@ -55,7 +55,7 @@ class ShouldCallParentMethodsRector extends AbstractScopeAwareRector
 
         $hasParentCall = $this->hasParentClassCall($node->getStmts());
 
-        if (!$hasParentCall) {
+        if ($hasParentCall === false) {
             $expr = new Node\Stmt\Expression(
                 new Node\Expr\StaticCall(
                     new Node\Name('parent'),

--- a/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
+++ b/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Rector\PHPUnit;
+
+use PhpParser\Node;
+use PhpParser\NodeDumper;
+use PHPStan\Analyser\Scope;
+use Rector\Core\Rector\AbstractScopeAwareRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+class ShouldCallParentMethodsRector extends AbstractScopeAwareRector
+{
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Stmt\ClassMethod::class,
+        ];
+    }
+
+    /**
+     * @phpstan-param Node\Stmt\ClassMethod $node
+     *
+     * @param \PhpParser\Node         $node
+     * @param \PHPStan\Analyser\Scope $scope
+     *
+     * @return \PhpParser\Node|null
+     */
+    public function refactorWithScope(Node $node, Scope $scope)
+    {
+        if ($scope->getClassReflection() === null) {
+            return null;
+        }
+
+        if (!$scope->getClassReflection()->isSubclassOf(\PHPUnit\Framework\TestCase::class)) {
+            return null;
+        }
+
+        $parentClass = $scope->getClassReflection()->getParentClass();
+
+        if ($parentClass === null) {
+            return null;
+        }
+
+        $parentClassesNames = $scope->getClassReflection()
+            ->getParentClassesNames();
+        if (!in_array(\PHPUnit\Framework\TestCase::class, $parentClassesNames)) {
+            return null;
+        }
+
+        if (!in_array(strtolower($node->name->name), ['setup', 'teardown'], true)) {
+            return null;
+        }
+
+        echo (new NodeDumper())->dump($node);
+
+        $hasParentCall = $this->hasParentClassCall($node->getStmts());
+
+        if (!$hasParentCall) {
+            $expr = new Node\Stmt\Expression(
+                new Node\Expr\StaticCall(
+                    new Node\Name('parent'),
+                    $node->name->name
+                )
+            );
+
+            $node->stmts = array_merge([$expr], $node->stmts);
+
+            return $node;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Node\Stmt[]|null $stmts
+     *
+     * @return bool
+     */
+    private function hasParentClassCall(?array $stmts): bool
+    {
+        if ($stmts === null) {
+            return false;
+        }
+
+        foreach ($stmts as $stmt) {
+            if (!$stmt instanceof Node\Stmt\Expression) {
+                continue;
+            }
+
+            if (!$stmt->expr instanceof Node\Expr\StaticCall) {
+                continue;
+            }
+
+            if (!$stmt->expr->class instanceof Node\Name) {
+                continue;
+            }
+
+            $class = (string) $stmt->expr->class;
+
+            if (strtolower($class) !== 'parent') {
+                continue;
+            }
+
+            if (!$stmt->expr->name instanceof Node\Identifier) {
+                continue;
+            }
+
+            if (in_array(strtolower($stmt->expr->name->name), ['setup', 'teardown'], true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('PHPUnit based tests should call parent methods (setUp, tearDown)',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\fixture;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        $test = 'doing things';
+    }
+
+    protected function tearDown(): void
+    {
+        $test = 'doing things';
+    }
+
+}
+CODE_BEFORE
+                    ,
+                    <<<'CODE_SAMPLE'
+namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\fixture;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $test = 'doing things';
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $test = 'doing things';
+    }
+
+}
+CODE_SAMPLE
+                ),
+            ]
+        );
+    }
+}

--- a/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/ShouldCallParentMethodsRectorTest.php
+++ b/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/ShouldCallParentMethodsRectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\PHPUnit\ShouldCallParentMethodsRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class ShouldCallParentMethodsRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @covers ::refactor
+     *
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/config/configured_rule.php
+++ b/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(ShouldCallParentMethodsRector::class, $rectorConfig, false);
+};

--- a/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/fixture/test_missing_parent.php.inc
+++ b/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/fixture/test_missing_parent.php.inc
@@ -4,7 +4,7 @@ namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\
 
 use Drupal\KernelTests\KernelTestBase;
 
-final class SetupVoidTest extends KernelTestBase {
+final class MissingParentTest extends KernelTestBase {
 
     protected function setUp(): void
     {
@@ -18,6 +18,18 @@ final class SetupVoidTest extends KernelTestBase {
 
 }
 
+final class MissingParentInEmptyTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+    }
+
+    protected function tearDown(): void
+    {
+    }
+
+}
+
 ?>
 -----
 <?php
@@ -26,7 +38,7 @@ namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\
 
 use Drupal\KernelTests\KernelTestBase;
 
-final class SetupVoidTest extends KernelTestBase {
+final class MissingParentTest extends KernelTestBase {
 
     protected function setUp(): void
     {
@@ -38,6 +50,20 @@ final class SetupVoidTest extends KernelTestBase {
     {
         parent::tearDown();
         $test = 'doing things';
+    }
+
+}
+
+final class MissingParentInEmptyTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
     }
 
 }

--- a/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/fixture/test_missing_parent.php.inc
+++ b/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/fixture/test_missing_parent.php.inc
@@ -30,6 +30,20 @@ final class MissingParentInEmptyTest extends KernelTestBase {
 
 }
 
+final class NotAtestClass {
+
+    protected function setUp(): void
+    {
+        $test = 'doing things';
+    }
+
+    protected function tearDown(): void
+    {
+        $test = 'doing things';
+    }
+
+}
+
 ?>
 -----
 <?php
@@ -64,6 +78,20 @@ final class MissingParentInEmptyTest extends KernelTestBase {
     protected function tearDown(): void
     {
         parent::tearDown();
+    }
+
+}
+
+final class NotAtestClass {
+
+    protected function setUp(): void
+    {
+        $test = 'doing things';
+    }
+
+    protected function tearDown(): void
+    {
+        $test = 'doing things';
     }
 
 }

--- a/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/fixture/test_missing_parent.php.inc
+++ b/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/fixture/test_missing_parent.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\fixture;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        $test = 'doing things';
+    }
+
+    protected function tearDown(): void
+    {
+        $test = 'doing things';
+    }
+
+}
+
+?>
+-----
+<?php
+
+namespace Drupal\Tests\Rector\Deprecation\PHPUnit\ShouldCallParentMethodsRector\fixture;
+
+use Drupal\KernelTests\KernelTestBase;
+
+final class SetupVoidTest extends KernelTestBase {
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $test = 'doing things';
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        $test = 'doing things';
+    }
+
+}
+
+?>


### PR DESCRIPTION
## Description
Based on this phpstan rule: https://github.com/phpstan/phpstan-phpunit/commit/d686c82965e4e44fb753ca4342fcf797c1f01c88

Adds parent::setUp and parent::tearDown to those methods when missing.

## To Test
Run tests
