### PR TITLE
Better workflows

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,7 +1,11 @@
 name: php-cs-fixer
 
-# This test will run on every pull request, and on every commit on any branch
-on: [push, pull_request]
+# This test will run on every pull request, and on every push on main branch
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
     php-cs-fixer:

--- a/.github/workflows/functional_test__rector_examples.yml
+++ b/.github/workflows/functional_test__rector_examples.yml
@@ -2,7 +2,14 @@
 name: functional_test__rector_examples
 
 # This test will run on every pull request, and on every commit on any branch
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Run tests every week (to check for rector changes)
+    - cron:  '0 0 * * 0'
 
 jobs:
     run_functional_test:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,7 +1,14 @@
 name: phpstan
 
 # This test will run on every pull request, and on every commit on any branch
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Run tests every week (to check for rector changes)
+    - cron:  '0 0 * * 0'
 
 jobs:
     run_static_analysis_phpstan_analyze:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,7 +1,14 @@
 name: phpunit
 
 # This test will run on every pull request, and on every commit on any branch
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    # Run tests every week (to check for rector changes)
+    - cron:  '0 0 * * 0'
 
 jobs:
     tests:


### PR DESCRIPTION
Only run on push on main, also schedule tests every week for rector regressions.

No more double runs in PR's also weekly check if rector didnt break everything.