### PR TITLE
feat(rector): add HookRequirementsAlterRenameRector to breaking set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ release-by-release.
 
 ### Added
 
+- **`HookRequirementsAlterRenameRector`** — renames procedural
+  `{module}_requirements_alter()` hook implementations to
+  `{module}_runtime_requirements_alter()`, deprecated in drupal:11.3.0 and
+  removed in drupal:13.0.0. The runtime hook is only invoked on Drupal minors
+  where it exists, so the renamed function is a silent no-op on older Drupal;
+  this is a non-BC rewrite and ships in the opt-in `DRUPAL_113_BREAKING` set, not
+  the default deprecation set. The rule only renames functions with a single
+  by-reference parameter, skips the `hook_requirements_alter()` API-doc function,
+  and is idempotent — the `_runtime_`/`_update_requirements_alter()` hooks are
+  left untouched.
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.3-breaking.php
+++ b/config/drupal-11/drupal-11.3-breaking.php
@@ -15,10 +15,23 @@ declare(strict_types=1);
  * Opt in via `Drupal11SetList::DRUPAL_113_BREAKING`.
  */
 
+use DrupalRector\Drupal11\Rector\Deprecation\HookRequirementsAlterRenameRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    // https://www.drupal.org/node/3490846
+    // https://www.drupal.org/node/3549685 (change record)
+    // hook_requirements_alter() deprecated in drupal:11.3.0, removed in
+    // drupal:13.0.0. Renames procedural {module}_requirements_alter() to
+    // {module}_runtime_requirements_alter(). The runtime hook is only invoked on
+    // Drupal minors where it exists, so on older Drupal the renamed function is
+    // never called (a silent no-op) — a non-BC rewrite. It cannot be BC-wrapped
+    // (a function declaration is not an Expr → Expr transformation), hence the
+    // breaking set. Apply only after dropping support for Drupal minors that
+    // predate hook_runtime_requirements_alter().
+    $rectorConfig->rule(HookRequirementsAlterRenameRector::class);
+
     // https://www.drupal.org/node/3551446
     // https://www.drupal.org/node/3551450 (change record)
     // workspaces.association service / WorkspaceAssociationInterface renamed

