### PR TITLE
Fix D9+D11 set collision and document running against Drupal 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ release-by-release.
 
 ## [Unreleased]
 
+### Added
+
+- Guide: [Running against a Drupal 10 project](docs/running-against-drupal-10.md) — covers the
+  direct install and a standalone-runner recipe for sites whose PHPStan 1 tooling conflicts with
+  Rector 2's PHPStan 2 requirement.
+
 ### Fixed
 
 - Loading the Drupal 9 and Drupal 11 sets together no longer crashes at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ release-by-release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Loading the Drupal 9 and Drupal 11 sets together no longer crashes at
+  container-build time. The Drupal 9 `FunctionToFirstArgMethodRector` (and the
+  Drupal 8 `DrupalServiceRenameRector`) subclass the generic rule, so Rector
+  delivered the generic rule's configuration to the subclass instance as well
+  (`afterResolving` callbacks match by `instanceof`); the subclass' strict type
+  guard then threw. The subclasses now ignore configuration that is not their own.
+  This unblocks running the full, bundled rule set — including the D10-era
+  deprecations that live in the Drupal 11 set — against Drupal 10 sites.
+
 ## [1.0.0-alpha1] — 2026-06-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ For contribution suggestions, please see the later section of this document.
 
 **NOTE**: To have the best experience with Drupal Rector, your Drupal site should be running Drupal 10 or higher.
 
