### PR TITLE
feat(rector): add CommentLinkBuilderConstructorRector (#3544308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ release-by-release.
 
 ### Added
 
+- **`CommentLinkBuilderConstructorRector`** — rewrites the deprecated
+  5-argument `new \Drupal\comment\CommentLinkBuilder(...)` constructor call to
+  the new 3-argument form, dropping the `$module_handler` and
+  `$entity_type_manager` arguments (deprecated in drupal:11.3.0, removed in
+  drupal:12.0.0). Because the 3-argument signature only exists on Drupal >=
+  11.3.0, the rewrite is BC-wrapped with `DeprecationHelper::backwardsCompatibleCall()`
+  so the original 5-argument call still runs on older Drupal. Only calls with
+  exactly 5 positional arguments are rewritten.
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.3-deprecations.php
+++ b/config/drupal-11/drupal-11.3-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Drupal11\Rector\Deprecation\CommentLinkBuilderConstructorRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ErrorCurrentErrorHandlerRector;
 use DrupalRector\Drupal11\Rector\Deprecation\FileManagedFileSubmitRector;
 use DrupalRector\Drupal11\Rector\Deprecation\FileSystemBasenameToNativeRector;
@@ -268,6 +269,17 @@ return static function (RectorConfig $rectorConfig): void {
     // \Drupal::service(ViewsConfigUpdater::class) so state set via
     // setDeprecationsEnabled(FALSE) persists across hook invocations.
     $rectorConfig->ruleWithConfiguration(ViewsConfigUpdaterClassResolverToServiceRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.3.0'),
+    ]);
+
+    // https://www.drupal.org/node/3544308
+    // https://www.drupal.org/node/3544527 (change record)
+    // The $module_handler and $entity_type_manager arguments to
+    // CommentLinkBuilder::__construct() deprecated in drupal:11.3.0, removed in
+    // drupal:12.0.0. The 5-argument constructor call is rewritten to the new
+    // 3-argument form ($current_user, $comment_manager, $string_translation);
+    // BC-wrapped because the 3-argument signature only exists on Drupal >= 11.3.0.
+    $rectorConfig->ruleWithConfiguration(CommentLinkBuilderConstructorRector::class, [
         new DrupalIntroducedVersionConfiguration('11.3.0'),
     ]);
 };

--- a/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector.php
+++ b/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Removes the deprecated $module_handler and $entity_type_manager arguments
+ * from CommentLinkBuilder::__construct().
+ *
+ * The 5-argument form is rewritten to the new 3-argument form introduced in
+ * Drupal 11.3.0. The $module_handler (arg 2) and $entity_type_manager (arg 4)
+ * parameters were deprecated and removed; $string_translation shifts from
+ * position 3 to position 2.
+ *
+ * Only rewrites calls with exactly 5 positional arguments. Named arguments or
+ * calls with a different argument count are left untouched.
+ *
+ * @see https://www.drupal.org/node/3544308
+ * @see https://www.drupal.org/node/3544527
+ */
+class CommentLinkBuilderConstructorRector extends AbstractDrupalCoreRector
+{
+    /**
+     * @var array|DrupalIntroducedVersionConfiguration[]
+     */
+    protected array $configuration;
+
+    // TODO PHPSTAN_MESSAGES CommentLinkBuilderConstructorRector:
+    // CommentLinkBuilder::__construct() is not annotated @deprecated — only
+    // passing the (now removed) $module_handler/$entity_type_manager arguments
+    // triggers a runtime trigger_error in core, keyed on the argument *types*.
+    // PHPStan emits no static deprecation message for this call shape, so
+    // upgrade_status cannot match this rector via the standard $rector_covered
+    // lookup. Verified live against the installed Drupal 11.3 core constructor.
+    public const PHPSTAN_MESSAGES = [];
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove deprecated $module_handler and $entity_type_manager arguments from CommentLinkBuilder::__construct()',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_BEFORE'
+new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $stringTranslation);
+CODE_AFTER,
+                    [new DrupalIntroducedVersionConfiguration('11.3.0')]
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof New_);
+        if (!$node->class instanceof Name) {
+            return null;
+        }
+        if (!$this->isName($node->class, 'Drupal\comment\CommentLinkBuilder')) {
+            return null;
+        }
+        if (count($node->args) !== 5) {
+            return null;
+        }
+
+        // Old signature: ($current_user, $comment_manager, $module_handler, $string_translation, $entity_type_manager)
+        // New signature: ($current_user, $comment_manager, $string_translation)
+        $cloned = clone $node;
+        $cloned->args = [$node->args[0], $node->args[1], $node->args[3]];
+
+        return $cloned;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/CommentLinkBuilderConstructorRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/CommentLinkBuilderConstructorRectorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\CommentLinkBuilderConstructorRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class CommentLinkBuilderConstructorRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\CommentLinkBuilderConstructorRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(CommentLinkBuilderConstructorRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.3.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$builder = new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager);
+
+?>
+-----
+<?php
+
+$builder = new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture/basic.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$builder = new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager);
+
+?>
+-----
+<?php
+
+$builder = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $stringTranslation), fn() => new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager));
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture/no_change_already_migrated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture/no_change_already_migrated.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Already on the 3-argument form — leave untouched.
+$builder = new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $stringTranslation);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Unrelated class with the same 5-argument shape — must not be transformed.
+$builder = new \Drupal\other\SomeOtherBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager);
+
+?>


### PR DESCRIPTION
## What

Adds **`CommentLinkBuilderConstructorRector`**, which rewrites the deprecated 5-argument `new \Drupal\comment\CommentLinkBuilder(...)` constructor call to the new 3-argument form:

```php
// before
new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager)

// after (BC-wrapped)
\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0',
    fn() => new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $stringTranslation),
    fn() => new \Drupal\comment\CommentLinkBuilder($currentUser, $commentManager, $moduleHandler, $stringTranslation, $entityTypeManager))
```

The `$module_handler` and `$entity_type_manager` arguments were deprecated in drupal:11.3.0 and are removed in drupal:12.0.0; `$string_translation` shifts from position 3 to position 2.

## Why BC-wrapped

The 3-argument constructor signature only exists on Drupal >= 11.3.0 — calling it with 3 arguments on an older Drupal would fatal with "Too few arguments". The rector therefore extends `AbstractDrupalCoreRector` and emits a `DeprecationHelper::backwardsCompatibleCall()` so the original 5-argument call keeps running on pre-11.3 Drupal while the new form runs on 11.3+.

Only calls with exactly 5 positional arguments are rewritten; named arguments or other arg counts are left untouched.

## References

- Issue: https://www.drupal.org/node/3544308
- Change record: https://www.drupal.org/node/3544527

## Testing

- Version-gating PHPUnit tests (`testAboveVersion` / `testBelowVersion`) — 4 tests, 5 assertions, all passing
- Fixture coverage: `basic`, `no_change_unrelated`, `no_change_already_migrated`, and `fixture-below-version/basic`
- PHPStan: clean
- php-cs-fixer: no changes
- **Live-tested** against real contrib on a Drupal 11.3 site: correctly rewrites the deprecated 5-arg form, skips the already-migrated 3-arg form (the only contrib usage, in the `history` module's tests, is already migrated)

Note: PHPStan emits no static deprecation for this pattern (the removed-argument deprecation is a runtime `trigger_error` keyed on argument types, not a `@deprecated` annotation), so `PHPSTAN_MESSAGES` is intentionally empty with a documented `TODO`.