### PR TITLE
docs: Prepare 1.0.0-alpha1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ release-by-release.
 
 ## [Unreleased]
 
+## [1.0.0-alpha1] — 2026-06-01
+
 ### Changed
 
-This will be the first beta of the 1.0 line. Adds full Drupal 11 deprecation coverage 
+This will be the first alpha of the 1.0 line. Adds full Drupal 11 deprecation coverage 
 (versions 11.0 through 11.4), a new container-managed settings service that gives users 
 explicit control over backward-compatibility wrapping, a documented set of Claude Code 
 skills for building further rectors, and drops support for Rector 1.
@@ -441,7 +443,7 @@ Still included for legacy projects. The classes
 `Drupal9\Rector\Deprecation\FunctionToFirstArgMethodRector` are thin subclasses
 re-validating their D8/D9 configuration value objects; behaviour is unchanged.
 
-[1.0.0-beta1]: https://github.com/palantirnet/drupal-rector/releases/tag/1.0.0-beta1
+[1.0.0-alpha1]: https://github.com/palantirnet/drupal-rector/releases/tag/1.0.0-alpha1
 ## [0.21.2] — 2026-05-08
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/palantirnet/drupal-rector/releases
 
 ## Scope and limitations
 
-Drupal 10 and 11 are the primary targets (Drupal 8/9 rules are included for legacy projects). The development of this tool is prioritized by the perceived impact of the deprecations and updates. There are many deprecations that often involve several components and for each of these there are several ways to address the deprecation.
+Drupal 10 and 11 are the primary targets — deprecation coverage spans Drupal 10.0 through 11.4 (Drupal 8/9 rules are included for legacy projects). The development of this tool is prioritized by the perceived impact of the deprecations and updates. There are many deprecations that often involve several components and for each of these there are several ways to address the deprecation.
 
 We've tried to determine impact based on:
 - The use of the deprecated functionality in the contributed modules on Drupal.org
@@ -62,6 +62,12 @@ For contribution suggestions, please see the later section of this document.
 ```bash
 $ composer require --dev palantirnet/drupal-rector
 ```
+
+> **Trying the 1.0 pre-release?** The 1.0.x line is currently published as an alpha. Until a stable `1.0.0` is tagged, the command above resolves to the latest stable release — request the pre-release explicitly instead:
+>
+> ```bash
+> $ composer require --dev "palantirnet/drupal-rector:^1.0@alpha"
+> ```
 
 ### Create a configuration file in your project
 


### PR DESCRIPTION
- CHANGELOG: stamp [1.0.0-alpha1] heading with release date, reconcile alpha naming, add fresh [Unreleased] section
- README: note Drupal 10.0-11.4 deprecation coverage and document installing the 1.0 pre-release via ^1.0@alpha

## Description
Prepare for the first alpha release.