### PR TITLE
docs(skills): add silent-divergence (Q4b) check to the BC decision

### DIFF
--- a/.claude/skills/prompts/digest-to-rector-prompt.md
+++ b/.claude/skills/prompts/digest-to-rector-prompt.md
@@ -146,16 +146,41 @@ Ask: *Could the transformed code run unchanged on a Drupal version that predates
   > Example: `locale_config_batch_set_config_langcodes()` → `locale_config_batch_update_default_config_langcodes()`.
   > The new function only exists on Drupal ≥ 11.1.0; calling it on 11.0.x would fail.
 
-- **No, the replacement is version-agnostic** → BC wrapping is **NOT** needed — use `AbstractRector`.
+- **No, the replacement is version-agnostic** → continue to Q4b before concluding.
   The replacement is pure PHP, uses only native PHP functions, or uses Drupal APIs that existed
   long before this deprecation. The transformed code is safe to run on any Drupal version, so
   there is nothing to guard with a version check.
   > Example: `uasort($arr, 'system_sort_themes')` → `uasort($arr, static function ($a, $b) { … })`.
   > The inline closure is pure PHP and works on every Drupal version; BC wrapping adds no value.
 
+**Q4b: Even if it won't fatal, is the replacement behaviorally equivalent on pre-deprecation versions?**
+
+This catches the case Q4 misses: the replacement uses only old symbols (so it won't fatal), but
+its *effect* depends on infrastructure introduced **alongside** the deprecation — a new cache bin
+or cache tag, a new service that now owns the data, a new storage location, a changed default.
+On an older Drupal the symbols resolve fine but the call does **nothing** (or something different)
+compared to the original. A silent no-op is a real BC break, just a quieter one than a fatal.
+
+Ask: *On a Drupal version that predates the deprecation, does the replacement produce the same
+observable effect as the original — not just "does it run"?*
+
+- **No — it silently no-ops or diverges on old versions** → BC wrapping IS needed.
+  Even though no symbol is missing, wrap it so the original call runs on old versions and the new
+  call runs on new ones. Use `AbstractDrupalCoreRector`.
+  > Example: `drupal_static_reset('file_get_file_references')` →
+  > `\Drupal::service('cache.memory')->invalidateTags(['file_references'])`. The `cache.memory`
+  > service and `invalidateTags()` existed long before 11.4.0 (no fatal), but the `file_references`
+  > cache tag was introduced *with* the deprecation — so on 11.3 the new call invalidates a tag
+  > nothing uses and never resets the `drupal_static()` the old code path actually relies on.
+  > Behaviorally equivalent only on 11.4+. BC-wrap it.
+
+- **Yes — same effect on every supported version** → BC wrapping is **NOT** needed — use `AbstractRector`.
+  > Example: the `system_sort_themes` closure above — pure PHP, identical behavior everywhere.
+
 **Decision:**
-- Q2 eligible AND Q3 >= 10.1.0 AND Q4 = new API → Use `AbstractDrupalCoreRector` + `DrupalIntroducedVersionConfiguration`
-- Q4 = version-agnostic replacement (or Q2/Q3 not met) → Use `AbstractRector`
+- Q2 eligible AND Q3 >= 10.1.0 AND (Q4 = new API **OR** Q4b = silent divergence on old versions)
+  → Use `AbstractDrupalCoreRector` + `DrupalIntroducedVersionConfiguration`
+- Q4b = truly version-agnostic (same observable effect everywhere), or Q2/Q3 not met → Use `AbstractRector`
 
 **Quick reference:**
 

--- a/.claude/skills/rector-qa/SKILL.md
+++ b/.claude/skills/rector-qa/SKILL.md
@@ -194,14 +194,35 @@ Do not run the other passes in bulk mode.
      - Ask: could this replacement code run unchanged on a Drupal version that predates the deprecation?
      - **New Drupal API** (function/method/class introduced alongside the deprecation) → BC needed.
      - **Pure PHP or version-agnostic** (native functions, inline closures, no new Drupal symbols) → BC NOT needed.
+   - **Q4b (silent-divergence check — do NOT skip):** If Q4 said "version-agnostic", confirm the
+     replacement is also *behaviorally equivalent* on old versions, not merely non-fatal. A
+     replacement can use only old symbols yet still depend on infrastructure shipped **with** the
+     deprecation — a new cache bin/tag, a new service that now owns the data, a new storage
+     location, a changed default. On older Drupal it runs without error but produces a **different
+     effect (often a silent no-op)** than the original. That is a BC break and requires wrapping.
+     - **Verify against core history**, do not eyeball it. Find the commit that introduced the
+       deprecation and check whether the thing the replacement targets (the cache tag, service,
+       bin, option) existed *before* it:
+       ```bash
+       cd repos/drupal-core
+       git log --oneline -3 -- <path/to/new/Service.php>          # find the introducing commit <sha>
+       git grep -n "<tag-or-service-or-symbol>" <sha>~1 -- core/  # was it there BEFORE? empty = no
+       ```
+       If the target only appears at `<sha>` and not `<sha>~1`, the replacement silently diverges
+       on older versions → **BC needed** even though Q4 found no missing symbol.
+     - Reference case: `ReplaceDrupalStaticResetFileReferencesRector` — `cache.memory`/`invalidateTags()`
+       are old (no fatal), but the `file_references` cache tag was introduced with the 11.4.0
+       deprecation, so the new call is a no-op on 11.3. It is correctly `AbstractDrupalCoreRector`.
 
 3. Expected base class:
-   - Q2 = Expr → Expr AND Q3 = version >= 10.1.0 AND **Q4 = new Drupal API** → **`AbstractDrupalCoreRector`**
-   - Q4 = version-agnostic replacement (or Q2/Q3 not met) → **`AbstractRector`**
+   - Q2 = Expr → Expr AND Q3 = version >= 10.1.0 AND (**Q4 = new Drupal API** OR **Q4b = silent
+     divergence on old versions**) → **`AbstractDrupalCoreRector`**
+   - Q4b = truly version-agnostic (identical observable effect on every supported version), or
+     Q2/Q3 not met → **`AbstractRector`**
 
 4. Compare expected vs actual.
 
-**Output:** `Pass 3: [PASS|FAIL] — expected <base class>, found <base class>`
+**Output:** `Pass 3: [PASS|FAIL] — expected <base class>, found <base class> (note Q4b result)`
 
 **If FAIL:** The base class is wrong. Propose the corrected class and note that `configure()`, `refactorWithConfiguration()`, and the test class will need updating.
 


### PR DESCRIPTION
## Summary

Strengthens the BC-decision logic in the rector-authoring skills so they catch a class of bug the current criterion misses.

Both `digest-to-rector-prompt.md` (Step 4) and `rector-qa` (Pass 3) only asked: *"does the replacement use a **new symbol** → would it fatal on old Drupal?"* That screen passes any replacement built from old symbols — even when the replacement's **effect** depends on infrastructure introduced *with* the deprecation (a new cache tag/bin, a new service that now owns the data, a changed default). On older Drupal such a replacement runs without error but **silently no-ops or diverges** from the original. That's a real BC break, just quieter than a fatal.

## What changed

Adds an explicit **Q4b "silent-divergence" check** to both docs:

> Even if it won't fatal, is the replacement *behaviorally equivalent* on pre-deprecation versions — not merely "does it run"?

- Updated the decision rule: BC-wrap when **Q4 (new API) OR Q4b (silent divergence)**.
- rector-qa Pass 3 now includes a concrete way to verify it against `repos/drupal-core` git history (was the targeted tag/service/symbol present *before* the introducing commit?), rather than eyeballing it.
- Uses `ReplaceDrupalStaticResetFileReferencesRector` (the `file_references` cache tag, new in 11.4.0 although `cache.memory`/`invalidateTags()` are old) as the worked reference case.

## Motivation

Found while implementing that rector (#342): the digest had chosen `AbstractRector` (no BC) on the "no new symbol → no fatal" reasoning, but the rewrite is a silent no-op on 11.3 because the `file_references` tag doesn't exist there. The criterion as written would not have flagged it — this change makes the next one catch it.