### PR TITLE
refactor: Replace deprecated LevelSetLists for version specific PHPUnit, Symfony and Twig sets

### DIFF
--- a/config/drupal-10/drupal-10.0-deprecations.php
+++ b/config/drupal-10/drupal-10.0-deprecations.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 use DrupalRector\Rector\PHPUnit\ShouldCallParentMethodsRector;
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
-use Rector\Symfony\Set\SymfonyLevelSetList;
-use Rector\Symfony\Set\TwigLevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
+use Rector\Symfony\Set\SymfonySetList;
+use Rector\Symfony\Set\TwigSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
-        SymfonyLevelSetList::UP_TO_SYMFONY_62,
-        TwigLevelSetList::UP_TO_TWIG_240,
+        PHPUnitSetList::PHPUNIT_90,
+        SymfonySetList::SYMFONY_62,
+        TwigSetList::TWIG_240,
     ]);
 
     $rectorConfig->rule(ShouldCallParentMethodsRector::class);

--- a/config/drupal-10/drupal-10.1-deprecations.php
+++ b/config/drupal-10/drupal-10.1-deprecations.php
@@ -8,11 +8,11 @@ use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
 use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
 use Rector\Config\RectorConfig;
-use Rector\Symfony\Set\SymfonyLevelSetList;
+use Rector\Symfony\Set\SymfonySetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
-        SymfonyLevelSetList::UP_TO_SYMFONY_63,
+        SymfonySetList::SYMFONY_63,
     ]);
 
     // https://www.drupal.org/node/3244583

--- a/config/drupal-9/drupal-9-all-deprecations.php
+++ b/config/drupal-9/drupal-9-all-deprecations.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use DrupalRector\Services\AddCommentService;
 use DrupalRector\Set\Drupal9SetList;
 use Rector\Config\RectorConfig;
-use Rector\PHPUnit\Set\PHPUnitLevelSetList;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(AddCommentService::class, function () {
@@ -17,7 +17,7 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal9SetList::DRUPAL_92,
         Drupal9SetList::DRUPAL_93,
         Drupal9SetList::DRUPAL_94,
-        PHPUnitLevelSetList::UP_TO_PHPUNIT_90,
+        PHPUnitSetList::PHPUNIT_90,
     ]);
 
     $rectorConfig->bootstrapFiles([


### PR DESCRIPTION


## Description
In the latest [rector release 0.19.2](https://github.com/rectorphp/rector/releases/tag/0.19.2) there are some deprecations added for the Symfony/Twig/PHPUnit level sets. See https://github.com/rectorphp/rector-src/pull/5477

https://github.com/palantirnet/drupal-rector/actions/runs/7643040570/job/20824102985?pr=289

```shell
------ ------------------------------------------------------------------- 
  Line   config/drupal-10/drupal-10.0-deprecations.php                      
 ------ ------------------------------------------------------------------- 
  13     Fetching class constant UP_TO_PHPUNIT_90 of deprecated class       
         Rector\PHPUnit\Set\PHPUnitLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         PHPUnit set                                                        
  13     Fetching deprecated class constant UP_TO_PHPUNIT_90 of class       
         Rector\PHPUnit\Set\PHPUnitLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         PHPUnit set                                                        
  14     Fetching class constant UP_TO_SYMFONY_62 of deprecated class       
         Rector\Symfony\Set\SymfonyLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         Symfony set                                                        
  14     Fetching deprecated class constant UP_TO_SYMFONY_62 of class       
         Rector\Symfony\Set\SymfonyLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         Symfony set                                                        
  15     Fetching class constant UP_TO_TWIG_2[40](https://github.com/palantirnet/drupal-rector/actions/runs/7643040570/job/20824102985?pr=289#step:5:41) of deprecated class         
         Rector\Symfony\Set\TwigLevelSetList:                               
         Instead of too bloated and overriding level sets, use only latest  
         Twig set                                                           
  15     Fetching deprecated class constant UP_TO_TWIG_240 of class         
         Rector\Symfony\Set\TwigLevelSetList:                               
         Instead of too bloated and overriding level sets, use only latest  
         Twig set                                                           
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   config/drupal-10/drupal-10.1-deprecations.php                      
 ------ ------------------------------------------------------------------- 
  15     Fetching class constant UP_TO_SYMFONY_63 of deprecated class       
         Rector\Symfony\Set\SymfonyLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         Symfony set                                                        
  15     Fetching deprecated class constant UP_TO_SYMFONY_63 of class       
         Rector\Symfony\Set\SymfonyLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         Symfony set                                                        
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   config/drupal-9/drupal-9-all-deprecations.php                      
 ------ ------------------------------------------------------------------- 
  20     Fetching class constant UP_TO_PHPUNIT_90 of deprecated class       
         Rector\PHPUnit\Set\PHPUnitLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         PHPUnit set                                                        
  20     Fetching deprecated class constant UP_TO_PHPUNIT_90 of class       
         Rector\PHPUnit\Set\PHPUnitLevelSetList:                            
         Instead of too bloated and overriding level sets, use only latest  
         PHPUnit set                                                        
 ------ -------------------------------------------------------------------
``` 

## To Test
- run 'composer test'

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3416880
