### PR TITLE
feat: rename HelpSearch to SearchHelpSearch (DRUPAL_114_BREAKING)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ release-by-release.
 
 ### Added
 
+- **`DRUPAL_114_BREAKING`: `HelpSearch` → `SearchHelpSearch` class rename.**
+  `Drupal\help\Plugin\Search\HelpSearch` was moved out of the `help` module and
+  renamed to `Drupal\search_help\Plugin\Search\SearchHelpSearch` in the new
+  `search_help` core sub-module (`system_update_11400()`, drupal:11.4.0). Added
+  as a `RenameClassRector` entry to `drupal-11.4-breaking.php`: the
+  `SearchHelpSearch` class does not exist on any Drupal minor below 11.4, and a
+  `use` / `::class` rename is structural and cannot be BC-wrapped, so applying
+  it against code that still needs to run on an older minor would fatal there.
+  Opt in via `Drupal11SetList::DRUPAL_114_BREAKING` only after dropping support
+  for Drupal < 11.4 ([#3581109](https://www.drupal.org/i/3581109)).
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-breaking.php
+++ b/config/drupal-11/drupal-11.4-breaking.php
@@ -32,8 +32,23 @@ return static function (RectorConfig $rectorConfig): void {
     // do not exist on any Drupal 10.x branch. Running this rule against code
     // that still needs to work on Drupal 10 will produce a "class not found"
     // fatal there.
+    // https://www.drupal.org/node/3581109
+    // Drupal\help\Plugin\Search\HelpSearch moved out of the help module and
+    // renamed to Drupal\search_help\Plugin\Search\SearchHelpSearch in the new
+    // search_help core sub-module (drupal-core f55aee0362e, 11.4.0 via
+    // system_update_11400()). The SearchHelpSearch class does not exist on any
+    // Drupal minor below 11.4, so rewriting `use` / `::class` references to it
+    // would produce a "class not found" fatal there.
+    //
+    // PHPSTAN_MESSAGES RenameClassRector: none. The old class was moved out of
+    //   core entirely with no `class_alias` BC shim and no `@deprecated` alias
+    //   left behind (verified: the `Drupal\help\Plugin\Search\HelpSearch` FQCN
+    //   appears nowhere in 11.4 core), so phpstan-deprecation-rules emits no
+    //   deprecation message — only a plain "class not found" once a site is on
+    //   11.4. There is no message for upgrade_status to match against.
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Drupal\menu_link_content\Plugin\migrate\process\LinkOptions' => 'Drupal\migrate\Plugin\migrate\process\LinkOptions',
         'Drupal\menu_link_content\Plugin\migrate\process\LinkUri' => 'Drupal\migrate\Plugin\migrate\process\LinkUri',
+        'Drupal\help\Plugin\Search\HelpSearch' => 'Drupal\search_help\Plugin\Search\SearchHelpSearch',
     ]);
 };


### PR DESCRIPTION
## What

Adds a `RenameClassRector` entry to the opt-in `DRUPAL_114_BREAKING` set for Drupal issue [#3581109](https://www.drupal.org/i/3581109):

```
Drupal\help\Plugin\Search\HelpSearch
  → Drupal\search_help\Plugin\Search\SearchHelpSearch
```

`HelpSearch` was moved out of the `help` module and renamed in the new `search_help` core sub-module via `system_update_11400()` (drupal:11.4.0, core commit `f55aee0362e`).

## Why breaking (not the default deprecation set)

The `SearchHelpSearch` class does not exist on any Drupal minor below 11.4, and a `use` / `::class` rename is a structural change (not an `Expr → Expr` rewrite) so it cannot be BC-wrapped. Applying it against code that still needs to run on an older minor would produce a "class not found" fatal there. Consumers opt in via `Drupal11SetList::DRUPAL_114_BREAKING` only after dropping support for Drupal < 11.4 — consistent with the existing `LinkOptions`/`LinkUri` entry in the same file.

## PHPStan coverage message: none

Verified against drupal-core 11.4-dev: the old `Drupal\help\Plugin\Search\HelpSearch` FQCN appears nowhere in core — moved out with **no `class_alias` BC shim and no `@deprecated` alias**. So `phpstan-deprecation-rules` emits no deprecation message (only a plain "class not found" once on 11.4); there is nothing for upgrade_status to match. Documented inline as `PHPSTAN_MESSAGES RenameClassRector: none.`

## Verification

- Live `rector --dry-run` with `DRUPAL_114_BREAKING`: both the aliased `use` reference and the fully-qualified `::class` reference rewrite correctly to `SearchHelpSearch`.
- Contrib search (api.tresbien.tech + GitLab): no D11-compatible contrib module references the old class (the lone `advanced_help` hit is a substring false positive — it extends `SearchPluginBase`).
- `ddev composer phpstan`: no errors.
- `ddev composer fix-style`: no changes.
- FQCNs + introduced version verified against `repos/drupal-core` (11.4-dev).

## Files

- `config/drupal-11/drupal-11.4-breaking.php` — the `RenameClassRector` mapping + provenance comment.
- `CHANGELOG.md` — `[Unreleased] / Added` entry.