### PR TITLE
New rector (10.1): drupal_theme_rebuild is deprecated 

### DIFF
--- a/config/drupal-8/drupal-8.0-deprecations.php
+++ b/config/drupal-8/drupal-8.0-deprecations.php
@@ -43,13 +43,13 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class, [
         // https://www.drupal.org/node/2418133
-        new FunctionToServiceConfiguration('drupal_realpath', 'file_system', 'realpath'),
+        new FunctionToServiceConfiguration('8.0.0', 'drupal_realpath', 'file_system', 'realpath'),
         // https://www.drupal.org/node/2912696
-        new FunctionToServiceConfiguration('drupal_render', 'renderer', 'render'),
+        new FunctionToServiceConfiguration('8.0.0', 'drupal_render', 'renderer', 'render'),
         // https://www.drupal.org/node/2912696
-        new FunctionToServiceConfiguration('drupal_render_root', 'renderer', 'renderRoot'),
+        new FunctionToServiceConfiguration('8.0.0', 'drupal_render_root', 'renderer', 'renderRoot'),
         // https://www.drupal.org/node/1876852
-        new FunctionToServiceConfiguration('format_date', 'date.formatter', 'format'),
+        new FunctionToServiceConfiguration('8.0.0', 'format_date', 'date.formatter', 'format'),
     ]);
 
     $rectorConfig->rule(EntityInterfaceLinkRector::class);

