### PR TITLE
fix(Drupal11): Complete coverage for image/responsive_image removals (#3574424)

### DIFF
--- a/config/drupal-11/drupal-11.1-deprecations.php
+++ b/config/drupal-11/drupal-11.1-deprecations.php
@@ -107,7 +107,8 @@ return static function (RectorConfig $rectorConfig): void {
     // https://www.drupal.org/node/3488176
     // drupal_common_theme() removed in drupal:11.1.0.
     // Replaced by \Drupal\Core\Theme\ThemeCommonElements::commonElements().
-    // https://www.drupal.org/node/3268441
+    // https://www.drupal.org/node/3574424 (digest issue)
+    // https://www.drupal.org/node/3268441 (change record)
     // image_filter_keyword() deprecated in drupal:11.1.0, removed in drupal:12.0.0.
     // Replaced by \Drupal\Component\Utility\Image::getKeywordOffset().
     $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [

--- a/config/drupal-11/drupal-11.3-deprecations.php
+++ b/config/drupal-11/drupal-11.3-deprecations.php
@@ -112,14 +112,15 @@ return static function (RectorConfig $rectorConfig): void {
         new DrupalIntroducedVersionConfiguration('11.3.0'),
     ]);
 
-    // https://www.drupal.org/node/3548329
+    // https://www.drupal.org/node/3574424 (digest issue)
+    // https://www.drupal.org/node/3548329 (change record)
     // responsive_image_* functions deprecated in drupal:11.3.0, removed in drupal:12.0.0.
     // Replaced by \Drupal::service(ResponsiveImageBuilder::class)->method() calls.
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class, [
-        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_build_source_attributes', 'Drupal\responsive_image\ResponsiveImageBuilder', 'buildSourceAttributes'),
-        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_image_dimensions', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageDimensions'),
-        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_mime_type', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getMimeType'),
-        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_image_style_url', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageStyleUrl'),
+        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_build_source_attributes', 'Drupal\responsive_image\ResponsiveImageBuilder', 'buildSourceAttributes', true),
+        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_image_dimensions', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageDimensions', true),
+        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_mime_type', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getMimeType', true),
+        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_image_style_url', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageStyleUrl', true),
     ]);
 
     // https://www.drupal.org/node/3489266

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
@@ -27,11 +27,11 @@ return static function (RectorConfig $rectorConfig): void {
         new FunctionToServiceConfiguration('11.2.0', 'template_preprocess_container', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessContainer'),
         new FunctionToServiceConfiguration('11.2.0', 'template_preprocess_html', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessHtml'),
         new FunctionToServiceConfiguration('11.2.0', 'template_preprocess_page', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessPage'),
-        // https://www.drupal.org/node/3548329 (Drupal 11.3)
-        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_build_source_attributes', 'Drupal\responsive_image\ResponsiveImageBuilder', 'buildSourceAttributes'),
-        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_image_style_url', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageStyleUrl'),
-        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_image_dimensions', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageDimensions'),
-        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_mime_type', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getMimeType'),
+        // https://www.drupal.org/node/3574424 (digest issue) / https://www.drupal.org/node/3548329 (change record, Drupal 11.3)
+        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_build_source_attributes', 'Drupal\responsive_image\ResponsiveImageBuilder', 'buildSourceAttributes', true),
+        new FunctionToServiceConfiguration('11.3.0', '_responsive_image_image_style_url', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageStyleUrl', true),
+        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_image_dimensions', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getImageDimensions', true),
+        new FunctionToServiceConfiguration('11.3.0', 'responsive_image_get_mime_type', 'Drupal\responsive_image\ResponsiveImageBuilder', 'getMimeType', true),
         // https://www.drupal.org/node/3533083 (Drupal 11.3)
         new FunctionToServiceConfiguration('11.3.0', 'node_mass_update', 'Drupal\node\NodeBulkUpdate', 'process', true),
         // https://www.drupal.org/node/3571382 (Drupal 11.3)

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/responsive_image_functions.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/responsive_image_functions.php.inc
@@ -11,9 +11,9 @@ function example($variables, $breakpoint, $multipliers, $image_style_name, $dime
 <?php
 
 function example($variables, $breakpoint, $multipliers, $image_style_name, $dimensions, $uri, $extension, $style_name, $path) {
-    $attributes = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\responsive_image\ResponsiveImageBuilder')->buildSourceAttributes($variables, $breakpoint, $multipliers), fn() => _responsive_image_build_source_attributes($variables, $breakpoint, $multipliers));
-    $dims = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\responsive_image\ResponsiveImageBuilder')->getImageDimensions($image_style_name, $dimensions, $uri), fn() => responsive_image_get_image_dimensions($image_style_name, $dimensions, $uri));
-    $mime = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\responsive_image\ResponsiveImageBuilder')->getMimeType($image_style_name, $extension), fn() => responsive_image_get_mime_type($image_style_name, $extension));
-    $url = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\responsive_image\ResponsiveImageBuilder')->getImageStyleUrl($style_name, $path), fn() => _responsive_image_image_style_url($style_name, $path));
+    $attributes = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service(\Drupal\responsive_image\ResponsiveImageBuilder::class)->buildSourceAttributes($variables, $breakpoint, $multipliers), fn() => _responsive_image_build_source_attributes($variables, $breakpoint, $multipliers));
+    $dims = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service(\Drupal\responsive_image\ResponsiveImageBuilder::class)->getImageDimensions($image_style_name, $dimensions, $uri), fn() => responsive_image_get_image_dimensions($image_style_name, $dimensions, $uri));
+    $mime = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service(\Drupal\responsive_image\ResponsiveImageBuilder::class)->getMimeType($image_style_name, $extension), fn() => responsive_image_get_mime_type($image_style_name, $extension));
+    $url = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service(\Drupal\responsive_image\ResponsiveImageBuilder::class)->getImageStyleUrl($style_name, $path), fn() => _responsive_image_image_style_url($style_name, $path));
 }
 ?>

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/config/configured_rule.php
@@ -31,5 +31,7 @@ return static function (RectorConfig $rectorConfig): void {
         // https://www.drupal.org/node/3495966 (Drupal 11.2)
         new FunctionToStaticConfiguration('11.2.0', 'entity_test_create_bundle', 'Drupal\entity_test\EntityTestHelper', 'createBundle'),
         new FunctionToStaticConfiguration('11.2.0', 'entity_test_delete_bundle', 'Drupal\entity_test\EntityTestHelper', 'deleteBundle'),
+        // https://www.drupal.org/node/3574424 (digest issue) / https://www.drupal.org/node/3268441 (change record, Drupal 11.1)
+        new FunctionToStaticConfiguration('11.1.0', 'image_filter_keyword', 'Drupal\Component\Utility\Image', 'getKeywordOffset'),
     ]);
 };

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/image_filter_keyword.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/fixture/image_filter_keyword.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+function example($anchor, $current_size, $new_size) {
+    $offset = image_filter_keyword($anchor, $current_size, $new_size);
+}
+?>
+-----
+<?php
+
+function example($anchor, $current_size, $new_size) {
+    $offset = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.1.0', fn() => \Drupal\Component\Utility\Image::getKeywordOffset($anchor, $current_size, $new_size), fn() => image_filter_keyword($anchor, $current_size, $new_size));
+}
+?>


