### PR TITLE
bugfix: remove extra \ from Drupal\Core\StringTranslation\ByteSizeMarkup rector

### DIFF
--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -16,7 +16,7 @@ return static function (RectorConfig $rectorConfig): void {
 
     // https://www.drupal.org/node/2999981
     $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
-        new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
+        new FunctionToStaticConfiguration('10.2.0', 'format_size', 'Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
     ]);
 
     // https://www.drupal.org/node/3265963

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
@@ -11,6 +11,6 @@ return static function (RectorConfig $rectorConfig): void {
     DeprecationBase::addClass(FunctionToStaticRector::class, $rectorConfig, false, [
         new FunctionToStaticConfiguration('8.1.0', 'file_directory_os_temp', 'Drupal\Component\FileSystem\FileSystem', 'getOsTemporaryDirectory'),
         new FunctionToStaticConfiguration('10.1.0', 'drupal_rewrite_settings', 'Drupal\Core\Site\SettingsEditor', 'rewrite', [0 => 1, 1 => 0]),
-        new FunctionToStaticConfiguration('10.2.0', 'format_size', '\Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
+        new FunctionToStaticConfiguration('10.2.0', 'format_size', 'Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
@@ -34,6 +34,6 @@ function simple_example_os_temp() {
 }
 
 function simple_example_format_size() {
-    $size_literal = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.2.0', fn() => \\Drupal\Core\StringTranslation\ByteSizeMarkup::create(81862076662), fn() => format_size(81862076662));
+    $size_literal = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.2.0', fn() => \Drupal\Core\StringTranslation\ByteSizeMarkup::create(81862076662), fn() => format_size(81862076662));
 }
 ?>


### PR DESCRIPTION
## Description
Found a bug, double slash, appearantly overlooked in the test o_O
