### PR TITLE
feat(Drupal11): add ReplaceDrupalStaticResetFileReferencesRector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ release-by-release.
 
 ### Added
 
+- **`ReplaceDrupalStaticResetFileReferencesRector`** — rewrites
+  `drupal_static_reset('file_get_file_references')` and
+  `drupal_static_reset('file_get_file_references:field_columns')` to
+  `\Drupal::service('cache.memory')->invalidateTags(['file_references'])`.
+  Both static-cache keys were deprecated in drupal:11.4.0 (removed in
+  drupal:13.0.0) when the file-reference lookup moved to the new
+  `FileReferenceResolver` service, which uses the `file_references`
+  memory-cache tag instead of `drupal_static()`. Only those two literal keys
+  are matched; other `drupal_static_reset()` calls, calls to
+  `file_get_file_references()` itself, and named/unpacked argument forms are
+  intentionally left for manual review. BC-wrapped via `DeprecationHelper`:
+  the `file_references` cache tag does not exist before drupal:11.4.0, so the
+  new call would be a silent no-op there — the wrapper keeps the original
+  `drupal_static_reset()` on older versions and only switches to the
+  `cache.memory` invalidation on drupal:11.4.0 and above.
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -22,6 +22,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\RemoveSetUriCallbackRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveToolkitArgFromImageToolkitOperationConstructorRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveTrustDataCallRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveViewsRowCacheKeysRector;
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceDrupalStaticResetFileReferencesRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceEntityReferenceRecursiveLimitRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceExpectDeprecationRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceHideShowWithPrintedRector;
@@ -498,6 +499,24 @@ return static function (RectorConfig $rectorConfig): void {
     // DrupalTestCaseTrait::getDrupalRoot() deprecated in drupal:11.4.0, removed in drupal:13.0.0.
     // Replaced by direct access to the $this->root property on Drupal base test classes.
     $rectorConfig->rule(GetDrupalRootToRootPropertyRector::class);
+
+    // https://www.drupal.org/node/1452100
+    // https://www.drupal.org/node/3573884 (change record)
+    // drupal_static_reset('file_get_file_references') and
+    // drupal_static_reset('file_get_file_references:field_columns') deprecated in
+    // drupal:11.4.0, removed in drupal:13.0.0. Replaced by
+    // \Drupal::service('cache.memory')->invalidateTags(['file_references']).
+    // BC-wrapped: the 'file_references' cache tag does not exist before 11.4.0, so
+    // the new call would be a silent no-op there; the DeprecationHelper wrapper
+    // keeps the original drupal_static_reset() on older versions.
+    // TODO PHPSTAN_MESSAGES ReplaceDrupalStaticResetFileReferencesRector:
+    //   No PHPStan deprecation is emitted. The deprecated thing is the static-cache
+    //   key string passed to drupal_static_reset(); the deprecation lives in a
+    //   runtime @trigger_error inside file_get_file_references(), not on a
+    //   @deprecated PHP symbol PHPStan analyses. Nothing to match.
+    $rectorConfig->ruleWithConfiguration(ReplaceDrupalStaticResetFileReferencesRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
 
     // https://www.drupal.org/node/3550268
     // https://www.drupal.org/node/3545276 (change record)

--- a/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces drupal_static_reset() for the deprecated file_get_file_references
+ * static-cache keys with cache.memory tag invalidation.
+ *
+ * Both static-cache keys ('file_get_file_references' and
+ * 'file_get_file_references:field_columns') were deprecated in drupal:11.4.0
+ * when the file-reference lookup moved to the new FileReferenceResolver
+ * service, which caches in the 'cache.memory' bin under the 'file_references'
+ * cache tag instead of drupal_static().
+ *
+ * The replacement is BC-wrapped: on Drupal < 11.4.0 the 'file_references'
+ * cache tag does not exist, so calling invalidateTags() there would be a
+ * silent no-op instead of resetting the drupal_static() the old code path
+ * actually uses. The DeprecationHelper wrapper therefore keeps the original
+ * drupal_static_reset() call on older versions and only switches to the
+ * cache.memory invalidation on drupal:11.4.0 and above.
+ *
+ * Calls to file_get_file_references() itself are intentionally left untouched:
+ * its replacement FileReferenceResolver::getReferences() returns a Generator
+ * of FileReferenceUsage objects rather than the old nested array, so callers
+ * need manual refactoring. Named-argument and unpacked-argument forms of
+ * drupal_static_reset() are also left for manual review.
+ *
+ * @see https://www.drupal.org/node/1452100
+ * @see https://www.drupal.org/node/3573884
+ */
+class ReplaceDrupalStaticResetFileReferencesRector extends AbstractDrupalCoreRector
+{
+    /** @var DrupalIntroducedVersionConfiguration[] */
+    protected array $configuration;
+
+    // Both static keys were deprecated together (drupal:11.4.0).
+    private const DEPRECATED_KEYS = [
+        'file_get_file_references',
+        'file_get_file_references:field_columns',
+    ];
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    public function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof FuncCall);
+
+        if (!$this->isName($node->name, 'drupal_static_reset')) {
+            return null;
+        }
+        if (count($node->args) !== 1) {
+            return null;
+        }
+        $firstArg = $node->args[0];
+        if (!$firstArg instanceof Arg) {
+            return null;
+        }
+        // Skip named and unpacked args — they are exotic enough to leave for
+        // manual review.
+        if ($firstArg->name !== null || $firstArg->unpack) {
+            return null;
+        }
+        if (!$firstArg->value instanceof String_) {
+            return null;
+        }
+        if (!in_array($firstArg->value->value, self::DEPRECATED_KEYS, true)) {
+            return null;
+        }
+
+        return new MethodCall(
+            new StaticCall(
+                new FullyQualified('Drupal'),
+                'service',
+                [new Arg(new String_('cache.memory'))],
+            ),
+            'invalidateTags',
+            [new Arg(new Array_([new ArrayItem(new String_('file_references'))]))],
+        );
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace drupal_static_reset() for file_get_file_references keys with cache tag invalidation',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_BEFORE'
+drupal_static_reset('file_get_file_references');
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+\Drupal::service('cache.memory')->invalidateTags(['file_references']);
+CODE_AFTER,
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+            ]
+        );
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/ReplaceDrupalStaticResetFileReferencesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/ReplaceDrupalStaticResetFileReferencesRectorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceDrupalStaticResetFileReferencesRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class ReplaceDrupalStaticResetFileReferencesRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /** @return \Iterator<array<string>> */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /** @return \Iterator<array<string>> */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceDrupalStaticResetFileReferencesRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(ReplaceDrupalStaticResetFileReferencesRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+function reset_file_reference_statics() {
+    drupal_static_reset('file_get_file_references');
+    drupal_static_reset('file_get_file_references:field_columns');
+}
+
+?>
+-----
+<?php
+
+function reset_file_reference_statics() {
+    drupal_static_reset('file_get_file_references');
+    drupal_static_reset('file_get_file_references:field_columns');
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/fixture/basic.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+function reset_file_reference_statics() {
+    drupal_static_reset('file_get_file_references');
+    drupal_static_reset('file_get_file_references:field_columns');
+}
+
+?>
+-----
+<?php
+
+function reset_file_reference_statics() {
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('cache.memory')->invalidateTags(['file_references']), fn() => drupal_static_reset('file_get_file_references'));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('cache.memory')->invalidateTags(['file_references']), fn() => drupal_static_reset('file_get_file_references:field_columns'));
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/fixture/no_change.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/fixture/no_change.php.inc
@@ -1,0 +1,17 @@
+<?php
+
+function unrelated_static_resets($key) {
+    // Different static-cache key — not one of the deprecated file-reference keys.
+    drupal_static_reset('some_other_cache');
+    // Non-string argument — left for manual review.
+    drupal_static_reset($key);
+    // No argument — resets everything, unrelated to file references.
+    drupal_static_reset();
+    // Named argument — left for manual review.
+    drupal_static_reset(name: 'file_get_file_references');
+    // Unpacked argument — left for manual review.
+    $args = ['file_get_file_references'];
+    drupal_static_reset(...$args);
+}
+
+?>


### PR DESCRIPTION
## Summary

Adds `ReplaceDrupalStaticResetFileReferencesRector`, which rewrites the two deprecated `drupal_static_reset()` file-reference cache keys to `cache.memory` tag invalidation:

```php
// before
drupal_static_reset('file_get_file_references');
drupal_static_reset('file_get_file_references:field_columns');

// after (≥ 11.4.0)
\Drupal::service('cache.memory')->invalidateTags(['file_references']);
```

Both keys were deprecated in **drupal:11.4.0** (removed in 13.0.0) when the file-reference lookup moved to the new `FileReferenceResolver` service, which caches in the `cache.memory` bin under the `file_references` cache tag instead of `drupal_static()`.

## Why BC-wrapped

`cache.memory` and `invalidateTags()` predate 11.4.0, so the replacement does **not** fatal on older Drupal — but the `file_references` cache tag was introduced *with* this deprecation. On 11.3 and earlier the new call invalidates a tag nothing uses and never resets the `drupal_static()` the old code path actually relies on — a silent no-op. The rector therefore extends `AbstractDrupalCoreRector` and wraps the replacement in `DeprecationHelper::backwardsCompatibleCall()`, keeping the original `drupal_static_reset()` on versions below 11.4.0.

## Scope

Only the two literal keys are matched. Calls to `file_get_file_references()` itself (its replacement returns a `Generator`, needing manual refactoring), other `drupal_static_reset()` keys, and named/unpacked argument forms are intentionally left for manual review.

## Testing

- `testAboveVersion` (99.99.99) → BC-wrapped output; `testBelowVersion` (1.0.0) → unchanged. No-change fixture covers other keys, dynamic/no-arg/named/unpacked forms.
- Verified against a real Drupal 11 install (synthetic probe — no contrib module uses this niche, recently-deprecated pattern).
- `phpstan` clean, `fix-style` clean.

Issue: https://www.drupal.org/node/1452100
Change record: https://www.drupal.org/node/3573884