--- a/config/drupal-8/drupal-8.7-deprecations.php
+++ b/config/drupal-8/drupal-8.7-deprecations.php
@@ -15,9 +15,9 @@ return static function (RectorConfig $rectorConfig): void {
     });
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class, [
         // https://www.drupal.org/node/3006851
-        new FunctionToServiceConfiguration('file_prepare_directory', 'file_system', 'prepareDirectory'),
+        new FunctionToServiceConfiguration('8.7.0', 'file_prepare_directory', 'file_system', 'prepareDirectory'),
         // https://www.drupal.org/node/3006851
-        new FunctionToServiceConfiguration('file_unmanaged_save_data', 'file_system', 'saveData'),
+        new FunctionToServiceConfiguration('8.7.0', 'file_unmanaged_save_data', 'file_system', 'saveData'),
     ]);
 
     /**

--- a/config/drupal-8/drupal-8.8-deprecations.php
+++ b/config/drupal-8/drupal-8.8-deprecations.php
@@ -30,15 +30,15 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class,
         [
             // https://www.drupal.org/node/2835616
-            new FunctionToServiceConfiguration('entity_get_display', 'entity_display.repository', 'getViewDisplay'),
+            new FunctionToServiceConfiguration('8.8.0', 'entity_get_display', 'entity_display.repository', 'getViewDisplay'),
             // https://www.drupal.org/node/2835616
-            new FunctionToServiceConfiguration('entity_get_form_display', 'entity_display.repository', 'getFormDisplay'),
+            new FunctionToServiceConfiguration('8.8.0', 'entity_get_form_display', 'entity_display.repository', 'getFormDisplay'),
             // https://www.drupal.org/node/3039255
-            new FunctionToServiceConfiguration('file_directory_temp', 'file_system', 'getTempDirectory'),
+            new FunctionToServiceConfiguration('8.8.0', 'file_directory_temp', 'file_system', 'getTempDirectory'),
             // https://www.drupal.org/node/3038437
-            new FunctionToServiceConfiguration('file_scan_directory', 'file_system', 'scanDirectory'),
+            new FunctionToServiceConfiguration('8.8.0', 'file_scan_directory', 'file_system', 'scanDirectory'),
             // https://www.drupal.org/node/3035273
-            new FunctionToServiceConfiguration('file_uri_target', 'stream_wrapper_manager', 'getTarget'),
+            new FunctionToServiceConfiguration('8.8.0', 'file_uri_target', 'stream_wrapper_manager', 'getTarget'),
         ]);
 
     $rectorConfig->ruleWithConfiguration(MethodToMethodWithCheckRector::class, [

--- a/config/drupal-9/drupal-9.3-deprecations.php
+++ b/config/drupal-9/drupal-9.3-deprecations.php
@@ -39,11 +39,11 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Change record: https://www.drupal.org/node/3223520
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class, [
-        new FunctionToServiceConfiguration('file_copy', 'file.repository', 'copy'),
-        new FunctionToServiceConfiguration('file_move', 'file.repository', 'move'),
-        new FunctionToServiceConfiguration('file_save_data', 'file.repository', 'writeData'),
+        new FunctionToServiceConfiguration('9.3.0', 'file_copy', 'file.repository', 'copy'),
+        new FunctionToServiceConfiguration('9.3.0', 'file_move', 'file.repository', 'move'),
+        new FunctionToServiceConfiguration('9.3.0', 'file_save_data', 'file.repository', 'writeData'),
         // Change record: https://www.drupal.org/node/2939099
-        new FunctionToServiceConfiguration('render', 'renderer', 'render'),
+        new FunctionToServiceConfiguration('9.3.0', 'render', 'renderer', 'render'),
     ]);
 
     // Change record: https://www.drupal.org/node/3223091.

--- a/src/Rector/Deprecation/FunctionToServiceRector.php
+++ b/src/Rector/Deprecation/FunctionToServiceRector.php
@@ -8,8 +8,6 @@ use DrupalRector\Contract\VersionedConfigurationInterface;
 use DrupalRector\Rector\AbstractDrupalCoreRector;
 use DrupalRector\Rector\ValueObject\FunctionToServiceConfiguration;
 use PhpParser\Node;
-use Rector\Contract\Rector\ConfigurableRectorInterface;
-use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -58,14 +56,14 @@ class FunctionToServiceRector extends AbstractDrupalCoreRector
         assert($configuration instanceof FunctionToServiceConfiguration);
         assert($node instanceof Node\Expr\FuncCall);
 
-            if ($this->getName($node->name) === $configuration->getDeprecatedFunctionName()) {
-                // This creates a service call like `\Drupal::service('file_system').
-                $service = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'), 'service', [new Node\Arg(new Node\Scalar\String_($configuration->getServiceName()))]);
+        if ($this->getName($node->name) === $configuration->getDeprecatedFunctionName()) {
+            // This creates a service call like `\Drupal::service('file_system').
+            $service = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'), 'service', [new Node\Arg(new Node\Scalar\String_($configuration->getServiceName()))]);
 
-                $method_name = new Node\Identifier($configuration->getServiceMethodName());
+            $method_name = new Node\Identifier($configuration->getServiceMethodName());
 
-                return new Node\Expr\MethodCall($service, $method_name, $node->args);
-            }
+            return new Node\Expr\MethodCall($service, $method_name, $node->args);
+        }
 
         return null;
     }
@@ -268,7 +266,7 @@ $date = \Drupal::service('date.formatter')->format($timestamp, $type, $format, $
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('8.0.0' , 'format_date', 'date.formatter', 'format'),
+                    new FunctionToServiceConfiguration('8.0.0', 'format_date', 'date.formatter', 'format'),
                 ]
             ),
             new ConfiguredCodeSample(

--- a/src/Rector/Deprecation/FunctionToServiceRector.php
+++ b/src/Rector/Deprecation/FunctionToServiceRector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace DrupalRector\Rector\Deprecation;
 
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
 use DrupalRector\Rector\ValueObject\FunctionToServiceConfiguration;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
@@ -20,12 +22,12 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Dependency injection
  */
-class FunctionToServiceRector extends AbstractRector implements ConfigurableRectorInterface
+class FunctionToServiceRector extends AbstractDrupalCoreRector
 {
     /**
      * @var FunctionToServiceConfiguration[]
      */
-    private array $functionToServiceConfigs;
+    protected array $configuration;
 
     public function configure(array $configuration): void
     {
@@ -35,7 +37,7 @@ class FunctionToServiceRector extends AbstractRector implements ConfigurableRect
             }
         }
 
-        $this->functionToServiceConfigs = $configuration;
+        $this->configuration = $configuration;
     }
 
     /**
@@ -51,10 +53,11 @@ class FunctionToServiceRector extends AbstractRector implements ConfigurableRect
     /**
      * {@inheritdoc}
      */
