### PR TITLE
[2/7] fix: default introducedVersion on Configuration value objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,27 @@ release-by-release.
   extend `AbstractDrupalCoreRector` and auto-wrap their `Expr → Expr` rewrites
   via `DeprecationHelper::backwardsCompatibleCall()`. Their configuration value
   objects (`ClassConstantToClassConstantConfiguration`,
-  `MethodToMethodWithCheckConfiguration`) gain a required `introducedVersion`
-  constructor argument and now implement `VersionedConfigurationInterface`.
-  This closes three D11 → D10 runtime regressions (Comment* enums in 11.4,
+  `MethodToMethodWithCheckConfiguration`) gain an optional `introducedVersion`
+  constructor argument (default `'0.0.0'`) and now implement
+  `VersionedConfigurationInterface`. The default falls outside the BC-wrap
+  gate (`< 10.0.0`), so consumers that instantiate these value objects without
+  passing the new argument keep pre-refactor behaviour (no wrapping). This
+  closes three D11 → D10 runtime regressions (Comment* enums in 11.4,
   `RequirementSeverity` in 11.2, `AliasManager` method rename in 11.1) without
   moving anything to a `-breaking.php` set.
 - `MethodToMethodWithCheckRector` no longer attaches a "please confirm the
   receiver type" TODO comment for the `maybe` type-inference case. The
   comment-on-parent-statement mechanism relied on parent-node tracking that
-  Rector 2.x removed; the BC wrap makes both code paths runtime-safe by
-  selecting the right call based on `\Drupal::VERSION`, which addresses the
-  underlying concern.
+  Rector 2.x removed. For configurations whose `introducedVersion ≥ 10.0.0`,
+  the BC wrap selects the right call at runtime via `\Drupal::VERSION` and
+  fully addresses the underlying concern. Configurations with an older
+  introduced version (e.g. `urlInfo` → `toUrl` @ 8.0.0,
+  `getLowercaseLabel` → `getSingularLabel` @ 8.8.0,
+  `clearCsrfTokenSeed` → `stampNew` @ 9.2.0) fall outside the BC-wrap gate
+  and rewrite unconditionally on a `maybe`-typed receiver. Contrib audit
+  (api.tresbien.tech, 2026-05-28) found zero live callers of those three
+  methods on receivers PHPStan cannot resolve to a concrete type, so the
+  residual risk is theoretical.
 
 ## [1.0.0-beta1] — 2026-05-25
 

--- a/src/Rector/ValueObject/ClassConstantToClassConstantConfiguration.php
+++ b/src/Rector/ValueObject/ClassConstantToClassConstantConfiguration.php
@@ -17,7 +17,7 @@ final class ClassConstantToClassConstantConfiguration implements VersionedConfig
 
     private string $introducedVersion;
 
-    public function __construct(string $deprecatedClass, string $deprecated, string $class, string $constant, string $introducedVersion)
+    public function __construct(string $deprecatedClass, string $deprecated, string $class, string $constant, string $introducedVersion = '0.0.0')
     {
         $this->deprecatedClass = $deprecatedClass;
         $this->deprecated = $deprecated;

--- a/src/Rector/ValueObject/MethodToMethodWithCheckConfiguration.php
+++ b/src/Rector/ValueObject/MethodToMethodWithCheckConfiguration.php
@@ -16,7 +16,7 @@ class MethodToMethodWithCheckConfiguration implements VersionedConfigurationInte
 
     protected string $introducedVersion;
 
-    public function __construct(string $className, string $deprecatedMethodName, string $methodName, string $introducedVersion)
+    public function __construct(string $className, string $deprecatedMethodName, string $methodName, string $introducedVersion = '0.0.0')
     {
         $this->className = $className;
         $this->deprecatedMethodName = $deprecatedMethodName;


### PR DESCRIPTION
## Description

The BC-wrap refactor in [\`0e2211bf\`](https://github.com/palantirnet/drupal-rector/commit/0e2211bf) made \`\$introducedVersion\` a **required** constructor argument on:

- \`ClassConstantToClassConstantConfiguration\`
- \`MethodToMethodWithCheckConfiguration\`

Both classes are part of the public API surface and not annotated
\`@internal\` — downstream consumers that instantiate them directly hit
\`ArgumentCountError\` on upgrade.

Make the argument optional with default \`'0.0.0'\`. The default falls
outside the BC-wrap gate (\`< 10.0.0\` in
\`AbstractDrupalCoreRector::supportBackwardsCompatibility()\`), so
consumers that omit the argument keep pre-refactor behaviour (no
wrapping).

Also refines the relevant \`[Unreleased] / ### Changed\` CHANGELOG bullets:

- Updates the BC-wrap refactor bullet to describe \`introducedVersion\` as
  optional with its default, and to spell out the BC implication.
- Tightens the dropped-TODO-comment bullet to honestly acknowledge that
  pre-10.0 configurations (\`urlInfo\`, \`getLowercaseLabel\`,
  \`clearCsrfTokenSeed\`) fall outside the BC-wrap gate. Contrib audit
  (api.tresbien.tech, 2026-05-28) found zero live callers of those three
  methods on receivers PHPStan cannot resolve, so the residual risk is
  theoretical.

## To test

- \`composer test\` — 509 / 509 passing
- \`composer phpstan\` — clean
- \`composer check-style\` — clean

## Split context

This is part 2 of 7 in the orthogonal split of [#8](https://github.com/bbrala/drupal-rector/pull/8).
Plan is in \`docs/pr8-split-proposal.md\` on the bbrala fork.

**Depends on:** nothing.
**Blocks:** [6/7] (BC-wrapped rectors) benefits from this landing first so
its consumers get the optional default; not a hard blocker.

## Drupal.org issue

N/A — API BC fix on top of the BC-wrap refactor.