+> **On Drupal 10 preparing for Drupal 11?** You can run Drupal Rector against a D10 site to clean up
+> deprecations before upgrading. If your project pins PHPStan 1 (e.g. via `mglaman/phpstan-drupal`)
+> the direct install below will conflict — see
+> [Running against a Drupal 10 project](docs/running-against-drupal-10.md) for the standalone-runner
+> recipe that avoids it.
+
 ### Install Drupal Rector inside a Drupal project.
 
 ```bash

--- a/docs/running-against-drupal-10.md
+++ b/docs/running-against-drupal-10.md
@@ -1,0 +1,167 @@
+# Running Drupal Rector against a Drupal 10 project
+
+Drupal Rector targets Drupal 11, but it is just as useful **on a Drupal 10 site** to clean up
+deprecations *before* you upgrade. Because rules are gated on the **installed** Drupal version,
+running on a D10 site fixes everything deprecated up to that version and leaves not-yet-deprecated
+D11-only APIs alone — exactly what you want when preparing for D11.
+
+There are two ways to run it. Try the direct install first; fall back to the standalone runner only
+if your project's dev dependencies conflict.
+
+---
+
+## Option A — Install directly in the project (simplest)
+
+If your project does **not** pin PHPStan 1, install Drupal Rector as a normal dev dependency:
+
+```bash
+$ composer require --dev "palantirnet/drupal-rector:^1.0@alpha"
+$ cp vendor/palantirnet/drupal-rector/rector.php .
+$ vendor/bin/rector process web/modules/custom --dry-run
+```
+
+This is the standard flow documented in the [README](../README.md#installation). Drop `--dry-run`
+to apply the changes.
+
+### When this fails: the PHPStan conflict
+
+`rector/rector` (v2) requires **PHPStan ^2**. If your project also requires PHPStan **1** — most
+commonly through [`mglaman/phpstan-drupal`](https://github.com/mglaman/phpstan-drupal) or
+`drupal/core-dev` on Drupal 10 — Composer cannot resolve both at once:
+
+```
+rector/rector ... requires phpstan/phpstan ^2 ... but it conflicts with your root
+composer.json require (^1...).
+```
+
+You don't need to remove your existing PHPStan tooling. Use Option B instead.
+
+---
+
+## Option B — Run from a standalone project (no dependency conflict)
+
+Install Drupal Rector in its **own** Composer project, separate from the site under analysis. That
+project carries Rector 2 + PHPStan 2 in its own `vendor/`; your site's PHPStan 1 is never installed
+alongside it, so there is nothing to conflict. Rector reads your site's code by path and loads its
+classes with `--autoload-file`.
+
+### 1. Create the runner project
+
+Anywhere outside your site, e.g. `~/drupal-rector-runner`:
+
+```bash
+$ mkdir ~/drupal-rector-runner && cd ~/drupal-rector-runner
+$ composer init --no-interaction --name=local/drupal-rector-runner
+$ composer config minimum-stability dev
+$ composer config prefer-stable true
+$ composer require "palantirnet/drupal-rector:^1.0@alpha" "rector/rector:^2"
+```
+
+### 2. Add a runner config
+
+Create `rector.php` in the runner project. **Point `TARGET_SITE` at your Drupal site** and note
+the two differences from a normal in-project config (both explained below):
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Set\Drupal8SetList;
+use DrupalRector\Set\Drupal9SetList;
+use DrupalRector\Set\Drupal10SetList;
+use DrupalRector\Set\Drupal11SetList;
+use DrupalRector\Services\DrupalRectorSettings;
+use Rector\Config\RectorConfig;
+
+// Absolute path to the root of the Drupal site you want to analyse.
+const TARGET_SITE = '/path/to/your/drupal-site';
+
+return static function (RectorConfig $rectorConfig): void {
+    // (1) Load the PER-VERSION sets, not the DRUPAL_10 / DRUPAL_11 aggregators.
+    $rectorConfig->sets([
+        Drupal8SetList::DRUPAL_80, Drupal8SetList::DRUPAL_81, Drupal8SetList::DRUPAL_82,
+        Drupal8SetList::DRUPAL_83, Drupal8SetList::DRUPAL_84, Drupal8SetList::DRUPAL_85,
+        Drupal8SetList::DRUPAL_86, Drupal8SetList::DRUPAL_87, Drupal8SetList::DRUPAL_88,
+        Drupal9SetList::DRUPAL_90, Drupal9SetList::DRUPAL_91, Drupal9SetList::DRUPAL_92,
+        Drupal9SetList::DRUPAL_93, Drupal9SetList::DRUPAL_94,
+        Drupal10SetList::DRUPAL_100, Drupal10SetList::DRUPAL_101,
+        Drupal10SetList::DRUPAL_102, Drupal10SetList::DRUPAL_103,
+        Drupal11SetList::DRUPAL_110, Drupal11SetList::DRUPAL_111, Drupal11SetList::DRUPAL_112,
+        Drupal11SetList::DRUPAL_113, Drupal11SetList::DRUPAL_114,
+    ]);
+
+    // Enable BC wrapping so rewritten code still runs on your current Drupal 10.
+    $rectorConfig->singleton(DrupalRectorSettings::class, fn () =>
+        (new DrupalRectorSettings())->enableBackwardCompatibility());
+
+    // Locate the docroot of the EXTERNAL site (filesystem scan — must be the
+    // plain DrupalFinder, not DrupalFinderComposerRuntime).
+    $drupalFinder = new DrupalFinder\DrupalFinder();
+    $drupalFinder->locateRoot(TARGET_SITE);
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+
+    $rectorConfig->autoloadPaths([
+        $drupalRoot . '/core',
+        $drupalRoot . '/modules',
+        $drupalRoot . '/profiles',
+        $drupalRoot . '/themes',
+    ]);
+
+    $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
+    $rectorConfig->importNames(true, false);
+    $rectorConfig->importShortClasses(false);
+};
+```
+
+### 3. Run it
+
+Point Rector at the code to analyse and load the **site's** autoloader so type-aware rules can
+resolve Drupal classes:
+
+```bash
+$ vendor/bin/rector process /path/to/your/drupal-site/web/modules/custom \
+    --dry-run \
+    --autoload-file=/path/to/your/drupal-site/vendor/autoload.php
+```
+
+Drop `--dry-run` to write the changes into your site. Because the files live in your site's
+checkout, review and commit them there as usual.
+
+---
+
+## Why the two differences in the runner config
+
+- **(1) Per-version sets instead of the `DRUPAL_10` / `DRUPAL_11` aggregators.** The aggregator sets
+  register an extra bootstrap file that fixes up Drupal's PHPUnit test-namespace autoloading. That
+  bootstrap assumes Rector is installed *inside* the site (it resolves `drupal/core` through
+  `Composer\InstalledVersions`) and aborts with `Package "drupal/core" is not installed` when run
+  from a standalone project. The per-version sets contain the same rules without that bootstrap,
+  and `--autoload-file` already gives Rector the class reflection it needs.
+
+- **`--autoload-file`** must point at your **site's** `vendor/autoload.php`. Without it, type-aware
+  rules (those that check the type of a method's receiver) can't resolve your site's Drupal classes
+  and won't fire.
+
+---
+
+## What gets fixed
+
+With BC wrapping enabled, each rewrite is wrapped so it keeps working on your current Drupal 10
+while also being correct on the newer API, e.g.:
+
+```php
+// before
+return format_size($bytes);
+
+// after
+return \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(
+    \Drupal::VERSION, '10.2.0',
+    fn() => \Drupal\Core\StringTranslation\ByteSizeMarkup::create($bytes),
+    fn() => format_size($bytes),
+);
+```
+
+Rules whose deprecation was introduced **after** your installed Drupal version are skipped, so a
+run on Drupal 10 will not pull in Drupal 11-only changes. When you later move to Drupal 11, run
+Rector again to pick up the remaining rewrites.

--- a/src/Drupal8/Rector/Deprecation/DrupalServiceRenameRector.php
+++ b/src/Drupal8/Rector/Deprecation/DrupalServiceRenameRector.php
@@ -10,12 +10,19 @@ class DrupalServiceRenameRector extends \DrupalRector\Rector\Deprecation\DrupalS
 {
     public function configure(array $configuration): void
     {
-        foreach ($configuration as $value) {
-            if (!$value instanceof DrupalServiceRenameConfiguration) {
-                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalServiceRenameConfiguration::class));
-            }
+        // This rule subclasses the generic DrupalServiceRenameRector, so Rector's
+        // container also fires the generic rule's configuration callback on this
+        // instance (afterResolving callbacks match by instanceof). Keep only our
+        // own configuration; the generic rule instance applies the rest itself.
+        $ownConfiguration = array_values(array_filter(
+            $configuration,
+            static fn ($value): bool => $value instanceof DrupalServiceRenameConfiguration
+        ));
+
+        if ($ownConfiguration === []) {
+            return;
         }
 
-        parent::configure($configuration);
+        parent::configure($ownConfiguration);
     }
 }

