### PR TITLE
Better replacement for dynamic uppercase parts in Implements hook_xy

### DIFF
--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -320,25 +320,11 @@ CODE_SAMPLE
     {
         // If the doxygen contains "Implements hook_foo()" then parse the hook
         // name. A difficulty here is "Implements hook_form_FORM_ID_alter".
-        // Find these by looking for an optional part starting with an
-        // uppercase letter.
         if (preg_match('/^ \* Implements hook_([a-zA-Z0-9_]+)/m', (string) $node->getDocComment()?->getReformattedText(), $matches)) {
-            $parts = explode('_', $matches[1]);
-            $isUppercase = false;
-            foreach ($parts as &$part) {
-                if (!$part) {
-                    continue;
-                }
-                if ($part === strtoupper($part)) {
-                    if (!$isUppercase) {
-                        $isUppercase = true;
-                        $part = '[a-z0-9_]+';
-                    }
-                } else {
-                    $isUpperCase = false;
-                }
-            }
-            $hookRegex = implode('_', $parts);
+            // Replace sections that start and end with an uppercase character
+            // and contain any number of uppercase characters or underscores
+            // inbetween.
+            $hookRegex = preg_replace('/([A-Z][A-Z0-9_]*[A-Z0-9])/', '[a-zA-Z0-9]+', $matches[1]);
             $hookRegex = "_(?<hook>$hookRegex)";
             $functionName = $node->name->toString();
             // And now find the module and the hook.

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -324,7 +324,7 @@ CODE_SAMPLE
             // Replace sections that start and end with an uppercase character
             // and contain any number of uppercase characters or underscores
             // inbetween.
-            $hookRegex = preg_replace('/([A-Z][A-Z0-9_]*[A-Z0-9])/', '[a-zA-Z0-9]+', $matches[1]);
+            $hookRegex = preg_replace('/([A-Z][A-Z0-9_]*[A-Z0-9])/', '[a-zA-Z0-9_]+', $matches[1]);
             $hookRegex = "_(?<hook>$hookRegex)";
             $functionName = $node->name->toString();
             // And now find the module and the hook.


### PR DESCRIPTION
## Description

Replacement of hooks that contain a dynamic part such as FORM_ID or ENTITY_TYPE currently don't work.

The problem is that it explicitly only replaces one section of uppercase characters with a regex, so it will try to match against an explicit ID or TYPE. Adding multiple dynamic sections wouldn't work either because the actual replacement might be just one part.

I suggest replacing the whole thing with a preg_replace() that finds any complete section of uppercase characters.


## To Test
- Run it on a module that has such a hook.

## Drupal.org issue
There is no issue since this is a bugfix to an existing rule.
