### PR TITLE
Allow rector ^2.4.1 and replace file with getFile() if method exists

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "^1 || ^2",
+        "rector/rector": "^1 || ^2.4.1",
         "webflo/drupal-finder": "^1.2"
     },
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "ast"
     ],
     "require": {
-        "rector/rector": "^1 || ^2.4.1",
+        "rector/rector": "^1 || ^2",
         "webflo/drupal-finder": "^1.2"
     },
     "license": "MIT",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -572,3 +572,9 @@ parameters:
 			identifier: property.deprecated
 			count: 3
 			path: src/Rector/Convert/HookConvertRector.php
+
+		-
+			message: '#^Call to function method_exists\(\) with \$this\(DrupalRector\\Rector\\Convert\\HookConvertRector\) and ''getFile'' will always evaluate to true\.$#'
+			identifier: function.alreadyNarrowedType
+			count: 3
+			path: src/Rector/Convert/HookConvertRector.php

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -128,8 +128,8 @@ CODE_SAMPLE
     public function refactor(Node $node): Node|int|null
     {
         $filePath = method_exists($this, 'getFile')
-            ? $this->file->getFilePath()
-            : $this->getFile()->getFilePath();
+            ? $this->getFile()->getFilePath()
+            : $this->file->getFilePath();
         $ext = pathinfo($filePath, \PATHINFO_EXTENSION);
         if (!in_array($ext, ['inc', 'module'])) {
             return null;
@@ -184,8 +184,8 @@ CODE_SAMPLE
     {
         $this->__destruct();
         $this->moduleDir = method_exists($this, 'getFile')
-            ? $this->file->getFilePath()
-            : $this->getFile()->getFilePath();
+            ? $this->getFile()->getFilePath()
+            : $this->file->getFilePath();
         $this->inputFilename = $this->moduleDir;
         // Find the relevant info.yml: it's either in the current directory or
         // one of the parents.
@@ -194,7 +194,7 @@ CODE_SAMPLE
         if (!empty($info)) {
             $infoFile = reset($info);
             $this->module = basename($infoFile, '.info.yml');
-            $filename = pathinfo(method_exists($this, 'getFile') ? $this->file->getFilePath() : $this->getFile()->getFilePath(), \PATHINFO_FILENAME);
+            $filename = pathinfo(method_exists($this, 'getFile') ? $this->getFile()->getFilePath() : $this->file->getFilePath(), \PATHINFO_FILENAME);
             $hookClassName = ucfirst(CaseStringHelper::camelCase(str_replace('.', '_', $filename).'_hooks'));
             $counter = '';
             do {

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -127,7 +127,9 @@ CODE_SAMPLE
 
     public function refactor(Node $node): Node|int|null
     {
-        $filePath = $this->file->getFilePath();
+        $filePath = method_exists($this, 'getFile')
+            ? $this->file->getFilePath()
+            : $this->getFile()->getFilePath();
         $ext = pathinfo($filePath, \PATHINFO_EXTENSION);
         if (!in_array($ext, ['inc', 'module'])) {
             return null;
@@ -181,7 +183,9 @@ CODE_SAMPLE
     protected function initializeHookClass(): void
     {
         $this->__destruct();
-        $this->moduleDir = $this->file->getFilePath();
+        $this->moduleDir = method_exists($this, 'getFile')
+            ? $this->file->getFilePath()
+            : $this->getFile()->getFilePath();
         $this->inputFilename = $this->moduleDir;
         // Find the relevant info.yml: it's either in the current directory or
         // one of the parents.
@@ -190,7 +194,7 @@ CODE_SAMPLE
         if (!empty($info)) {
             $infoFile = reset($info);
             $this->module = basename($infoFile, '.info.yml');
-            $filename = pathinfo($this->file->getFilePath(), \PATHINFO_FILENAME);
+            $filename = pathinfo(method_exists($this, 'getFile') ? $this->file->getFilePath() : $this->getFile()->getFilePath(), \PATHINFO_FILENAME);
             $hookClassName = ucfirst(CaseStringHelper::camelCase(str_replace('.', '_', $filename).'_hooks'));
             $counter = '';
             do {

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -13,7 +13,6 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Use_;
-use PhpParser\Node\UseItem;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
@@ -222,7 +221,11 @@ CODE_SAMPLE
             $hookClassStmts = [
                 new Node\Stmt\Namespace_(new Node\Name($namespace)),
                 ...$this->useStmts,
-                new Use_([new UseItem(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))]),
+                new Use_([
+                    class_exists('PhpParser\Node\UseItem')
+                    ? new Node\UseItem(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))
+                    : new Node\Stmt\UseUse(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))
+                ]),
                 $this->hookClass,
             ];
             $this->hookClass->setDocComment(new \PhpParser\Comment\Doc("/**\n * Hook implementations for $this->module.\n */"));

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\Node\Stmt\Use_;
+use PhpParser\Node\UseItem;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
@@ -221,7 +222,7 @@ CODE_SAMPLE
             $hookClassStmts = [
                 new Node\Stmt\Namespace_(new Node\Name($namespace)),
                 ...$this->useStmts,
-                new Use_([new Node\Stmt\UseUse(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))]),
+                new Use_([new UseItem(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))]),
                 $this->hookClass,
             ];
             $this->hookClass->setDocComment(new \PhpParser\Comment\Doc("/**\n * Hook implementations for $this->module.\n */"));

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -224,7 +224,7 @@ CODE_SAMPLE
                 new Use_([
                     class_exists('PhpParser\Node\UseItem')
                     ? new Node\UseItem(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))
-                    : new Node\Stmt\UseUse(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))
+                    : new Node\Stmt\UseUse(new Node\Name('Drupal\Core\Hook\Attribute\Hook')),
                 ]),
                 $this->hookClass,
             ];


### PR DESCRIPTION
## Description

In rector 2.4.1, the `file` property usage is deprecated, use `->getFile()` instead.

- https://github.com/rectorphp/rector-src/pull/7962

since this repo allow rector 1, this need method_exists() check.

