### PR TITLE
Isolate HookConvertRector into a separate pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ Real-world validated end-to-end:
 ### Added
 
 #### Infrastructure
+- **`config/convert/hook-convert.php`** — dedicated configuration that registers
+  only `HookConvertRector`, for running hook conversion as a separate second
+  pass. `HookConvertRector` writes the generated `src/Hook/*Hooks.php` to disk
+  outside Rector's file pipeline, so bundling it with the deprecation sets would
+  copy un-fixed hook bodies into the new class. Documented in the README
+  ("Converting hooks to OOP hook classes"): run deprecations first, then this
+  config.
 - **`DrupalRectorSettings`** (`src/Services/DrupalRectorSettings.php`) — container-
   managed settings object with `enableBackwardCompatibility()` /
   `disableBackwardCompatibility()` / `setMinimumCoreVersionSupported(string)` /

--- a/README.md
+++ b/README.md
@@ -159,6 +159,35 @@ $ vendor/bin/rector process web/modules/contrib/[YOUR_MODULE]
 
 You can find more information about Rector [here](https://github.com/rectorphp/rector).
 
+## Converting hooks to OOP hook classes (run as a separate pass)
+
+Drupal Rector ships `HookConvertRector`, which converts procedural hook
+implementations (`mymodule_form_alter()`, …) into a `#[Hook]`-attributed class
+under `src/Hook/`. **This rule must be run on its own, as a second pass, after
+your normal deprecation run — never in the same configuration as the deprecation
+sets.**
+
+To convert hooks, run your deprecation pass first, then point Rector at the
+dedicated config that registers only `HookConvertRector`:
+
+```sh
+# Pass 1 — fix deprecations in place (your normal config)
+$ vendor/bin/rector process web/modules/contrib/[YOUR_MODULE]
+
+# Pass 2 — convert hooks to OOP hook classes
+$ vendor/bin/rector process web/modules/contrib/[YOUR_MODULE] \
+    --config=vendor/palantirnet/drupal-rector/config/convert/hook-convert.php
+```
+
+**Why two passes?** `HookConvertRector` moves each hook body into a brand-new
+`src/Hook/*Hooks.php` file that it writes directly to disk. Rector (2.x) cannot
+feed a newly-created file back through the rule pipeline within the same run, so
+a deprecated API call that lives inside a hook body would be copied into the new
+class **unchanged** if hook conversion ran together with the deprecation sets.
+Running deprecations first means the bodies are already fixed before they are
+moved. For this reason the example `rector.php` above intentionally does **not**
+register `HookConvertRector`.
+
 ## Development and contribution suggestions
 
 Thanks for your interest in contributing!

--- a/config/convert/hook-convert.php
+++ b/config/convert/hook-convert.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Rector\Convert\HookConvertRector;
+use Rector\Config\RectorConfig;
+
+/**
+ * Standalone configuration for converting procedural hook implementations into
+ * OOP hook classes (#[Hook] attributes).
+ *
+ * IMPORTANT: run this as a SEPARATE rector pass, AFTER your deprecation pass.
+ *
+ * HookConvertRector moves each hook body into a brand-new `src/Hook/*Hooks.php`
+ * file that it writes directly to disk. Rector (2.x) has no way to feed a
+ * newly-created file back through the rule pipeline within the same run, so any
+ * deprecated API call that lives inside a hook body would NOT be fixed if this
+ * rule ran together with the deprecation sets — the unfixed body would be copied
+ * into the new class and never revisited.
+ *
+ * Therefore: do not add this rule to a config that also loads the Drupal
+ * deprecation sets. Run two passes instead:
+ *
+ *   vendor/bin/rector process modules/contrib/my_module                       # pass 1: deprecations
+ *   vendor/bin/rector process modules/contrib/my_module \
+ *     --config=vendor/palantirnet/drupal-rector/config/convert/hook-convert.php # pass 2: hook conversion
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(HookConvertRector::class);
+
+    if (class_exists('DrupalFinder\DrupalFinderComposerRuntime')) {
+        $drupalFinder = new DrupalFinder\DrupalFinderComposerRuntime();
+    } else {
+        $drupalFinder = new DrupalFinder\DrupalFinder();
+        $drupalFinder->locateRoot(__DIR__);
+    }
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+    $rectorConfig->autoloadPaths([
+        $drupalRoot.'/core',
+        $drupalRoot.'/modules',
+        $drupalRoot.'/profiles',
+        $drupalRoot.'/themes',
+    ]);
+
+    $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);
+    $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
+    $rectorConfig->importNames(true, false);
+    $rectorConfig->importShortClasses(false);
+};

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2,6 +2,46 @@ parameters:
 	ignoreErrors:
 		-
 			message: '''
+				#^Call to method __construct\(\) of deprecated class DrupalFinder\\DrupalFinder\:
+				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
+				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: config/convert/hook-convert.php
+
+		-
+			message: '''
+				#^Call to method getDrupalRoot\(\) of deprecated class DrupalFinder\\DrupalFinder\:
+				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
+				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: config/convert/hook-convert.php
+
+		-
+			message: '''
+				#^Call to method locateRoot\(\) of deprecated class DrupalFinder\\DrupalFinder\:
+				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
+				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
+			'''
+			identifier: method.deprecatedClass
+			count: 1
+			path: config/convert/hook-convert.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class DrupalFinder\\DrupalFinder\:
+				in drupal\-finder\:1\.3\.0 and is removed from drupal\-finder\:2\.0\.0\.
+				  Use \\DrupalFinder\\DrupalFinderComposerRuntime instead\.$#
+			'''
+			identifier: new.deprecatedClass
+			count: 1
+			path: config/convert/hook-convert.php
+
+		-
+			message: '''
 				#^Fetching deprecated class constant SYMFONY_50 of class Rector\\Symfony\\Set\\SymfonySetList\:
 				Set list are too generic and do not handle package differences\. Use \-\>withComposerBased\(symfony\: true\) instead$#
 			'''


### PR DESCRIPTION
## Problem

`HookConvertRector` writes the generated `src/Hook/*Hooks.php` directly to disk via `file_put_contents` (in `__destruct`), outside Rector's file pipeline. Rector 2.x has no way to feed a newly-created file back through the rule set within the same run (the added-files collector was removed upstream in rector/rector#4117). It also snapshots each hook body at the moment it fires.

As a result, when `HookConvertRector` runs **in the same configuration as the deprecation sets**, any deprecated API call living inside a hook body is copied into the new class **unconverted** — the deprecation rectors never get to fix it. Deprecations in non-hook functions (which stay in the `.module`) are fixed fine.

This was found while reviewing whole-of-contrib `project_analysis` patches: hook-resident deprecations (`REQUEST_TIME`, `check_markup()`, `filter_formats()`, …) were left raw in the generated Hook classes, and the generated class could also miss an import (e.g. `FormStateInterface`).

## Fix

Run hook conversion as a **separate second pass**, after the deprecation pass:

1. **Pass 1** — deprecation sets only. Fixes procedural code in place in `.module`/`.inc`/`.theme`.
2. **Pass 2** — `HookConvertRector` only. Moves the already-fixed bodies into the Hook class, carrying their imports along via its `Use_` collection.

### Changes

- **`config/convert/hook-convert.php`** (new) — dedicated config registering only `HookConvertRector`, with a header explaining the two-pass requirement.
- **`README.md`** — new "Converting hooks to OOP hook classes (run as a separate pass)" section documenting the workflow and the why. Notes that the example `rector.php` intentionally does not register `HookConvertRector`.
- **`CHANGELOG.md`** — `[Unreleased] / Added` entry.
- **`phpstan-baseline.neon`** — baseline the `DrupalFinder` fallback deprecation in the new config (same as the existing `rector.php` entries).

## Validation

Verified end-to-end against a test module with deprecations both inside and outside hooks. With the two-pass run, all three hook-resident deprecations are correctly transformed in the generated `Hook` class and all imports are carried over. `composer fix-style` and `composer phpstan` are green.