### PR TITLE
feat: add rector rule for format_size in 10.2

### DIFF
--- a/config/drupal-10/drupal-10-all-deprecations.php
+++ b/config/drupal-10/drupal-10-all-deprecations.php
@@ -9,6 +9,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         Drupal10SetList::DRUPAL_100,
         Drupal10SetList::DRUPAL_101,
+        Drupal10SetList::DRUPAL_102,
     ]);
 
     $rectorConfig->bootstrapFiles([

--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -5,13 +5,8 @@ declare(strict_types=1);
 use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Set\SymfonyLevelSetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->sets([
-        SymfonyLevelSetList::UP_TO_SYMFONY_63,
-    ]);
-
     // https://www.drupal.org/node/2999981
     $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
         new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),

--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
+use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonyLevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        SymfonyLevelSetList::UP_TO_SYMFONY_63,
+    ]);
+
+    // https://www.drupal.org/node/2999981
+    $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
+        new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
+    ]);
+};

--- a/src/Set/Drupal10SetList.php
+++ b/src/Set/Drupal10SetList.php
@@ -11,4 +11,5 @@ final class Drupal10SetList implements SetListInterface
     public const DRUPAL_10 = __DIR__.'/../../config/drupal-10/drupal-10-all-deprecations.php';
     public const DRUPAL_100 = __DIR__.'/../../config/drupal-10/drupal-10.0-deprecations.php';
     public const DRUPAL_101 = __DIR__.'/../../config/drupal-10/drupal-10.1-deprecations.php';
+    public const DRUPAL_102 = __DIR__.'/../../config/drupal-10/drupal-10.2-deprecations.php';
 }

--- a/stubs/Drupal/Drupal.php
+++ b/stubs/Drupal/Drupal.php
@@ -5,5 +5,5 @@ if (class_exists(\Drupal::class)) {
 }
 
 class Drupal {
-    const VERSION = '10.1.x-dev';
+    const VERSION = '10.2.x-dev';
 }

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
@@ -11,5 +11,6 @@ return static function (RectorConfig $rectorConfig): void {
     DeprecationBase::addClass(FunctionToStaticRector::class, $rectorConfig, false, [
         new FunctionToStaticConfiguration('8.1.0', 'file_directory_os_temp', 'Drupal\Component\FileSystem\FileSystem', 'getOsTemporaryDirectory'),
         new FunctionToStaticConfiguration('10.1.0', 'drupal_rewrite_settings', 'Drupal\Core\Site\SettingsEditor', 'rewrite', [0 => 1, 1 => 0]),
+        new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
@@ -12,6 +12,10 @@ function simple_example() {
 function simple_example_os_temp() {
     $x = file_directory_os_temp();
 }
+
+function simple_example_format_size() {
+    $size_literal = format_size(81862076662);
+}
 ?>
 -----
 <?php
@@ -27,5 +31,9 @@ function simple_example() {
  */
 function simple_example_os_temp() {
     $x = \Drupal\Component\FileSystem\FileSystem::getOsTemporaryDirectory();
+}
+
+function simple_example_format_size() {
+    $size_literal = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.2.0', fn() => format_size(81862076662), fn() => \\Drupal\Core\StringTranslation\ByteSizeMarkup::create(81862076662));
 }
 ?>


### PR DESCRIPTION
## Description
The `format_size()` function in `common.inc` is deprecated in favour of using `\Drupal\Core\StringTranslation\ByteSizeMarkup::create()` that returns `TranslatableMarkup`

## To Test


## Drupal.org issue
https://www.drupal.org/node/3413972
