### PR TITLE
fix: remove deprecated SetInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -155,27 +155,3 @@ parameters:
 			"""
 			count: 1
 			path: src/Drupal9/Rector/Deprecation/PassRector.php
-
-		-
-			message: """
-				#^Class DrupalRector\\\\Set\\\\Drupal10SetList implements deprecated interface Rector\\\\Set\\\\Contract\\\\SetListInterface\\:
-				This interface needs a reflection to load and uses constant links\\. Now we changed to services provider architecture that can be used and registerd easily\\. Use$#
-			"""
-			count: 1
-			path: src/Set/Drupal10SetList.php
-
-		-
-			message: """
-				#^Class DrupalRector\\\\Set\\\\Drupal8SetList implements deprecated interface Rector\\\\Set\\\\Contract\\\\SetListInterface\\:
-				This interface needs a reflection to load and uses constant links\\. Now we changed to services provider architecture that can be used and registerd easily\\. Use$#
-			"""
-			count: 1
-			path: src/Set/Drupal8SetList.php
-
-		-
-			message: """
-				#^Class DrupalRector\\\\Set\\\\Drupal9SetList implements deprecated interface Rector\\\\Set\\\\Contract\\\\SetListInterface\\:
-				This interface needs a reflection to load and uses constant links\\. Now we changed to services provider architecture that can be used and registerd easily\\. Use$#
-			"""
-			count: 1
-			path: src/Set/Drupal9SetList.php

--- a/src/Drupal8/Rector/Deprecation/DBRector.php
+++ b/src/Drupal8/Rector/Deprecation/DBRector.php
@@ -56,7 +56,7 @@ class DBRector extends AbstractRector implements ConfigurableRectorInterface
     protected $optionsArgumentPosition;
 
     /**
-     * @var \DrupalRector\Drupal8\Rector\ValueObject\DBConfiguration[]
+     * @var DBConfiguration[]
      */
     private array $configuration;
 

--- a/src/Drupal8/Rector/Deprecation/DrupalServiceRenameRector.php
+++ b/src/Drupal8/Rector/Deprecation/DrupalServiceRenameRector.php
@@ -14,7 +14,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 class DrupalServiceRenameRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var \DrupalRector\Drupal8\Rector\ValueObject\DrupalServiceRenameConfiguration[]
+     * @var DrupalServiceRenameConfiguration[]
      */
     protected array $staticArgumentRenameConfigs = [];
 

--- a/src/Drupal8/Rector/Deprecation/EntityLoadRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityLoadRector.php
@@ -27,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 final class EntityLoadRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var \DrupalRector\Drupal8\Rector\ValueObject\EntityLoadConfiguration[]
+     * @var EntityLoadConfiguration[]
      */
     protected array $entityTypes;
 

--- a/src/Drupal9/Rector/Deprecation/ExtensionPathRector.php
+++ b/src/Drupal9/Rector/Deprecation/ExtensionPathRector.php
@@ -15,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 class ExtensionPathRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var \DrupalRector\Drupal9\Rector\ValueObject\ExtensionPathConfiguration[]
+     * @var ExtensionPathConfiguration[]
      */
     private array $configuration;
 

--- a/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
+++ b/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
@@ -48,7 +48,7 @@ CODE_AFTER
      *
      * @throws ShouldNotHappenException
      *
-     * @return array<int, ?\PhpParser\Node\Arg>
+     * @return array<int, ?Node\Arg>
      */
     private function safeArgDestructure(Node\Expr\MethodCall $node): array
     {

--- a/src/Rector/AbstractDrupalCoreRector.php
+++ b/src/Rector/AbstractDrupalCoreRector.php
@@ -16,7 +16,7 @@ use Rector\Rector\AbstractRector;
 abstract class AbstractDrupalCoreRector extends AbstractRector implements ConfigurableRectorInterface
 {
     /**
-     * @var array|\DrupalRector\Contract\VersionedConfigurationInterface[]
+     * @var array|VersionedConfigurationInterface[]
      */
     protected array $configuration = [];
 

--- a/src/Set/Drupal10SetList.php
+++ b/src/Set/Drupal10SetList.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DrupalRector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-final class Drupal10SetList implements SetListInterface
+final class Drupal10SetList
 {
     public const DRUPAL_10 = __DIR__.'/../../config/drupal-10/drupal-10-all-deprecations.php';
     public const DRUPAL_100 = __DIR__.'/../../config/drupal-10/drupal-10.0-deprecations.php';

--- a/src/Set/Drupal8SetList.php
+++ b/src/Set/Drupal8SetList.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DrupalRector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-final class Drupal8SetList implements SetListInterface
+final class Drupal8SetList
 {
     public const DRUPAL_8 = __DIR__.'/../../config/drupal-8/drupal-8-all-deprecations.php';
     public const DRUPAL_80 = __DIR__.'/../../config/drupal-8/drupal-8.0-deprecations.php';

--- a/src/Set/Drupal9SetList.php
+++ b/src/Set/Drupal9SetList.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace DrupalRector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-final class Drupal9SetList implements SetListInterface
+final class Drupal9SetList
 {
     public const DRUPAL_9 = __DIR__.'/../../config/drupal-9/drupal-9-all-deprecations.php';
     public const DRUPAL_90 = __DIR__.'/../../config/drupal-9/drupal-9.0-deprecations.php';


### PR DESCRIPTION
## Description
SetInterface has been deprecated, this needs removing. We could move to the new SetProvider to supply sets eventually. Which also enables things like composer based sets. For now, just fix the deprecation. This should help us make the transition to 2.0 easier.

## To Test
- Tests should be grean

## Drupal.org issue
No issue.