--- a/src/Drupal9/Rector/Deprecation/FunctionToFirstArgMethodRector.php
+++ b/src/Drupal9/Rector/Deprecation/FunctionToFirstArgMethodRector.php
@@ -10,12 +10,21 @@ final class FunctionToFirstArgMethodRector extends \DrupalRector\Rector\Deprecat
 {
     public function configure(array $configuration): void
     {
-        foreach ($configuration as $value) {
-            if (!$value instanceof FunctionToFirstArgMethodConfiguration) {
-                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', FunctionToFirstArgMethodConfiguration::class));
-            }
+        // This rule subclasses the generic FunctionToFirstArgMethodRector, so
+        // Rector's container also fires the generic rule's configuration callback
+        // on this instance (afterResolving callbacks match by instanceof). When
+        // both the Drupal 9 and Drupal 11 sets are loaded, the generic rule's
+        // (version-tagged) configuration is delivered here too. Keep only our own
+        // configuration; the generic rule instance applies the rest itself.
+        $ownConfiguration = array_values(array_filter(
+            $configuration,
+            static fn ($value): bool => $value instanceof FunctionToFirstArgMethodConfiguration
+        ));
+
+        if ($ownConfiguration === []) {
+            return;
         }
 
-        parent::configure($configuration);
+        parent::configure($ownConfiguration);
     }
 }

--- a/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/FunctionToFirstArgMethodSetCollisionTest.php
+++ b/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/FunctionToFirstArgMethodSetCollisionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Rector\Deprecation\FunctionToFirstArgMethodSetCollision;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+/**
+ * Regression test for the Drupal 9 + Drupal 11 set collision.
+ *
+ * The Drupal 9 FunctionToFirstArgMethodRector subclasses the generic rule, so
+ * Rector's container fires the generic rule's configuration callback on the
+ * subclass instance too (afterResolving callbacks match by instanceof). When
+ * both sets are loaded this delivered the generic, version-tagged configuration
+ * to the subclass, whose strict type guard threw at container-build time. The
+ * subclass now ignores configuration that is not its own.
+ */
+class FunctionToFirstArgMethodSetCollisionTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/config/configured_rule.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal9\Rector\Deprecation\FunctionToFirstArgMethodRector as Drupal9FunctionToFirstArgMethodRector;
+use DrupalRector\Drupal9\Rector\ValueObject\FunctionToFirstArgMethodConfiguration as Drupal9FunctionToFirstArgMethodConfiguration;
+use DrupalRector\Rector\Deprecation\FunctionToFirstArgMethodRector;
+use DrupalRector\Rector\ValueObject\FunctionToFirstArgMethodConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    // The generic rule, as registered by the Drupal 11 sets.
+    DeprecationBase::addClass(FunctionToFirstArgMethodRector::class, $rectorConfig, false, [
+        new FunctionToFirstArgMethodConfiguration('11.3.0', 'comment_uri', 'permalink'),
+    ]);
+
+    // The Drupal 9 subclass, as registered by the Drupal 9 set. Because it extends
+    // the generic rule, Rector's container delivers the generic configuration above
+    // to this instance as well; the subclass must ignore it rather than throw.
+    DeprecationBase::addClass(Drupal9FunctionToFirstArgMethodRector::class, $rectorConfig, false, [
+        new Drupal9FunctionToFirstArgMethodConfiguration('taxonomy_term_uri', 'toUrl'),
+    ]);
+};

