### PR TITLE
Update Deny list to include to missing hooks and remove preprocess

### DIFF
--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -192,7 +192,9 @@ CODE_SAMPLE
             $infoFile = reset($info);
             $this->module = basename($infoFile, '.info.yml');
             $filename = pathinfo($this->file->getFilePath(), \PATHINFO_FILENAME);
-            $hookClassName = ucfirst(CaseStringHelper::camelCase(str_replace('.', '_', $filename).'_hooks'));
+            // Remove _theme before merge.
+            // This is important.
+            $hookClassName = ucfirst(CaseStringHelper::camelCase(str_replace('.', '_', $filename).'_theme_hooks'));
             $counter = '';
             do {
                 $candidate = "$hookClassName$counter";

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -192,9 +192,7 @@ CODE_SAMPLE
             $infoFile = reset($info);
             $this->module = basename($infoFile, '.info.yml');
             $filename = pathinfo($this->file->getFilePath(), \PATHINFO_FILENAME);
-            // Remove _theme before merge.
-            // This is important.
-            $hookClassName = ucfirst(CaseStringHelper::camelCase(str_replace('.', '_', $filename).'_theme_hooks'));
+            $hookClassName = ucfirst(CaseStringHelper::camelCase(str_replace('.', '_', $filename).'_hooks'));
             $counter = '';
             do {
                 $candidate = "$hookClassName$counter";

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -241,19 +241,17 @@ CODE_SAMPLE
         if ($info = $this->getHookAndModuleName($node)) {
             ['hook' => $hook, 'module' => $implementsModule] = $info;
             $procOnly = [
-                $staticDenyHooks = [
-                  'hook_info',
-                  'install',
-                  'install_tasks',
-                  'install_tasks_alter',
-                  'module_implements_alter',
-                  'removed_post_updates',
-                  'requirements',
-                  'schema',
-                  'uninstall',
-                  'update_dependencies',
-                  'update_last_removed',
-                ];
+              'hook_info',
+              'install',
+              'install_tasks',
+              'install_tasks_alter',
+              'module_implements_alter',
+              'removed_post_updates',
+              'requirements',
+              'schema',
+              'uninstall',
+              'update_dependencies',
+              'update_last_removed',
             ];
             if (in_array($hook, $procOnly)) {
                 return null;

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -241,17 +241,21 @@ CODE_SAMPLE
         if ($info = $this->getHookAndModuleName($node)) {
             ['hook' => $hook, 'module' => $implementsModule] = $info;
             $procOnly = [
-                'install',
-                'requirements',
-                'schema',
-                'uninstall',
-                'update_last_removed',
-                'module_implements_alter',
-                'hook_info',
-                'install_tasks',
-                'install_tasks_alter',
+                $staticDenyHooks = [
+                  'hook_info',
+                  'install',
+                  'install_tasks',
+                  'install_tasks_alter',
+                  'module_implements_alter',
+                  'removed_post_updates',
+                  'requirements',
+                  'schema',
+                  'uninstall',
+                  'update_dependencies',
+                  'update_last_removed',
+                ];
             ];
-            if (in_array($hook, $procOnly) || str_starts_with($hook, 'preprocess') || str_starts_with($hook, 'process')) {
+            if (in_array($hook, $procOnly)) {
                 return null;
             }
             // Resolve __FUNCTION__ and unqualify things so TRUE doesn't


### PR DESCRIPTION
## Description
There are two procedural only hooks we missed.

Also preprocess is now supported for 11.2.


## To Test
Needs manual testing.

## Drupal.org issue
https://www.drupal.org/project/drupal/issues/3524872
