### PR TITLE
feat: add rector rule for deprecated GDToolkit 

### DIFF
--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -7,8 +7,6 @@ use DrupalRector\Rector\Deprecation\MethodToMethodWithCheckRector;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
 use DrupalRector\Rector\ValueObject\MethodToMethodWithCheckConfiguration;
 use Rector\Config\RectorConfig;
-use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
-use Rector\Renaming\ValueObject\RenameProperty;
 
 return static function (RectorConfig $rectorConfig): void {
     // https://www.drupal.org/node/2999981

--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -21,9 +21,4 @@ return static function (RectorConfig $rectorConfig): void {
         new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'getResource', 'getImage'),
         new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'setResource', 'setImage'),
     ]);
-
-    // https://www.drupal.org/node/3265963
-    $rectorConfig->ruleWithConfiguration(RenamePropertyRector::class, [
-        new RenameProperty('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'resource', 'image'),
-    ]);
 };

--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -3,12 +3,27 @@
 declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
+use DrupalRector\Rector\Deprecation\MethodToMethodWithCheckRector;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
+use DrupalRector\Rector\ValueObject\MethodToMethodWithCheckConfiguration;
 use Rector\Config\RectorConfig;
+use Rector\Renaming\Rector\PropertyFetch\RenamePropertyRector;
+use Rector\Renaming\ValueObject\RenameProperty;
 
 return static function (RectorConfig $rectorConfig): void {
     // https://www.drupal.org/node/2999981
     $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
         new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
+    ]);
+
+    // https://www.drupal.org/node/3265963
+    $rectorConfig->ruleWithConfiguration(MethodToMethodWithCheckRector::class, [
+        new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'getResource', 'getImage'),
+        new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'setResource', 'setImage'),
+    ]);
+
+    // https://www.drupal.org/node/3265963
+    $rectorConfig->ruleWithConfiguration(RenamePropertyRector::class, [
+        new RenameProperty('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'resource', 'image'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/config/configured_rule.php
@@ -11,5 +11,7 @@ return static function (RectorConfig $rectorConfig): void {
     DeprecationBase::addClass(MethodToMethodWithCheckRector::class, $rectorConfig, true, [
         new MethodToMethodWithCheckConfiguration('Drupal\Core\Session\MetadataBag', 'clearCsrfTokenSeed', 'stampNew'),
         new MethodToMethodWithCheckConfiguration('Drupal\Core\Entity\EntityInterface', 'urlInfo', 'toUrl'),
+        new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'getResource', 'getImage'),
+        new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'setResource', 'setImage'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/fixture/basic.php.inc
+++ b/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/fixture/basic.php.inc
@@ -7,6 +7,10 @@ function simple_example() {
     /** @var \Drupal\Core\Entity\EntityInterface $untranslated_entity */
     $untranslated_entity = \Drupal::entityTypeManager()->getStorage('node')->load(123);
     $form_state->setRedirectUrl($untranslated_entity->urlInfo('canonical'));
+
+    $toolkit = new \Drupal\system\Plugin\ImageToolkit\GDToolkit;
+    $toolkit->getResource();
+    $toolkit->setResource();
 }
 ?>
 -----
@@ -19,5 +23,9 @@ function simple_example() {
     /** @var \Drupal\Core\Entity\EntityInterface $untranslated_entity */
     $untranslated_entity = \Drupal::entityTypeManager()->getStorage('node')->load(123);
     $form_state->setRedirectUrl($untranslated_entity->toUrl('canonical'));
+
+    $toolkit = new \Drupal\system\Plugin\ImageToolkit\GDToolkit;
+    $toolkit->getImage();
+    $toolkit->setImage();
 }
 ?>


### PR DESCRIPTION
feat: add rector rule for deprecated GDToolkit resource methods and properties in 10.2

## Description
GDToolkit::setResource(), GDToolkit::getResource() and GDToolkit::resource are deprecated.

GDToolkit has been updated to use the GD extension classed object \GdImage instead of a generic resource.

## Todo
- There should probably be a test for `RenamePropertyRector`, but I'm not sure where to start.

## To Test
- composer test

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3416757
https://www.drupal.org/node/3265963
