### PR TITLE
New rector (9.1): \Drupal\Component\Utility\Bytes::toInt() is deprecated

### DIFF
--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -18,6 +18,8 @@ use DrupalRector\Drupal9\Rector\ValueObject\AssertLegacyTraitConfiguration;
 use DrupalRector\Services\AddCommentService;
 use Rector\Config\RectorConfig;
 use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Renaming\Rector\StaticCall\RenameStaticMethodRector;
+use Rector\Renaming\ValueObject\RenameStaticMethod;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(AddCommentService::class, function () {
@@ -95,4 +97,13 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(GetRawContentRector::class);
     $rectorConfig->rule(GetAllOptionsRector::class);
     $rectorConfig->rule(UserPasswordRector::class);
+
+    $rectorConfig->ruleWithConfiguration(RenameStaticMethodRector::class, [
+        new RenameStaticMethod(
+            'Drupal\Component\Utility\Bytes',
+            'toInt',
+            'Drupal\Component\Utility\Bytes',
+            'toNumber'
+        ),
+    ]);
 };

--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -98,6 +98,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(GetAllOptionsRector::class);
     $rectorConfig->rule(UserPasswordRector::class);
 
+    // Change record: https://www.drupal.org/node/3162663
     $rectorConfig->ruleWithConfiguration(RenameStaticMethodRector::class, [
         new RenameStaticMethod(
             'Drupal\Component\Utility\Bytes',

--- a/fixtures/d9/rector_examples/rector_examples.module
+++ b/fixtures/d9/rector_examples/rector_examples.module
@@ -13,3 +13,7 @@ function rector_examples_with_render() {
     $build = [];
     $output = render($build);
 }
+
+function rector_utility_bytes_to_int() {
+    $int = \Drupal\Component\Utility\Bytes::toInt("15");
+}

--- a/fixtures/d9/rector_examples/rector_examples.module
+++ b/fixtures/d9/rector_examples/rector_examples.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Component\Utility\Bytes;
 function extension_paths() {
     drupal_get_path('module', 'node');
     drupal_get_path('theme', 'seven');
@@ -15,5 +16,5 @@ function rector_examples_with_render() {
 }
 
 function rector_utility_bytes_to_int() {
-    $int = \Drupal\Component\Utility\Bytes::toInt("15");
+    $int = Bytes::toInt("15");
 }

--- a/fixtures/d9/rector_examples_updated/rector_examples.module
+++ b/fixtures/d9/rector_examples_updated/rector_examples.module
@@ -13,3 +13,8 @@ function rector_examples_with_render() {
     $build = [];
     $output = \Drupal::service('renderer')->render($build);
 }
+
+function rector_utility_bytes_to_int() {
+    $int = \Drupal\Component\Utility\Bytes::toNumber("15");
+}
+

--- a/fixtures/d9/rector_examples_updated/rector_examples.module
+++ b/fixtures/d9/rector_examples_updated/rector_examples.module
@@ -1,5 +1,6 @@
 <?php
 
+use Drupal\Component\Utility\Bytes;
 function extension_paths() {
     \Drupal::service('extension.list.module')->getPath('node');
     \Drupal::service('extension.list.theme')->getPath('seven');
@@ -15,6 +16,6 @@ function rector_examples_with_render() {
 }
 
 function rector_utility_bytes_to_int() {
-    $int = \Drupal\Component\Utility\Bytes::toNumber("15");
+    $int = Bytes::toNumber("15");
 }
 


### PR DESCRIPTION
\Drupal\Component\Utility\Bytes::toInt() is deprecated in favor of \Drupal\Component\Utility\Bytes::toNumber()

https://www.drupal.org/node/3162663


## To Test
functional tests

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3410667
