### PR TITLE
Fix: double deprecated calls when already refactored

### DIFF
--- a/src/Drupal8/Rector/Deprecation/DBRector.php
+++ b/src/Drupal8/Rector/Deprecation/DBRector.php
@@ -98,37 +98,37 @@ class DBRector extends AbstractRector implements ConfigurableRectorInterface
     {
         assert($node instanceof Node\Stmt\Expression);
 
-        $isFuncCall = $node->expr instanceof Node\Expr\FuncCall;
-        $isMethodCall = $node->expr instanceof Node\Expr\MethodCall;
-        $isAssignedFuncCall = $node->expr instanceof Node\Expr\Assign && $node->expr->expr instanceof Node\Expr\FuncCall;
+        $isFuncCall = $node->expr instanceof Expr\FuncCall;
+        $isMethodCall = $node->expr instanceof MethodCall;
+        $isAssignedFuncCall = $node->expr instanceof Expr\Assign && $node->expr->expr instanceof Expr\FuncCall;
         if (!$isFuncCall && !$isAssignedFuncCall && !$isMethodCall) {
             return null;
         }
 
         foreach ($this->configuration as $configuration) {
-            if ($node->expr instanceof Node\Expr\FuncCall && $this->getName($node->expr->name) !== $configuration->getDeprecatedMethodName()) {
+            if ($node->expr instanceof Expr\FuncCall && $this->getName($node->expr->name) !== $configuration->getDeprecatedMethodName()) {
                 continue;
             }
 
-            if ($node->expr instanceof Node\Expr\Assign && $node->expr->expr instanceof Node\Expr\FuncCall && $this->getName($node->expr->expr->name) !== $configuration->getDeprecatedMethodName()) {
+            if ($node->expr instanceof Expr\Assign && $node->expr->expr instanceof Expr\FuncCall && $this->getName($node->expr->expr->name) !== $configuration->getDeprecatedMethodName()) {
                 continue;
             }
 
-            if ($node->expr instanceof Node\Expr\FuncCall) {
+            if ($node->expr instanceof Expr\FuncCall) {
                 $methodCall = $this->getMethodCall($node->expr, $node, $configuration);
                 $node->expr = $methodCall;
 
                 return $node;
             }
 
-            if ($node->expr instanceof Node\Expr\Assign && $node->expr->expr instanceof Node\Expr\FuncCall) {
+            if ($node->expr instanceof Expr\Assign && $node->expr->expr instanceof Expr\FuncCall) {
                 $methodCall = $this->getMethodCall($node->expr->expr, $node, $configuration);
                 $node->expr->expr = $methodCall;
 
                 return $node;
             }
 
-            if ($node->expr instanceof Node\Expr\MethodCall) {
+            if ($node->expr instanceof MethodCall) {
                 $funcCall = $this->findRootFuncCallForMethodCall($node->expr);
                 if ($funcCall === null || $this->getName($funcCall->name) !== $configuration->getDeprecatedMethodName()) {
                     continue;
@@ -187,7 +187,7 @@ class DBRector extends AbstractRector implements ConfigurableRectorInterface
         return null;
     }
 
-    public function getMethodCall(Node\Expr\FuncCall $expr, Node\Stmt\Expression $statement, DBConfiguration $configuration): Node\Expr\MethodCall
+    public function getMethodCall(Expr\FuncCall $expr, Node\Stmt\Expression $statement, DBConfiguration $configuration): MethodCall
     {
         // TODO: Check if we have are in a class and inject \Drupal\Core\Database\Connection
         // TODO: Check if we have are in a class and don't have access to the container, use `\Drupal\core\Database\Database::getConnection()`.
@@ -229,11 +229,11 @@ class DBRector extends AbstractRector implements ConfigurableRectorInterface
             $this->commentService->addDrupalRectorComment($statement, 'You will need to use `\Drupal\core\Database\Database::getConnection()` if you do not yet have access to the container here.');
         }
 
-        $var = new Node\Expr\StaticCall($name, $call, $method_arguments);
+        $var = new Expr\StaticCall($name, $call, $method_arguments);
 
         $method_name = new Node\Identifier(substr($configuration->getDeprecatedMethodName(), 3));
 
-        $methodCall = new Node\Expr\MethodCall($var, $method_name, $expr->args);
+        $methodCall = new MethodCall($var, $method_name, $expr->args);
 
         return $methodCall;
     }

--- a/src/Drupal8/Rector/Deprecation/EntityLoadRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityLoadRector.php
@@ -172,7 +172,7 @@ CODE_AFTER
                     if (!class_exists('\PhpParser\Node\ArrayItem')) {
                         $arrayItems = [new Node\Expr\ArrayItem($entity_id->value)];
                     } else {
-                        $arrayItems = [new \PhpParser\Node\ArrayItem($entity_id->value)];
+                        $arrayItems = [new Node\ArrayItem($entity_id->value)];
                     }
 
                     $reset_args = [

--- a/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector.php
+++ b/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector.php
@@ -67,7 +67,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param \PhpParser\Node\Stmt\Class_ $node
+     * @param Node\Stmt\Class_ $node
      */
     public function refactorWithScope(Node $node, Scope $scope): ?Node
     {

--- a/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector.php
@@ -56,7 +56,7 @@ class AssertLegacyTraitRector extends AbstractRector implements ConfigurableRect
      * @param string                         $method
      * @param array<Arg|VariadicPlaceholder> $args
      *
-     * @return \PhpParser\Node\Expr\MethodCall
+     * @return Node\Expr\MethodCall
      */
     protected function createAssertSessionMethodCall(string $method, array $args): Node\Expr\MethodCall
     {

--- a/src/Drupal9/Rector/Deprecation/AssertNoFieldByNameRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertNoFieldByNameRector.php
@@ -100,7 +100,7 @@ CODE_AFTER
      * @param string                         $method
      * @param array<Arg|VariadicPlaceholder> $args
      *
-     * @return \PhpParser\Node\Expr\MethodCall
+     * @return Node\Expr\MethodCall
      */
     protected function createAssertSessionMethodCall(string $method, array $args): Node\Expr\MethodCall
     {

--- a/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
+++ b/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
@@ -44,7 +44,7 @@ CODE_AFTER
     }
 
     /**
-     * @param \PhpParser\Node\Expr\MethodCall $node
+     * @param Node\Expr\MethodCall $node
      *
      * @throws ShouldNotHappenException
      *

--- a/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector.php
+++ b/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector.php
@@ -51,7 +51,7 @@ CODE_SAMPLE
     }
 
     /**
-     * @param \PhpParser\Node\Stmt\Property $node
+     * @param Node\Stmt\Property $node
      */
     public function refactor(Node $node): ?Node
     {

--- a/src/Rector/AbstractDrupalCoreRector.php
+++ b/src/Rector/AbstractDrupalCoreRector.php
@@ -8,7 +8,9 @@ use Drupal\Component\Utility\DeprecationHelper;
 use DrupalRector\Contract\VersionedConfigurationInterface;
 use PhpParser\Node;
 use PhpParser\Node\Expr\ArrowFunction;
+use PHPStan\Reflection\MethodReflection;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
+use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
 
 abstract class AbstractDrupalCoreRector extends AbstractRector implements ConfigurableRectorInterface
@@ -29,12 +31,41 @@ abstract class AbstractDrupalCoreRector extends AbstractRector implements Config
         $this->configuration = $configuration;
     }
 
+    protected function isInBackwardsCompatibleCall(Node $node): bool
+    {
+        if (!class_exists(DeprecationHelper::class)) {
+            return false;
+        }
+
+        $scope = $node->getAttribute(AttributeKey::SCOPE);
+
+        $callStack = $scope->getFunctionCallStackWithParameters();
+        if (count($callStack) === 0) {
+            return false;
+        }
+        [$function, $parameter] = $callStack[0];
+        if (!$function instanceof MethodReflection) {
+            return false;
+        }
+        if ($function->getName() !== 'backwardsCompatibleCall'
+            || $function->getDeclaringClass()->getName() !== DeprecationHelper::class
+        ) {
+            return false;
+        }
+
+        return $parameter !== null && $parameter->getName() === 'deprecatedCallable';
+    }
+
     public function refactor(Node $node)
     {
         $drupalVersion = str_replace(['.x-dev', '-dev'], '.0', \Drupal::VERSION);
 
         foreach ($this->configuration as $configuration) {
             if (version_compare($drupalVersion, $configuration->getIntroducedVersion(), '<')) {
+                continue;
+            }
+
+            if ($this->isInBackwardsCompatibleCall($node)) {
                 continue;
             }
 

--- a/tests/src/Drupal10/Rector/Deprecation/WatchdogExceptionRector/fixture/watchdog_exception.php.inc
+++ b/tests/src/Drupal10/Rector/Deprecation/WatchdogExceptionRector/fixture/watchdog_exception.php.inc
@@ -11,6 +11,8 @@ function advanced() {
     watchdog_exception('update', $exception, 'My custom message @foo', ['@foo' => 'bar'], RfcLogLevel::CRITICAL, 'http://example.com');
 
     watchdog_exception('update', $exception, 'My custom message @foo', ['@foo' => 'bar']);
+
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.1.0', fn() => \Drupal\Core\Utility\Error::logException(\Drupal::logger('update'), $exception), fn() => watchdog_exception('update', $exception));
 }
 ?>
 -----
@@ -27,5 +29,7 @@ function advanced() {
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.1.0', fn() => \Drupal\Core\Utility\Error::logException(\Drupal::logger('update'), $exception, 'My custom message @foo', ['@foo' => 'bar', 'link' => 'http://example.com'], RfcLogLevel::CRITICAL), fn() => watchdog_exception('update', $exception, 'My custom message @foo', ['@foo' => 'bar', 'link' => 'http://example.com'], RfcLogLevel::CRITICAL, 'http://example.com'));
 
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.1.0', fn() => \Drupal\Core\Utility\Error::logException(\Drupal::logger('update'), $exception, 'My custom message @foo', ['@foo' => 'bar']), fn() => watchdog_exception('update', $exception, 'My custom message @foo', ['@foo' => 'bar']));
+
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.1.0', fn() => \Drupal\Core\Utility\Error::logException(\Drupal::logger('update'), $exception), fn() => watchdog_exception('update', $exception));
 }
 ?>


### PR DESCRIPTION
## Description
This will fix the double deprecated calls. In the future we might need to refactor this, since something might actually need a nested deprecated call. That would be kinda nasty, but is an edge case that could happen (tm).

Codestyle is a bit noisy, annoying, but ah well.

## To Test
Run test.


## Drupal.org issue
https://www.drupal.org/project/rector/issues/3414169