-    public function refactor(Node $node): ?Node
+    public function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
     {
-        foreach ($this->functionToServiceConfigs as $configuration) {
-            /** @var Node\Expr\FuncCall $node */
+        assert($configuration instanceof FunctionToServiceConfiguration);
+        assert($node instanceof Node\Expr\FuncCall);
+
             if ($this->getName($node->name) === $configuration->getDeprecatedFunctionName()) {
                 // This creates a service call like `\Drupal::service('file_system').
                 $service = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'), 'service', [new Node\Arg(new Node\Scalar\String_($configuration->getServiceName()))]);
@@ -63,7 +66,6 @@ class FunctionToServiceRector extends AbstractRector implements ConfigurableRect
 
                 return new Node\Expr\MethodCall($service, $method_name, $node->args);
             }
-        }
 
         return null;
     }
@@ -82,7 +84,7 @@ $path = \Drupal::service('file_system')
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('drupal_realpath', 'file_system', 'realpath'),
+                    new FunctionToServiceConfiguration('8.0.0', 'drupal_realpath', 'file_system', 'realpath'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -95,7 +97,7 @@ $result = \Drupal::service('renderer')->render($elements);
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('drupal_render', 'renderer', 'render'),
+                    new FunctionToServiceConfiguration('8.0.0', 'drupal_render', 'renderer', 'render'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -108,7 +110,7 @@ $result = \Drupal::service('renderer')->renderRoot($elements);
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('drupal_render_root', 'renderer', 'renderRoot'),
+                    new FunctionToServiceConfiguration('8.0.0', 'drupal_render_root', 'renderer', 'renderRoot'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -122,7 +124,7 @@ $display = \Drupal::service('entity_display.repository')
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('entity_get_display', 'entity_display.repository', 'getViewDisplay'),
+                    new FunctionToServiceConfiguration('8.8.0', 'entity_get_display', 'entity_display.repository', 'getViewDisplay'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -136,7 +138,7 @@ $display = \Drupal::service('entity_display.repository')
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('entity_get_form_display', 'entity_display.repository', 'getFormDisplay'),
+                    new FunctionToServiceConfiguration('8.8.0', 'entity_get_form_display', 'entity_display.repository', 'getFormDisplay'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -149,7 +151,7 @@ CODE_BEFORE
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_copy', 'file.repository', 'copy'),
+                    new FunctionToServiceConfiguration('9.3.0', 'file_copy', 'file.repository', 'copy'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -162,7 +164,7 @@ $dir = \Drupal::service('file_system')->getTempDirectory();
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_directory_temp', 'file_system', 'getTempDirectory'),
+                    new FunctionToServiceConfiguration('8.0.0', 'file_directory_temp', 'file_system', 'getTempDirectory'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -175,7 +177,7 @@ CODE_BEFORE
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_move', 'file.repository', 'move'),
+                    new FunctionToServiceConfiguration('9.3.0', 'file_move', 'file.repository', 'move'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -188,7 +190,7 @@ $result = \Drupal::service('file_system')->prepareDirectory($directory, $options
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_prepare_directory', 'file_system', 'prepareDirectory'),
+                    new FunctionToServiceConfiguration('8.7.0', 'file_prepare_directory', 'file_system', 'prepareDirectory'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -201,7 +203,7 @@ CODE_BEFORE
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_save_data', 'file.repository', 'writeData'),
+                    new FunctionToServiceConfiguration('8.7.0', 'file_save_data', 'file.repository', 'writeData'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -214,7 +216,7 @@ $files = \Drupal::service('file_system')->scanDirectory($directory);
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_scan_directory', 'file_system', 'scanDirectory'),
+                    new FunctionToServiceConfiguration('8.8.0', 'file_scan_directory', 'file_system', 'scanDirectory'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -227,7 +229,7 @@ $result = \Drupal::service('file_system')->saveData($data, $destination, $replac
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_unmanaged_save_data', 'file_system', 'saveData'),
+                    new FunctionToServiceConfiguration('9.3.0', 'file_unmanaged_save_data', 'file_system', 'saveData'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -240,7 +242,7 @@ $result = \Drupal::service('stream_wrapper_manager')->getTarget($uri);
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('file_uri_target', 'stream_wrapper_manager', 'getTarget'),
+                    new FunctionToServiceConfiguration('8.8.0', 'file_uri_target', 'stream_wrapper_manager', 'getTarget'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -253,7 +255,7 @@ $date = \Drupal::service('date.formatter')->format($timestamp, $type, $format, $
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('format_date', 'date.formatter', 'format'),
+                    new FunctionToServiceConfiguration('8.0.0', 'format_date', 'date.formatter', 'format'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -266,7 +268,7 @@ $date = \Drupal::service('date.formatter')->format($timestamp, $type, $format, $
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('format_date', 'date.formatter', 'format'),
+                    new FunctionToServiceConfiguration('8.0.0' , 'format_date', 'date.formatter', 'format'),
                 ]
             ),
             new ConfiguredCodeSample(
@@ -279,7 +281,7 @@ $output = \Drupal::service('renderer')->render($build);
 CODE_AFTER
                 ,
                 [
-                    new FunctionToServiceConfiguration('render', 'renderer', 'render'),
+                    new FunctionToServiceConfiguration('9.3.0', 'render', 'renderer', 'render'),
                 ]
             ),
         ]);

--- a/src/Rector/ValueObject/FunctionToServiceConfiguration.php
+++ b/src/Rector/ValueObject/FunctionToServiceConfiguration.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace DrupalRector\Rector\ValueObject;
 
-class FunctionToServiceConfiguration
+use DrupalRector\Contract\VersionedConfigurationInterface;
+
+class FunctionToServiceConfiguration implements VersionedConfigurationInterface
 {
     /**
      * The deprecated function name.
@@ -21,11 +23,14 @@ class FunctionToServiceConfiguration
      */
     protected string $serviceMethodName;
 
-    public function __construct(string $deprecatedFunctionName, string $serviceName, string $serviceMethodName)
+    protected string $introducedVersion;
+
+    public function __construct(string $introducedVersion, string $deprecatedFunctionName, string $serviceName, string $serviceMethodName)
     {
         $this->deprecatedFunctionName = $deprecatedFunctionName;
         $this->serviceName = $serviceName;
         $this->serviceMethodName = $serviceMethodName;
+        $this->introducedVersion = $introducedVersion;
     }
 
     public function getDeprecatedFunctionName(): string
@@ -42,4 +47,9 @@ class FunctionToServiceConfiguration
     {
         return $this->serviceMethodName;
     }
+
+    public function getIntroducedVersion(): string {
+        return $this->introducedVersion;
+    }
+
 }

--- a/src/Rector/ValueObject/FunctionToServiceConfiguration.php
+++ b/src/Rector/ValueObject/FunctionToServiceConfiguration.php
@@ -48,8 +48,8 @@ class FunctionToServiceConfiguration implements VersionedConfigurationInterface
         return $this->serviceMethodName;
     }
 
-    public function getIntroducedVersion(): string {
+    public function getIntroducedVersion(): string
+    {
         return $this->introducedVersion;
     }
-
 }

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
@@ -9,9 +9,10 @@ use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
     DeprecationBase::addClass(FunctionToServiceRector::class, $rectorConfig, false, [
-        new FunctionToServiceConfiguration('render', 'renderer', 'render'),
-        new FunctionToServiceConfiguration('file_copy', 'file.repository', 'copy'),
-        new FunctionToServiceConfiguration('file_move', 'file.repository', 'move'),
-        new FunctionToServiceConfiguration('file_save_data', 'file.repository', 'writeData'),
+        new FunctionToServiceConfiguration('9.3.0', 'render', 'renderer', 'render'),
+        new FunctionToServiceConfiguration('8.0.0', 'file_copy', 'file.repository', 'copy'),
+        new FunctionToServiceConfiguration('9.3.0', 'file_move', 'file.repository', 'move'),
+        new FunctionToServiceConfiguration('9.3.0', 'file_save_data', 'file.repository', 'writeData'),
+        new FunctionToServiceConfiguration('10.1.0', 'drupal_theme_rebuild', 'theme.registry', 'reset'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/drupal_theme_rebuild.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/drupal_theme_rebuild.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Implements hook_install().
+ */
+function append_file_info_install() {
+  require_once DRUPAL_ROOT . '/includes/theme.inc';
+  drupal_theme_rebuild();
+}
+
+-----
+<?php
+
+/**
+ * Implements hook_install().
+ */
+function append_file_info_install() {
+  require_once DRUPAL_ROOT . '/includes/theme.inc';
+  \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.1.0', fn() => \Drupal::service('theme.registry')->reset(), fn() => drupal_theme_rebuild());
+}
+


### PR DESCRIPTION
## Description
Rector for drupal_theme_rebuild. Also refactor FunctionToServiceRector to allow BC patched. 

See: https://github.com/mglaman/drupal-change-record-triage/issues/435

## To Test
- Run tests

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3427029