### PR DESCRIPTION
## What

Issue [#3574424](https://www.drupal.org/node/3574424) removes five procedural functions across the `image` and `responsive_image` modules. They are handled — as intended — by two generic config-only rectors, split by introduced version. This PR closes two gaps in that coverage.

### `responsive_image_*()` (4 functions, 11.3.0, `FunctionToServiceRector`)
Added the `useClassSyntax` flag (5th arg `true`) so the rewrite emits:

```php
\Drupal::service(\Drupal\responsive_image\ResponsiveImageBuilder::class)->getMimeType(...)
```

instead of a string-literal service id. This matches the digest's intended output and the sibling `node_mass_update` entry. `Foo::class` on a literal class name is a **compile-time string constant** — it never autoloads or checks the class exists — so this is byte-for-byte equivalent at runtime and refactor-safe.

### `image_filter_keyword()` (11.1.0, `FunctionToStaticRector`)
Was registered in `drupal-11.1-deprecations.php` but had **no test coverage**. Added a BC-wrapped fixture and the test-config entry.

### Discoverability
Cross-referenced the digest issue (`3574424`) alongside the existing change-record URLs (`3268441`, `3548329`) in both deprecations configs and test configs.

## Test plan
- `vendor/bin/phpunit tests/src/Rector/Deprecation/FunctionToServiceRector/ tests/src/Rector/Deprecation/FunctionToStaticRector/` → **38/38 pass**
- `composer phpstan` → no errors
- `composer fix-style` → clean