--- a/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector.php
+++ b/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt\Function_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Renames procedural {module}_requirements_alter() implementations to
+ * {module}_runtime_requirements_alter().
+ *
+ * hook_requirements_alter() is deprecated in drupal:11.3.0 and removed in
+ * drupal:13.0.0. The most common use case is altering status-report (runtime)
+ * requirements, which maps directly to the new hook_runtime_requirements_alter().
+ * Modules that also alter update-phase requirements must manually add a
+ * {module}_update_requirements_alter() function.
+ *
+ * This is a NON-backward-compatible rewrite: hook_runtime_requirements_alter()
+ * is only invoked on Drupal minors where it exists, so the renamed function is
+ * never called on older Drupal (a silent no-op). It cannot be BC-wrapped — a
+ * function declaration is not an Expr → Expr transformation, so DeprecationHelper
+ * does not apply. The rule therefore lives in the opt-in DRUPAL_113_BREAKING set,
+ * not the default deprecation set. Only apply it after dropping support for the
+ * Drupal minors that predate hook_runtime_requirements_alter().
+ *
+ * @see https://www.drupal.org/node/3490846
+ * @see https://www.drupal.org/node/3549685
+ */
+final class HookRequirementsAlterRenameRector extends AbstractRector
+{
+    private const SUFFIX = '_requirements_alter';
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename {module}_requirements_alter() procedural hook implementations to {module}_runtime_requirements_alter() as required by the deprecation of hook_requirements_alter() in drupal:11.3.0.',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+function mymodule_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+function mymodule_runtime_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}
+CODE_AFTER
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [Function_::class];
+    }
+
+    /** @param Function_ $node */
+    public function refactor(Node $node): ?Node
+    {
+        $name = $node->name->toString();
+
+        // Exclude the API documentation function itself.
+        if ($name === 'hook_requirements_alter') {
+            return null;
+        }
+
+        // Match procedural implementations: {module_name}_requirements_alter.
+        if (!str_ends_with($name, self::SUFFIX)) {
+            return null;
+        }
+
+        // Skip the new hook names so the rule is idempotent and never clobbers
+        // already-migrated implementations — both also end in _requirements_alter.
+        if (str_ends_with($name, '_runtime_requirements_alter')
+            || str_ends_with($name, '_update_requirements_alter')) {
+            return null;
+        }
+
+        // Must have exactly one parameter (the $requirements array by reference).
+        if (count($node->params) !== 1) {
+            return null;
+        }
+
+        // The parameter must be passed by reference (array &$requirements).
+        if (!$node->params[0]->byRef) {
+            return null;
+        }
+
+        // Rename *_requirements_alter to *_runtime_requirements_alter.
+        $prefix = substr($name, 0, -strlen(self::SUFFIX));
+        $node->name = new Identifier($prefix.'_runtime_requirements_alter');
+
+        return $node;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/HookRequirementsAlterRenameRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/HookRequirementsAlterRenameRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\HookRequirementsAlterRenameRector;
+
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class HookRequirementsAlterRenameRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\HookRequirementsAlterRenameRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(HookRequirementsAlterRenameRector::class, $rectorConfig, false);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/basic.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+function mymodule_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}
+
+?>
+-----
+<?php
+
+function mymodule_runtime_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/no_change_already_migrated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/no_change_already_migrated.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+// Already-migrated runtime hook and the manually-added update hook both end in
+// _requirements_alter; the rule must leave them untouched (idempotent).
+function mymodule_runtime_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}
+
+function mymodule_update_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/no_change_api_doc.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/no_change_api_doc.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * The hook_requirements_alter() API documentation function itself is not an
+ * implementation and must never be renamed.
+ */
+function hook_requirements_alter(array &$requirements): void {
+  $requirements['php']['title'] = t('PHP version');
+}

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+// Not a *_requirements_alter implementation — left untouched.
+function mymodule_form_alter(array &$form): void {
+  $form['#title'] = t('Title');
+}
+
+// Wrong signature: the $requirements parameter must be passed by reference.
+function mymodule_requirements_alter(array $requirements): void {
+  // Not a real hook implementation.
+}
+
+// Wrong arity: a real implementation takes exactly one parameter.
+function othermodule_requirements_alter(array &$requirements, $extra): void {
+  $requirements['php']['title'] = t('PHP version');
+}


### PR DESCRIPTION
## What

Adds `HookRequirementsAlterRenameRector`, which renames procedural
`{module}_requirements_alter()` hook implementations to
`{module}_runtime_requirements_alter()`.

`hook_requirements_alter()` is deprecated in drupal:11.3.0 and removed in
drupal:13.0.0 ([#3490846](https://www.drupal.org/node/3490846), CR
[#3549685](https://www.drupal.org/node/3549685)).

## Why the breaking set, not the default deprecation set

`hook_runtime_requirements_alter()` is only invoked on Drupal minors where it
exists, so the renamed function is **never called on older Drupal** — a silent
no-op. This is a non-BC rewrite, and it **cannot** be `DeprecationHelper`-wrapped:
a function *declaration* (`Function_`) is not an `Expr → Expr` transformation, so
`AbstractDrupalCoreRector`'s BC path never fires.

It is therefore registered in the opt-in `DRUPAL_113_BREAKING` set (matching the
contract documented in `drupal-11.3-breaking.php`), not the default
`drupal-11.3-deprecations.php`. Consumers opt in only after dropping support for
the Drupal minors that predate the runtime hook.

> Note: a dual-function approach (keep the legacy hook marked
> `#[LegacyRequirementsHook]` + add a delegating runtime hook) was considered and
> rejected — it introduces a double-execution of the alter on Drupal 11.2, where
> the attribute is not yet recognized and core invokes both hooks.

## Behavior / guards

`AbstractRector`. The rule is idempotent — it skips:
- the `hook_requirements_alter()` API-documentation function itself,
- the new `_runtime_`/`_update_requirements_alter()` hook names,
- functions that don't take exactly one by-reference parameter.

## Testing

- 4 fixtures: `basic` (transform), `no_change_api_doc`, `no_change_unrelated`,
  `no_change_already_migrated`.
- `vendor/bin/phpunit` for the rector: 4 passed.
- `composer phpstan`: no errors. `composer fix-style`: no changes.