### PR TITLE
feat(index): bridge config↔digest via shared change-record citations

### DIFF
--- a/.claude/scripts/generate-rector-index.php
+++ b/.claude/scripts/generate-rector-index.php
@@ -83,8 +83,15 @@ function main(array $argv): void
     $cacheDir = $repoRoot . '/.claude/cache/drupal-issues';
     $citedSiblings = buildCitedSiblingMap($repoRoot . '/config', $cacheDir);
 
-    // Step 3b: Mark config-only / implemented entries found in any config/* subdir.
-    scanConfigFiles($repoRoot . '/config', $entries, $implementedClasses, $citedSiblings);
+    // Step 3b: Bridge config ↔ digest via shared citations. A config block often
+    // cites the change record (CR), while a digest filename uses a follow-up/cleanup
+    // issue the CR's field_issues never lists (so Step 3a cannot reach it). The digest
+    // file itself usually @see's that same CR, so matching on the shared citation
+    // connects them when the field_issues path comes up empty.
+    $digestCitations = buildDigestCitationMap($entries, $rulesDir, $cacheDir);
+
+    // Step 3c: Mark config-only / implemented entries found in any config/* subdir.
+    scanConfigFiles($repoRoot . '/config', $entries, $implementedClasses, $citedSiblings, $digestCitations);
 
     // Step 4: Add unmatched custom classes (no digest file found).
     foreach ($unmatched as $className => $data) {
@@ -414,8 +421,9 @@ function buildClassMap(array $entries, array $unmatched): array
  * @param array<string, array<string, mixed>> $entries
  * @param array<string, array<string, mixed>> $implementedClasses
  * @param array<string, list<string>> $citedSiblings  citedIssue → [siblingIssueIds]
+ * @param array<string, list<string>> $digestCitations  citedNodeId → [digestIssueId]
  */
-function scanConfigFiles(string $configRoot, array &$entries, array $implementedClasses, array $citedSiblings = []): void
+function scanConfigFiles(string $configRoot, array &$entries, array $implementedClasses, array $citedSiblings = [], array $digestCitations = []): void
 {
     foreach (glob($configRoot . '/*/', GLOB_ONLYDIR) as $configDir) {
         $dirName = basename(rtrim($configDir, '/'));
@@ -426,7 +434,7 @@ function scanConfigFiles(string $configRoot, array &$entries, array $implemented
             }
             $content = file_get_contents($configFile);
             $relFile  = 'config/' . $dirName . '/' . basename($configFile);
-            parseConfigBlock($content, $relFile, $entries, $implementedClasses, $citedSiblings);
+            parseConfigBlock($content, $relFile, $entries, $implementedClasses, $citedSiblings, $digestCitations);
         }
     }
 }
