### PR TITLE
New rector (10.3): Add rule for file_icon_class() and file_icon_map()

### DIFF
--- a/config/drupal-10/drupal-10-all-deprecations.php
+++ b/config/drupal-10/drupal-10-all-deprecations.php
@@ -10,6 +10,7 @@ return static function (RectorConfig $rectorConfig): void {
         Drupal10SetList::DRUPAL_100,
         Drupal10SetList::DRUPAL_101,
         Drupal10SetList::DRUPAL_102,
+        Drupal10SetList::DRUPAL_103,
     ]);
 
     $rectorConfig->bootstrapFiles([

--- a/config/drupal-10/drupal-10.3-deprecations.php
+++ b/config/drupal-10/drupal-10.3-deprecations.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
+use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    // https://www.drupal.org/node/3411269 file_icon_class, file_icon_map
+    $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
+        new FunctionToStaticConfiguration('10.3.0', 'file_icon_class', 'Drupal\file\IconMimeTypes', 'getIconClass'),
+        new FunctionToStaticConfiguration('10.3.0', 'file_icon_map', 'Drupal\file\IconMimeTypes', 'getGenericMimeType'),
+    ]);
+};

--- a/src/Set/Drupal10SetList.php
+++ b/src/Set/Drupal10SetList.php
@@ -12,4 +12,5 @@ final class Drupal10SetList implements SetListInterface
     public const DRUPAL_100 = __DIR__.'/../../config/drupal-10/drupal-10.0-deprecations.php';
     public const DRUPAL_101 = __DIR__.'/../../config/drupal-10/drupal-10.1-deprecations.php';
     public const DRUPAL_102 = __DIR__.'/../../config/drupal-10/drupal-10.2-deprecations.php';
+    public const DRUPAL_103 = __DIR__.'/../../config/drupal-10/drupal-10.3-deprecations.php';
 }

--- a/stubs/Drupal/Drupal.php
+++ b/stubs/Drupal/Drupal.php
@@ -5,5 +5,5 @@ if (class_exists(\Drupal::class)) {
 }
 
 class Drupal {
-    const VERSION = '10.2.x-dev';
+    const VERSION = '10.99.x-dev';
 }

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
@@ -14,5 +14,6 @@ return static function (RectorConfig $rectorConfig): void {
         new FunctionToServiceConfiguration('9.3.0', 'file_move', 'file.repository', 'move'),
         new FunctionToServiceConfiguration('9.3.0', 'file_save_data', 'file.repository', 'writeData'),
         new FunctionToServiceConfiguration('10.1.0', 'drupal_theme_rebuild', 'theme.registry', 'reset'),
+        new FunctionToServiceConfiguration('10.2.0', '_drupal_flush_css_js', 'asset.query_string', 'reset'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
@@ -12,5 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
         new FunctionToStaticConfiguration('8.1.0', 'file_directory_os_temp', 'Drupal\Component\FileSystem\FileSystem', 'getOsTemporaryDirectory'),
         new FunctionToStaticConfiguration('10.1.0', 'drupal_rewrite_settings', 'Drupal\Core\Site\SettingsEditor', 'rewrite', [0 => 1, 1 => 0]),
         new FunctionToStaticConfiguration('10.2.0', 'format_size', 'Drupal\Core\StringTranslation\ByteSizeMarkup', 'create'),
+        new FunctionToStaticConfiguration('10.3.0', 'file_icon_class', 'Drupal\file\IconMimeTypes', 'getIconClass'),
+        new FunctionToStaticConfiguration('10.3.0', 'file_icon_map', 'Drupal\file\IconMimeTypes', 'getGenericMimeType'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/function_to_static_call.php.inc
@@ -16,6 +16,16 @@ function simple_example_os_temp() {
 function simple_example_format_size() {
     $size_literal = format_size(81862076662);
 }
+
+function simple_example_file_icon_class() {
+    $mime_type = 'application/pdf';
+    $classes = [
+        'file',
+        'file--' . file_icon_class($mime_type),
+    ];
+
+    $generic_mime = file_icon_map($mime_type);
+}
 ?>
 -----
 <?php
@@ -35,5 +45,15 @@ function simple_example_os_temp() {
 
 function simple_example_format_size() {
     $size_literal = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.2.0', fn() => \Drupal\Core\StringTranslation\ByteSizeMarkup::create(81862076662), fn() => format_size(81862076662));
+}
+
+function simple_example_file_icon_class() {
+    $mime_type = 'application/pdf';
+    $classes = [
+        'file',
+        'file--' . \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.3.0', fn() => \Drupal\file\IconMimeTypes::getIconClass($mime_type), fn() => file_icon_class($mime_type)),
+    ];
+
+    $generic_mime = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '10.3.0', fn() => \Drupal\file\IconMimeTypes::getGenericMimeType($mime_type), fn() => file_icon_map($mime_type));
 }
 ?>


### PR DESCRIPTION
## Description
`file_icon_class()` and `file_icon_map()` are deprecated and replaced with static methods on `\Drupal\file\IconMimeTypes`. I've used the existing `FunctionToStaticConfiguration` to replace the deprecated functions.

@bbrala mentioned that `stubs/Drupal/Drupal.php` should be upped to `10.99.x-dev` because we always need to run the tests in this major.

## To Test
- run `composer test`

## Drupal.org issue
https://www.drupal.org/project/rector/issues/3450324
https://www.drupal.org/node/3411269