--- a/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/fixture/both_rules.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/fixture/both_rules.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+function full_example($comment, $term) {
+    $url = comment_uri($comment);
+    $route = taxonomy_term_uri($term);
+}
+
+?>
+-----
+<?php
+
+function full_example($comment, $term) {
+    $url = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => $comment->permalink(), fn() => comment_uri($comment));
+    $route = $term->toUrl();
+}
+
+?>


### PR DESCRIPTION
## Why

Teams on **Drupal 10** want to run Drupal Rector to clean up deprecations *before* upgrading to Drupal 11. Investigating how to support that surfaced a real crash in the bundled configuration, plus a packaging gotcha for sites that pin PHPStan 1.

## What's here

### `fix:` D9+D11 set collision (container-build crash)

Loading the Drupal 9 **and** Drupal 11 sets together crashed before processing any file:

```
InvalidArgumentException: Each configuration item must be an instance of
"DrupalRector\Drupal9\Rector\ValueObject\FunctionToFirstArgMethodConfiguration"
```

`Drupal9\…\FunctionToFirstArgMethodRector` (and `Drupal8\…\DrupalServiceRenameRector`) subclass their generic rules. Rector applies configuration via illuminate-container `afterResolving` callbacks that match by **`instanceof`**, so the subclass instances also received the generic rule's version-tagged configuration and their strict `configure()` type guard threw.

The bundled `rector.php` loads all four sets, so the **default config crashed on any run**. It matters for D10 specifically because some D10-era deprecations live only in the D11 set (e.g. `LoadAllIncludesRector`, deprecated in 10.3).

**Fix:** the subclasses filter `configure()` to their own configuration type and ignore the rest; the generic rule instance still applies its own configs, so no coverage is lost. Added a regression test that registers both rules together and fails on the pre-fix code.

### `docs:` Running against a Drupal 10 project

New guide (`docs/running-against-drupal-10.md`, linked from the README) covering:
- **Direct install** for plain D10 sites.
- A **standalone-runner** recipe for sites whose PHPStan 1 tooling (e.g. `mglaman/phpstan-drupal`) conflicts with Rector 2's PHPStan 2 requirement — a separate Composer project loading the per-version sets and pointing at the site via `--autoload-file`.

## Validation

- Full suite green (**510 tests**, +1 regression), PHPStan clean.
- Verified end-to-end against a real Drupal 10.6 site: D9, D10.2 and D10.3 deprecations all transform with the full D8–D11 set loaded, both for a direct install and via the standalone runner.