### PR TITLE
Add proper levels for all symfony versions deprecated in the different versions of Drupal

### DIFF
--- a/config/drupal-10/drupal-10.0-deprecations.php
+++ b/config/drupal-10/drupal-10.0-deprecations.php
@@ -11,6 +11,13 @@ use Rector\Symfony\Set\TwigSetList;
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->sets([
         PHPUnitSetList::PHPUNIT_90,
+        SymfonySetList::SYMFONY_50,
+        SymfonySetList::SYMFONY_51,
+        SymfonySetList::SYMFONY_52,
+        SymfonySetList::SYMFONY_53,
+        SymfonySetList::SYMFONY_54,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
         SymfonySetList::SYMFONY_62,
         TwigSetList::TWIG_240,
     ]);

--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -7,8 +7,13 @@ use DrupalRector\Rector\Deprecation\MethodToMethodWithCheckRector;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
 use DrupalRector\Rector\ValueObject\MethodToMethodWithCheckConfiguration;
 use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
 
 return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->sets([
+        SymfonySetList::SYMFONY_64,
+    ]);
+
     // https://www.drupal.org/node/2999981
     $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
         new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),


### PR DESCRIPTION
## Description
Since up-to setlists are no longer a thing. I've added the proper versions to the different drupal sets. Adding the new deprecated versions specifically at the Drupal core levels that are relevant.

## To Test
- You could go through: https://packagist.org/packages/drupal/core to see if the proper versions are used.

## Drupal.org issue
Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.
