### PR TITLE
chore: Remove use of protected property NodeNameResolver on HookConvertRector

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -137,6 +137,16 @@ parameters:
 
 		-
 			message: '''
+				#^Call to method __construct\(\) of deprecated class DrupalFinder\\DrupalFinder\:
+				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
+				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: config/drupal-phpunit-bootstrap-file.php
+
+		-
+			message: '''
 				#^Call to method getDrupalRoot\(\) of deprecated class DrupalFinder\\DrupalFinder\:
 				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
 				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
@@ -216,6 +226,16 @@ parameters:
 			identifier: new.deprecatedClass
 			count: 1
 			path: config/drupal-phpunit-bootstrap-file.php
+
+		-
+			message: '''
+				#^Call to method __construct\(\) of deprecated class DrupalFinder\\DrupalFinder\:
+				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
+				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: rector.php
 
 		-
 			message: '''

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -150,7 +150,7 @@ CODE_SAMPLE
             // Skip already converted hooks marked with the LegacyHook attribute.
             foreach ($node->attrGroups as $attrGroup) {
                 foreach ($attrGroup->attrs as $attribute) {
-                    if ($this->nodeNameResolver->getName($attribute->name) == 'Drupal\\Core\\Hook\\Attribute\\LegacyHook') {
+                    if ($this->getName($attribute->name) == 'Drupal\\Core\\Hook\\Attribute\\LegacyHook') {
                         return null;
                     }
                 }


### PR DESCRIPTION
## Description

Rector is removing use of protected property `nodeNameResolver` in rules, use `isName()` directly instead. Ref PR:

- https://github.com/rectorphp/rector-src/pull/6875


