### PR TITLE
Fix method not found on GetDeclaringSourceTrait::getDeclaringSource()

### DIFF
--- a/src/Utility/GetDeclaringSourceTrait.php
+++ b/src/Utility/GetDeclaringSourceTrait.php
@@ -31,6 +31,10 @@ trait GetDeclaringSourceTrait
 
         $name = $this->getName($expr->name);
         if ($expr instanceof Node\Expr\MethodCall) {
+            if (! $classReflection->hasMethod($name)) {
+                return null;
+            }
+
             $exprReflection = $classReflection->getMethod($name, $scope);
             // Concrete method has getDeclaringTrait, not interface.
             if (!$exprReflection instanceof PhpMethodReflection) {

--- a/src/Utility/GetDeclaringSourceTrait.php
+++ b/src/Utility/GetDeclaringSourceTrait.php
@@ -41,6 +41,10 @@ trait GetDeclaringSourceTrait
                 return null;
             }
         } elseif ($expr instanceof Node\Expr\PropertyFetch) {
+            if (!$classReflection->hasProperty($name)) {
+                return null;
+            }
+
             $exprReflection = $classReflection->getProperty($name, $scope);
         } else {
             throw new \InvalidArgumentException('Can only call getDeclaringSource on MethodCall or PropertyFetch. Received: '.get_class($expr));

--- a/src/Utility/GetDeclaringSourceTrait.php
+++ b/src/Utility/GetDeclaringSourceTrait.php
@@ -31,7 +31,7 @@ trait GetDeclaringSourceTrait
 
         $name = $this->getName($expr->name);
         if ($expr instanceof Node\Expr\MethodCall) {
-            if (! $classReflection->hasMethod($name)) {
+            if (!$classReflection->hasMethod($name)) {
                 return null;
             }
 


### PR DESCRIPTION
## Description

We got various reported issues because of this, see

https://github.com/rectorphp/rector/issues?q=is%3Aissue%20state%3Aclosed%20drupal-rector

this ensure only get method when exists to avoid error:

```
     "System error: "Method assertEscaped() was not found in reflection of class                                    
     Drupal\Tests\views_aggregator\Functional\Plugin\ViewsAggregatorStyleTableTest."  
```

For note: I think you better open "Issues" tab so people can report here as well