### PR TITLE
feat: add ReplaceItemAttributesWithAttributesRector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ release-by-release.
 
 ### Added
 
+- **`ReplaceItemAttributesWithAttributesRector`** — replaces the deprecated
+  `#item_attributes` key with `#attributes` in render arrays whose `#theme` is
+  `image_formatter` or `responsive_image_formatter`. The `#item_attributes`
+  property is deprecated in drupal:11.4.0 and removed in drupal:12.0.0. The
+  transformation is BC-wrapped: the `#attributes` variable was only added to
+  these theme hooks in 11.4.0, so a plain rename would silently drop the
+  attributes on Drupal < 11.4. The rector therefore wraps the array literal in
+  `DeprecationHelper::backwardsCompatibleCall()`, using `#attributes` on
+  Drupal ≥ 11.4 and the original `#item_attributes` on older versions. Arrays
+  with an unrelated (or absent) `#theme`, and arrays already using
+  `#attributes`, are left untouched.
+  [#3554447](https://www.drupal.org/i/3554447) /
+  [CR](https://www.drupal.org/node/3554585).
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -25,6 +25,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\RemoveViewsRowCacheKeysRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceEntityReferenceRecursiveLimitRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceExpectDeprecationRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceHideShowWithPrintedRector;
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceItemAttributesWithAttributesRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceLocaleTranslationPathConfigRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNonBoolAccessRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceRecipeRunnerInstallModuleRector;
@@ -530,5 +531,16 @@ return static function (RectorConfig $rectorConfig): void {
     // trait composition from a D10/D11-only codebase.
     $rectorConfig->ruleWithConfiguration(RemovePhpUnitCompatibilityTraitRector::class, [
         new DrupalIntroducedVersionConfiguration('12.0.0'),
+    ]);
+
+    // https://www.drupal.org/node/3554447
+    // https://www.drupal.org/node/3554585 (change record)
+    // The '#item_attributes' property of the image_formatter and
+    // responsive_image_formatter theme hooks deprecated in drupal:11.4.0,
+    // removed in drupal:12.0.0. Replaced by '#attributes'. BC-wrapped because
+    // the '#attributes' variable was only added to these hooks in 11.4.0, so a
+    // plain rename silently drops the attributes on Drupal < 11.4.
+    $rectorConfig->ruleWithConfiguration(ReplaceItemAttributesWithAttributesRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
     ]);
 };

--- a/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces the deprecated '#item_attributes' key with '#attributes' in render
+ * arrays that use the 'image_formatter' or 'responsive_image_formatter' theme
+ * hooks.
+ *
+ * The '#item_attributes' property is deprecated in drupal:11.4.0 and removed in
+ * drupal:12.0.0. The '#attributes' variable was only added to these theme hooks
+ * in 11.4.0, so a plain rename silently drops the attributes on Drupal < 11.4.
+ * The transformation is therefore BC-wrapped: the new key is used on Drupal
+ * >= 11.4.0 and the original key is preserved on older versions.
+ *
+ * @see https://www.drupal.org/node/3554447
+ * @see https://www.drupal.org/node/3554585
+ */
+final class ReplaceItemAttributesWithAttributesRector extends AbstractDrupalCoreRector
+{
+    private const AFFECTED_THEME_HOOKS = [
+        'image_formatter',
+        'responsive_image_formatter',
+    ];
+
+    /**
+     * @var array|DrupalIntroducedVersionConfiguration[]
+     */
+    protected array $configuration;
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            "Replace deprecated '#item_attributes' with '#attributes' in image_formatter and responsive_image_formatter render arrays",
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_BEFORE'
+$element = [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['my-image']],
+];
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$element = [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#attributes' => ['class' => ['my-image']],
+];
+CODE_AFTER,
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [Array_::class];
+    }
+
+    protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof Array_);
+        if (!$this->isImageFormatterArray($node)) {
+            return null;
+        }
+
+        $changed = false;
+        $cloned = clone $node;
+        foreach ($cloned->items as $index => $item) {
+            if (!$item->key instanceof String_ || $item->key->value !== '#item_attributes') {
+                continue;
+            }
+            $newItem = clone $item;
+            $newItem->key = new String_('#attributes');
+            $cloned->items[$index] = $newItem;
+            $changed = true;
+        }
+
+        return $changed ? $cloned : null;
+    }
+
+    /**
+     * Determines whether the array is a render array for an affected theme hook.
+     */
+    private function isImageFormatterArray(Array_ $array): bool
+    {
+        foreach ($array->items as $item) {
+            if (!$item->key instanceof String_ || $item->key->value !== '#theme') {
+                continue;
+            }
+            if (!$item->value instanceof String_) {
+                continue;
+            }
+            if (in_array($item->value->value, self::AFFECTED_THEME_HOOKS, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/ReplaceItemAttributesWithAttributesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/ReplaceItemAttributesWithAttributesRectorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceItemAttributesWithAttributesRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class ReplaceItemAttributesWithAttributesRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceItemAttributesWithAttributesRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(ReplaceItemAttributesWithAttributesRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+$element = [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['my-image']],
+    '#url' => $url,
+];
+
+?>
+-----
+<?php
+
+$element = [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['my-image']],
+    '#url' => $url,
+];
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/basic.php.inc
@@ -1,0 +1,26 @@
+<?php
+
+$element = [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['my-image']],
+    '#url' => $url,
+];
+
+?>
+-----
+<?php
+
+$element = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#attributes' => ['class' => ['my-image']],
+    '#url' => $url,
+], fn() => [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['my-image']],
+    '#url' => $url,
+]);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/no_change_already_migrated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/no_change_already_migrated.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Already migrated to '#attributes': nothing to do, and it must not be
+// re-wrapped in a DeprecationHelper call.
+$element = [
+    '#theme' => 'image_formatter',
+    '#item' => $item,
+    '#attributes' => ['class' => ['my-image']],
+];

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/no_change_unrelated_theme.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/no_change_unrelated_theme.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+// '#item_attributes' on a theme hook other than image_formatter /
+// responsive_image_formatter is unrelated and must not be changed.
+$element = [
+    '#theme' => 'table',
+    '#item_attributes' => ['class' => ['my-thing']],
+];
+
+// A plain associative array that merely happens to contain an
+// '#item_attributes' key but has no '#theme' must not be changed either.
+$data = [
+    '#item_attributes' => ['class' => ['nope']],
+];

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/responsive.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/fixture/responsive.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+$build['image'] = [
+    '#theme' => 'responsive_image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['responsive-image']],
+];
+
+?>
+-----
+<?php
+
+$build['image'] = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => [
+    '#theme' => 'responsive_image_formatter',
+    '#item' => $item,
+    '#attributes' => ['class' => ['responsive-image']],
+], fn() => [
+    '#theme' => 'responsive_image_formatter',
+    '#item' => $item,
+    '#item_attributes' => ['class' => ['responsive-image']],
+]);
+
+?>


