### PR TITLE
New rector (9.3): Support FILE_STATUS_PERMANENT deprecation

### DIFF
--- a/config/drupal-9/drupal-9.3-deprecations.php
+++ b/config/drupal-9/drupal-9.3-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Drupal8\Rector\ValueObject\ConstantToClassConfiguration;
 use DrupalRector\Drupal9\Rector\Deprecation\ExtensionPathRector;
 use DrupalRector\Drupal9\Rector\Deprecation\FileBuildUriRector;
 use DrupalRector\Drupal9\Rector\Deprecation\FunctionToEntityTypeStorageMethod;
@@ -66,4 +67,11 @@ return static function (RectorConfig $rectorConfig): void {
         new FunctionToFirstArgMethodConfiguration('taxonomy_term_uri', 'toUrl'),
         new FunctionToFirstArgMethodConfiguration('taxonomy_term_title', 'label'),
     ]);
+
+    // Change record: https://www.drupal.org/node/3022147
+    new ConstantToClassConfiguration(
+        'FILE_STATUS_PERMANENT',
+        'Drupal\file\FileInterface',
+        'STATUS_PERMANENT',
+    );
 };

--- a/tests/src/Drupal8/Rector/Deprecation/ConstantToClassConstantRector/config/configured_rule.php
+++ b/tests/src/Drupal8/Rector/Deprecation/ConstantToClassConstantRector/config/configured_rule.php
@@ -15,4 +15,11 @@ return static function (RectorConfig $rectorConfig): void {
             'STORAGE_TIMEZONE',
         ),
     ]);
+    DeprecationBase::addClass(ConstantToClassConstantRector::class, $rectorConfig, false, [
+        new ConstantToClassConfiguration(
+            'FILE_STATUS_PERMANENT',
+            'Drupal\file\FileInterface',
+            'STATUS_PERMANENT',
+        ),
+    ]);
 };

--- a/tests/src/Drupal8/Rector/Deprecation/ConstantToClassConstantRector/fixture/fixture.php.inc
+++ b/tests/src/Drupal8/Rector/Deprecation/ConstantToClassConstantRector/fixture/fixture.php.inc
@@ -11,6 +11,13 @@ function as_an_argument() {
 
     $class = new \TestClass(FILE_STATUS_PERMANENT);
 }
+
+class ClassDefault {
+    public function test($status = FILE_STATUS_PERMANENT) {
+        return true;
+    }
+}
+
 ?>
 -----
 <?php
@@ -26,4 +33,11 @@ function as_an_argument() {
 
     $class = new \TestClass(\Drupal\file\FileInterface::STATUS_PERMANENT);
 }
+
+class ClassDefault {
+    public function test($status = \Drupal\file\FileInterface::STATUS_PERMANENT) {
+        return true;
+    }
+}
+
 ?>

--- a/tests/src/Drupal8/Rector/Deprecation/ConstantToClassConstantRector/fixture/fixture.php.inc
+++ b/tests/src/Drupal8/Rector/Deprecation/ConstantToClassConstantRector/fixture/fixture.php.inc
@@ -2,10 +2,14 @@
 
 function simple_example() {
     $timezone = DATETIME_STORAGE_TIMEZONE;
+
+    $file_status = FILE_STATUS_PERMANENT;
 }
 
 function as_an_argument() {
     $timezone = new \DateTimeZone(DATETIME_STORAGE_TIMEZONE);
+
+    $class = new \TestClass(FILE_STATUS_PERMANENT);
 }
 ?>
 -----
@@ -13,9 +17,13 @@ function as_an_argument() {
 
 function simple_example() {
     $timezone = \Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface::STORAGE_TIMEZONE;
+
+    $file_status = \Drupal\file\FileInterface::STATUS_PERMANENT;
 }
 
 function as_an_argument() {
     $timezone = new \DateTimeZone(\Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface::STORAGE_TIMEZONE);
+
+    $class = new \TestClass(\Drupal\file\FileInterface::STATUS_PERMANENT);
 }
 ?>


### PR DESCRIPTION
https://www.drupal.org/node/3022147

## Description
Fix deprecated usage of FILE_STATUS_PERMANENT

## To Test
- Add steps to test this feature

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3410664
