### PR TITLE
New rector: Rector for _drupal_flush_css_js through new VersionedFunctionToServiceRector

### DIFF
--- a/config/drupal-10/drupal-10.2-deprecations.php
+++ b/config/drupal-10/drupal-10.2-deprecations.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Drupal10\Rector\Deprecation\VersionedFunctionToServiceRector;
+use DrupalRector\Drupal10\Rector\ValueObject\VersionedFunctionToServiceConfiguration;
 use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
 use DrupalRector\Rector\Deprecation\MethodToMethodWithCheckRector;
 use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
@@ -23,5 +25,10 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(MethodToMethodWithCheckRector::class, [
         new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'getResource', 'getImage'),
         new MethodToMethodWithCheckConfiguration('Drupal\system\Plugin\ImageToolkit\GDToolkit', 'setResource', 'setImage'),
+    ]);
+
+    // https://www.drupal.org/node/3358337
+    $rectorConfig->ruleWithConfiguration(VersionedFunctionToServiceRector::class, [
+        new VersionedFunctionToServiceConfiguration('10.2.0', '_drupal_flush_css_js', 'asset.query_string', 'reset'),
     ]);
 };

--- a/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector.php
+++ b/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal10\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Drupal10\Rector\ValueObject\VersionedFunctionToServiceConfiguration;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use PhpParser\Node;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces deprecated function call with service method call with backwards compatibility.
+ */
+class VersionedFunctionToServiceRector extends AbstractDrupalCoreRector
+{
+    /**
+     * @var array|VersionedFunctionToServiceConfiguration[]
+     */
+    protected array $configurations = [];
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!($value instanceof VersionedFunctionToServiceConfiguration)) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', VersionedFunctionToServiceConfiguration::class));
+            }
+        }
+
+        parent::configure($configuration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    /**
+     * @param Node\Expr\FuncCall                      $node
+     * @param VersionedFunctionToServiceConfiguration $configuration
+     *
+     * @return Node|null
+     */
+    public function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        /** @var Node\Expr\FuncCall $node */
+        if ($this->getName($node->name) === $configuration->getDeprecatedFunctionName()) {
+            // This creates a service call like `\Drupal::service('file_system').
+            $service = new Node\Expr\StaticCall(new Node\Name\FullyQualified('Drupal'), 'service', [new Node\Arg(new Node\Scalar\String_($configuration->getServiceName()))]);
+
+            $method_name = new Node\Identifier($configuration->getServiceMethodName());
+
+            return new Node\Expr\MethodCall($service, $method_name, $node->args);
+        }
+
+        return null;
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition('Fixes deprecated function to service calls, used in Drupal 8 and 9 deprecations', [
+            new ConfiguredCodeSample(
+                <<<'CODE_BEFORE'
+_drupal_flush_css_js();
+CODE_BEFORE
+                ,
+                <<<'CODE_AFTER'
+\Drupal::service('asset.query_string')->reset();
+CODE_AFTER
+                ,
+                [
+                    new VersionedFunctionToServiceConfiguration('10.2.0', '_drupal_flush_css_js', 'asset.query_string', 'reset'),
+                ]
+            ),
+        ]);
+    }
+}

--- a/src/Drupal10/Rector/ValueObject/VersionedFunctionToServiceConfiguration.php
+++ b/src/Drupal10/Rector/ValueObject/VersionedFunctionToServiceConfiguration.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal10\Rector\ValueObject;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+
+class VersionedFunctionToServiceConfiguration implements VersionedConfigurationInterface
+{
+    /**
+     * The deprecated function name.
+     */
+    protected string $deprecatedFunctionName;
+
+    /**
+     * The replacement service name.
+     */
+    protected string $serviceName;
+
+    /**
+     * The replacement service method.
+     */
+    protected string $serviceMethodName;
+
+    protected string $introducedVersion;
+
+    public function __construct(string $introducedVersion, string $deprecatedFunctionName, string $serviceName, string $serviceMethodName)
+    {
+        $this->deprecatedFunctionName = $deprecatedFunctionName;
+        $this->serviceName = $serviceName;
+        $this->serviceMethodName = $serviceMethodName;
+        $this->introducedVersion = $introducedVersion;
+    }
+
+    public function getDeprecatedFunctionName(): string
+    {
+        return $this->deprecatedFunctionName;
+    }
+
+    public function getServiceName(): string
+    {
+        return $this->serviceName;
+    }
+
+    public function getServiceMethodName(): string
+    {
+        return $this->serviceMethodName;
+    }
+
+    public function getIntroducedVersion(): string
+    {
+        return $this->introducedVersion;
+    }
+}

--- a/tests/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector/VersionedFunctionToServiceRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector/VersionedFunctionToServiceRectorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\VersionedFunctionToServiceRector;
+
+use Iterator;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+class VersionedFunctionToServiceRectorTest extends AbstractRectorTestCase
+{
+    /**
+     * @covers ::refactor
+     *
+     * @dataProvider provideData
+     */
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        // must be implemented
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector/config/configured_rule.php
+++ b/tests/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal10\Rector\Deprecation\VersionedFunctionToServiceRector;
+use DrupalRector\Drupal10\Rector\ValueObject\VersionedFunctionToServiceConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(VersionedFunctionToServiceRector::class, $rectorConfig, false, [
+        new VersionedFunctionToServiceConfiguration('10.2.0', '_drupal_flush_css_js', 'asset.query_string', 'reset'),
+    ]);
+};

--- a/tests/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector/fixture/fixture.php.inc
+++ b/tests/src/Drupal10/Rector/Deprecation/VersionedFunctionToServiceRector/fixture/fixture.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+function simple_example() {
+    _drupal_flush_css_js();
+}
+?>
+-----
+<?php
+
+function simple_example() {
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.2.0', fn() => \Drupal::service('asset.query_string')->reset(), fn() => _drupal_flush_css_js());
+}
+?>


### PR DESCRIPTION
## Description
New rector class for function to service with an introduced version. 

Targets: https://www.drupal.org/node/3358337
See: https://github.com/mglaman/drupal-change-record-triage/issues/588

## To Test
- There are tests

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3441711
