### PR TITLE
Upgrade project tooling to PHP 8.2

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -15,7 +15,7 @@ jobs:
           -   uses: actions/checkout@v3
           -   uses: shivammathur/setup-php@v2
               with:
-                  php-version: 8.1
+                  php-version: 8.2
                   coverage: none # disable xdebug, pcov
                   tools: composer:v2
                   extensions: zip

--- a/.github/workflows/functional_test__rector_examples.yml
+++ b/.github/workflows/functional_test__rector_examples.yml
@@ -30,6 +30,9 @@ jobs:
                     - php-version: "8.1"
                       drupal: "^10.0"
                       fixture: "d10"
+                    - php-version: "8.2"
+                      drupal: "^10.0"
+                      fixture: "d10"
         runs-on: ubuntu-latest
         steps:
             -   uses: actions/checkout@v3

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -19,7 +19,7 @@ jobs:
             -   uses: actions/checkout@v3
             -   uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: none # disable xdebug, pcov
                     tools: composer:v2
                     extensions: dom, curl, libxml, mbstring, zip, pdo, mysql, pdo_mysql, bcmath, gd, exif, iconv

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - "8.1"
+                    - "8.2"
         steps:
             -   uses: actions/checkout@v3
             -   uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
         "enable-patching": true
     },
     "require-dev": {
-        "php": "^8.1",
+        "php": "^8.2",
         "cweagans/composer-patches": "^1.7.2",
         "friendsofphp/php-cs-fixer": "^3.38",
         "phpstan/extension-installer": "^1.1",

--- a/composer.json
+++ b/composer.json
@@ -76,13 +76,13 @@
     "require-dev": {
         "php": "^8.2",
         "cweagans/composer-patches": "^1.7.2",
-        "friendsofphp/php-cs-fixer": "^3.38",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan": "^1.0",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpunit/phpunit": "^10.0",
         "symfony/yaml": "^5 || ^6",
-        "symplify/rule-doc-generator": "^12.0",
+        "symplify/rule-doc-generator": "dev-main",
         "symplify/vendor-patches": "^11.0"
     },
     "scripts": {

--- a/src/Drupal8/Rector/Deprecation/DrupalLRector.php
+++ b/src/Drupal8/Rector/Deprecation/DrupalLRector.php
@@ -46,7 +46,7 @@ CODE_AFTER
     public function getNodeTypes(): array
     {
         return [
-           Node\Expr\StaticCall::class,
+            Node\Expr\StaticCall::class,
         ];
     }
 

--- a/src/Drupal8/Rector/Deprecation/SafeMarkupFormatRector.php
+++ b/src/Drupal8/Rector/Deprecation/SafeMarkupFormatRector.php
@@ -27,15 +27,15 @@ final class SafeMarkupFormatRector extends AbstractRector
     public function getRuleDefinition(): RuleDefinition
     {
         return new RuleDefinition('Fixes deprecated SafeMarkup::format() calls', [
-          new CodeSample(
-              <<<'CODE_BEFORE'
+            new CodeSample(
+                <<<'CODE_BEFORE'
 $safe_string_markup_object = \Drupal\Component\Utility\SafeMarkup::format('hello world');
 CODE_BEFORE
-              ,
-              <<<'CODE_AFTER'
+                ,
+                <<<'CODE_AFTER'
 $safe_string_markup_object = new \Drupal\Component\Render\FormattableMarkup('hello world');
 CODE_AFTER
-          ),
+            ),
         ]);
     }
 
@@ -45,7 +45,7 @@ CODE_AFTER
     public function getNodeTypes(): array
     {
         return [
-          Node\Expr\StaticCall::class,
+            Node\Expr\StaticCall::class,
         ];
     }
 


### PR DESCRIPTION
## Description
Update composer requirements and github task runners to use PHP 8.2


## To Test
- Tests are automated, but should be repeated locally
- Checkout this branch and

```
rm -rf vendor
rm composer.lock
composer install
composer test
composer phpstan
composer check-style
composer fix-style
```

All should run without issue. However, I am getting this error locally using PHP 8.2.16:

```
composer check-style

> vendor/bin/php-cs-fixer check
PHP Fatal error:  Uncaught TypeError: PhpCsFixer\FixerFactory::registerFixer(): Argument #1 ($fixer) must be of type PhpCsFixer\Fixer\FixerInterface, PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer given, called in /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/src/FixerFactory.php on line 100 and defined in /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/src/FixerFactory.php:123
Stack trace:
#0 /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/src/FixerFactory.php(100): PhpCsFixer\FixerFactory->registerFixer(Object(PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer), false)
#1 /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/src/Console/Command/DescribeCommand.php(79): PhpCsFixer\FixerFactory->registerBuiltInFixers()
#2 /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/src/Console/Application.php(56): PhpCsFixer\Console\Command\DescribeCommand->__construct()
#3 /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/php-cs-fixer(101): PhpCsFixer\Console\Application->__construct()
#4 /Users/rickard/Sites/drupal-rector/vendor/bin/php-cs-fixer(119): include('/Users/rickard/...')
#5 {main}
  thrown in /Users/rickard/Sites/drupal-rector/vendor/friendsofphp/php-cs-fixer/src/FixerFactory.php on line 123
```


## Drupal.org issue
https://www.drupal.org/project/rector/issues/3437018