### PR TITLE
Upgrade to rector/rector 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "~0.19.0",
+        "rector/rector": "^1.0",
         "webflo/drupal-finder": "^1.2"
     },
     "license": "MIT",


### PR DESCRIPTION
## Description
We are currently on `rector/rector:~0.19.0` however there is now a GA release `1.0.1`. We should update to the latest stable version, ie `^1.0`.

## To Test
Update composer, run tests.

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3423067