@@ -440,8 +448,9 @@ function scanConfigFiles(string $configRoot, array &$entries, array $implemented
  * @param array<string, array<string, mixed>> $entries
  * @param array<string, array<string, mixed>> $implementedClasses  shortClassName => {class, files}
  * @param array<string, list<string>> $citedSiblings  citedIssue → [siblingIssueIds]
+ * @param array<string, list<string>> $digestCitations  citedNodeId → [digestIssueId]
  */
-function parseConfigBlock(string $content, string $relFile, array &$entries, array $implementedClasses, array $citedSiblings = []): void
+function parseConfigBlock(string $content, string $relFile, array &$entries, array $implementedClasses, array $citedSiblings = [], array $digestCitations = []): void
 {
     $lines = explode("\n", $content);
     $pendingIssues = [];
@@ -461,7 +470,7 @@ function parseConfigBlock(string $content, string $relFile, array &$entries, arr
 
         if ($isRuleCall) {
             $shortClass = extractShortClassName($m[1]);
-            $expandedIssues = expandIssuesViaSiblings($pendingIssues, $citedSiblings);
+            $expandedIssues = expandIssuesViaSiblings($pendingIssues, $citedSiblings, $digestCitations);
 
             if (isset(GENERIC_RECTORS[$shortClass])) {
                 // Generic rector — mark as config-only.
@@ -569,18 +578,81 @@ function buildCitedSiblingMap(string $configRoot, string $cacheDir): array
  *
  * @param list<string> $citedIssues
  * @param array<string, list<string>> $citedSiblings
+ * @param array<string, list<string>> $digestCitations  citedNodeId → [digestIssueId]
  * @return list<string>
  */
-function expandIssuesViaSiblings(array $citedIssues, array $citedSiblings): array
+function expandIssuesViaSiblings(array $citedIssues, array $citedSiblings, array $digestCitations = []): array
 {
     $expanded = [];
     foreach ($citedIssues as $issue) {
         $expanded[$issue] = true;
+        // CR → the deprecation issue(s) named in its field_issues.
         foreach ($citedSiblings[$issue] ?? [] as $siblingId) {
             $expanded[$siblingId] = true;
         }
+        // Any digest entry whose own @see citations name this node (e.g. the
+        // digest @see's the CR the config cites). Bridges the case where the
+        // digest's filename issue is not in the CR's field_issues.
+        foreach ($digestCitations[$issue] ?? [] as $digestId) {
+            $expanded[$digestId] = true;
+        }
     }
     return array_keys($expanded);
+}
+
+/**
+ * Builds a map from every drupal.org node ID cited inside a digest file (via
+ * @see URLs or issue links) to the digest entries that cite it.
+ *
+ * Config blocks usually cite the change record (CR), while a digest filename
+ * often uses a follow-up/cleanup issue the CR's field_issues never lists — so
+ * the CR→field_issues bridge (buildCitedSiblingMap) cannot reach it. The digest
+ * file itself, however, typically @see's that same CR. Matching on the shared
+ * citation connects config ↔ digest in exactly those cases.
+ *
+ * A digest's own issue number is skipped (it already matches the entry key
+ * directly), so this only adds genuinely indirect links. Only change records
+ * (changenotice nodes) are kept as bridge keys — the same authoritative-grouping
+ * philosophy as buildCitedSiblingMap. A shared plain-issue citation is too weak
+ * a signal and would risk false positives; the CR is the deliberate grouping.
+ *
+ * @param array<string, array<string, mixed>> $entries
+ * @return array<string, list<string>>  citedCrNodeId → [digestIssueId, ...]
+ */
+function buildDigestCitationMap(array $entries, string $rulesDir, string $cacheDir): array
+{
+    $map = [];
+    $isChangeRecord = [];
+    foreach ($entries as $issueId => $entry) {
+        $file = $entry['digest_file'] ?? null;
+        if (!is_string($file)) {
+            continue;
+        }
+        $path = $rulesDir . '/' . $file;
+        if (!is_file($path)) {
+            continue;
+        }
+        $content = file_get_contents($path);
+        if (!preg_match_all('#drupal\.org/(?:node|project/[\w-]+/issues)/(\d+)#', $content, $m)) {
+            continue;
+        }
+        foreach (array_unique($m[1]) as $citedId) {
+            $citedId = (string) $citedId;
+            if ($citedId === (string) $issueId) {
+                continue; // self-citation already matches the entry key directly
+            }
+            // Only bridge through change records, not coincidental shared issues.
+            if (!array_key_exists($citedId, $isChangeRecord)) {
+                $node = loadIssueNodeCached($citedId, $cacheDir);
+                $isChangeRecord[$citedId] = $node !== null && ($node['type'] ?? null) === 'changenotice';
+            }
+            if (!$isChangeRecord[$citedId]) {
+                continue;
+            }
+            $map[$citedId][] = (string) $issueId;
+        }
+    }
+    return $map;
 }
 
 /**


### PR DESCRIPTION
## Problem

`generate-rector-index.php`'s config-only matcher keys marks off the issue **cited in a config block** (usually the change record), expanded through the CR's `field_issues`. When a digest filename uses a follow-up/cleanup issue that the CR never lists in `field_issues`, that path can't reach it — so the entry stays `pending` in `docs/rector-index.yml` despite being fully wired up in config.

Concrete case: `template_preprocess_layout` (#3571382) is implemented via `FunctionToServiceRector` in `drupal-11.3-deprecations.php`, but showed as `pending` because the config cites CR `3504125`, whose `field_issues` lists only `3501136`/`3504381` — not the digest's filename issue `3571382`. This wasted a `/rector-implement` pass.

## Fix

Add `buildDigestCitationMap()`: read each digest file's own `@see`/issue citations, keep only those that are **change records** (`changenotice` type, via the existing cache), and expand config citations through them. A digest that `@see`s the same CR a config block cites is now marked `config-only`.

- Mirrors `buildCitedSiblingMap`'s CR-grouping philosophy (the reverse direction).
- Restricting to change records avoids false positives from coincidental shared-issue citations.

## Verification

- `php -l` clean; generator deterministic.
- Isolated the bridge's effect by regenerating with it neutralized and diffing: **exactly one entry flips** (`3571382` `pending → config-only`), zero collateral.

## Known limitation

The `files:` pointer for a bridged entry can list the wrong-version config file (e.g. `11.2` instead of `11.3`) when the broad CR is cited by multiple version blocks — pre-existing "first glob wins" behavior that also affects `field_issues`-bridged entries. Status is correct; only the convenience pointer is imprecise. Accurate attribution would need per-entry deprecated-symbol matching against config block contents.