### PR DESCRIPTION
## What

Adds `ReplaceItemAttributesWithAttributesRector`, which migrates the deprecated `#item_attributes` render-array key to `#attributes` for the `image_formatter` and `responsive_image_formatter` theme hooks.

- **Deprecated:** drupal:11.4.0 · **Removed:** drupal:12.0.0
- Issue: [#3554447](https://www.drupal.org/node/3554447) · Change record: [#3554585](https://www.drupal.org/node/3554585)

## Why it is BC-wrapped (not a plain rename)

The companion digest rule used a plain `AbstractRector` rename. Verified against core history that this is unsafe: the `#attributes` variable was **added** to these theme hooks in the same commit as the deprecation (`54be718`, 11.4.0). On Drupal < 11.4 the hook only reads `#item_attributes`, so a plain rename would **silently drop the attributes** there — a quiet BC break.

The rector therefore extends `AbstractDrupalCoreRector` and wraps the array literal in `DeprecationHelper::backwardsCompatibleCall()`:

```php
$element = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => [
    '#theme' => 'image_formatter',
    '#item' => $item,
    '#attributes' => ['class' => ['my-image']],
], fn() => [
    '#theme' => 'image_formatter',
    '#item' => $item,
    '#item_attributes' => ['class' => ['my-image']],
]);
```

`#attributes` is used on Drupal >= 11.4; the original `#item_attributes` is preserved on older versions.

## Scope / safety

- Only arrays whose `#theme` is `image_formatter` or `responsive_image_formatter` are touched.
- Arrays with an unrelated or absent `#theme`, and arrays already using `#attributes`, are left unchanged (covered by no-change fixtures).
- The new-side branch contains no `#item_attributes`, so revisiting it produces no change — no double-wrapping.

## Tests

- `basic` (image_formatter) and `responsive` (responsive_image_formatter) transformable fixtures
- `no_change_unrelated_theme`, `no_change_already_migrated`
- `fixture-below-version/basic` — confirms no transformation below the introduced version
- `testAboveVersion` / `testBelowVersion` via `DrupalRectorSettings::setDrupalVersion()`

PHPUnit, PHPStan (level 6), and php-cs-fixer all pass; registered in `config/drupal-11/drupal-11.4-deprecations.php`.