### PR TITLE
feat: add UploadedFileConstraintArrayOptionsToNamedArgsRector (#3561135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ release-by-release.
 
 ### Added
 
+- **`UploadedFileConstraintArrayOptionsToNamedArgsRector`** — replaces the
+  deprecated options-array argument of `UploadedFileConstraint` with explicit
+  named constructor arguments (e.g. `new UploadedFileConstraint(['maxSize' => 1024000])`
+  → `new UploadedFileConstraint(maxSize: 1024000)`). Passing an options array is
+  deprecated in drupal:11.4.0 and removed in drupal:12.0.0. The transformation is
+  BC-wrapped: the named-argument constructor was introduced alongside the
+  deprecation, so the new form would fatal (`Unknown named parameter`) on
+  Drupal < 11.4. The rector therefore wraps the `new` expression in
+  `DeprecationHelper::backwardsCompatibleCall()`, using named arguments on
+  Drupal ≥ 11.4 and the original options array on older versions. See
+  [#3561135](https://www.drupal.org/node/3561135) and the
+  [change record](https://www.drupal.org/node/3554746).
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -33,6 +33,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\ReplaceSystemPerformanceGzipKeyRect
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceViewsProceduralFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\SystemRegionFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\SystemSortThemesRector;
+use DrupalRector\Drupal11\Rector\Deprecation\UploadedFileConstraintArrayOptionsToNamedArgsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\UseEntityTypeHasIntegerIdRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ViewsPluginHandlerManagerRector;
 use DrupalRector\Rector\Deprecation\ClassConstantToClassConstantRector;
@@ -530,5 +531,16 @@ return static function (RectorConfig $rectorConfig): void {
     // trait composition from a D10/D11-only codebase.
     $rectorConfig->ruleWithConfiguration(RemovePhpUnitCompatibilityTraitRector::class, [
         new DrupalIntroducedVersionConfiguration('12.0.0'),
+    ]);
+
+    // https://www.drupal.org/node/3561135
+    // https://www.drupal.org/node/3554746 (change record)
+    // Passing an options array to the UploadedFileConstraint constructor is
+    // deprecated in drupal:11.4.0, removed in drupal:12.0.0. Replaced by named
+    // constructor arguments. BC-wrapped because the named-argument constructor
+    // was introduced alongside the deprecation, so the new form would fatal on
+    // Drupal < 11.4.
+    $rectorConfig->ruleWithConfiguration(UploadedFileConstraintArrayOptionsToNamedArgsRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
     ]);
 };

--- a/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector.php
+++ b/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\String_;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces the deprecated options-array argument of UploadedFileConstraint with
+ * explicit named constructor arguments.
+ *
+ * Symfony validator 7.4 deprecated passing an associative array as the first
+ * argument to Constraint constructors. Drupal's UploadedFileConstraint follows
+ * suit: passing an options array is deprecated in drupal:11.4.0 and removed in
+ * drupal:12.0.0. The named-argument constructor was introduced in the same
+ * commit as the deprecation, so the new form would fatal ("Unknown named
+ * parameter") on Drupal < 11.4. The transformation is therefore BC-wrapped: the
+ * named-argument form is used on Drupal >= 11.4.0 and the original options-array
+ * form is preserved on older versions.
+ *
+ * @see https://www.drupal.org/node/3561135
+ * @see https://www.drupal.org/node/3554746
+ */
+final class UploadedFileConstraintArrayOptionsToNamedArgsRector extends AbstractDrupalCoreRector
+{
+    /**
+     * @var array|DrupalIntroducedVersionConfiguration[]
+     */
+    protected array $configuration;
+
+    // TODO PHPSTAN_MESSAGES UploadedFileConstraintArrayOptionsToNamedArgsRector:
+    // Neither UploadedFileConstraint nor its constructor is annotated
+    // @deprecated — only passing an array as the first argument triggers a
+    // runtime trigger_error in core (keyed on is_array($options)). PHPStan
+    // emits no static deprecation message for this call shape, so
+    // upgrade_status cannot match this rector via the standard $rector_covered
+    // lookup. Verified live against the installed Drupal 11.4 core constructor.
+    public const PHPSTAN_MESSAGES = [];
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace the deprecated options-array argument of UploadedFileConstraint with named constructor arguments.',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_BEFORE'
+$constraint = new UploadedFileConstraint(['maxSize' => 1024000]);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$constraint = new UploadedFileConstraint(maxSize: 1024000);
+CODE_AFTER,
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof New_);
+
+        // Match both the imported short name and the fully-qualified name.
+        if (!$this->isNames($node->class, [
+            'UploadedFileConstraint',
+            'Drupal\\file\\Validation\\Constraint\\UploadedFileConstraint',
+        ])) {
+            return null;
+        }
+
+        // Nothing to do when there are no arguments at all.
+        if (0 === count($node->args)) {
+            return null;
+        }
+
+        $firstArg = $node->args[0];
+
+        // Skip when the first argument is already named, or is not a plain Arg
+        // node (e.g. a variadic/spread placeholder).
+        if (!$firstArg instanceof Arg || null !== $firstArg->name) {
+            return null;
+        }
+
+        // The first argument must be an inline array literal.
+        if (!$firstArg->value instanceof Array_) {
+            return null;
+        }
+
+        $array = $firstArg->value;
+
+        // Convert every array item into an explicit named argument. Bail out if
+        // any item lacks a plain string-literal key — we cannot safely derive a
+        // named argument in that case.
+        $namedArgs = [];
+        foreach ($array->items as $item) {
+            if (!$item->key instanceof String_) {
+                return null;
+            }
+            $namedArg = new Arg($item->value);
+            $namedArg->name = new Identifier($item->key->value);
+            $namedArgs[] = $namedArg;
+        }
+
+        // Build the replacement node, preserving any positional args (groups,
+        // payload, …) that follow the options array. The original $node is left
+        // untouched so the base class can emit it as the BC fallback.
+        $new = clone $node;
+        $new->args = array_merge($namedArgs, array_slice($node->args, 1));
+
+        return $new;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/UploadedFileConstraintArrayOptionsToNamedArgsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/UploadedFileConstraintArrayOptionsToNamedArgsRectorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\UploadedFileConstraintArrayOptionsToNamedArgsRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class UploadedFileConstraintArrayOptionsToNamedArgsRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\UploadedFileConstraintArrayOptionsToNamedArgsRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(UploadedFileConstraintArrayOptionsToNamedArgsRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\foo;
+
+use Drupal\file\Validation\Constraint\UploadedFileConstraint;
+
+function makeConstraint() {
+    return new UploadedFileConstraint(['maxSize' => 1024000, 'groups' => ['myGroup']]);
+}
+
+?>
+-----
+<?php
+
+namespace Drupal\foo;
+
+use Drupal\file\Validation\Constraint\UploadedFileConstraint;
+
+function makeConstraint() {
+    return new UploadedFileConstraint(['maxSize' => 1024000, 'groups' => ['myGroup']]);
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture/basic.php.inc
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\foo;
+
+use Drupal\file\Validation\Constraint\UploadedFileConstraint;
+
+function makeConstraint() {
+    return new UploadedFileConstraint(['maxSize' => 1024000, 'groups' => ['myGroup']]);
+}
+
+?>
+-----
+<?php
+
+namespace Drupal\foo;
+
+use Drupal\file\Validation\Constraint\UploadedFileConstraint;
+
+function makeConstraint() {
+    return \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => new UploadedFileConstraint(maxSize: 1024000, groups: ['myGroup']), fn() => new UploadedFileConstraint(['maxSize' => 1024000, 'groups' => ['myGroup']]));
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture/no_change_already_named.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture/no_change_already_named.php.inc
@@ -1,0 +1,10 @@
+<?php
+
+namespace Drupal\foo;
+
+use Drupal\file\Validation\Constraint\UploadedFileConstraint;
+
+// Already using named arguments: nothing to do (proves idempotency).
+$constraint = new UploadedFileConstraint(maxSize: 1024000);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,8 @@
+<?php
+
+namespace Drupal\foo;
+
+// An unrelated class that happens to take an options array must not be touched.
+$other = new \Drupal\foo\SomeOtherConstraint(['maxSize' => 1024000]);
+
+?>


### PR DESCRIPTION
## What

Adds `UploadedFileConstraintArrayOptionsToNamedArgsRector`, which rewrites the deprecated options-array argument of `UploadedFileConstraint` into explicit named constructor arguments:

```php
new UploadedFileConstraint(['maxSize' => 1024000]);
// →
new UploadedFileConstraint(maxSize: 1024000);
```

Passing an options array is deprecated in **drupal:11.4.0** and removed in **drupal:12.0.0** (Symfony validator 7.4 deprecated the options-array `Constraint` constructor; `UploadedFileConstraint` follows suit).

- Issue: https://www.drupal.org/node/3561135
- Change record: https://www.drupal.org/node/3554746

## Why BC-wrapped

The rule extends `AbstractDrupalCoreRector` and wraps the result in `DeprecationHelper::backwardsCompatibleCall()`:

```php
\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(
    \Drupal::VERSION, '11.4.0',
    fn() => new UploadedFileConstraint(maxSize: 1024000),
    fn() => new UploadedFileConstraint(['maxSize' => 1024000]),
);
```

Core commit `70ea860634` added the named-argument constructor (`#[HasNamedArguments]` with an explicit `?int $maxSize` parameter) in the **same commit** as the deprecation. Before 11.4, `UploadedFileConstraint` inherited Symfony's `Constraint::__construct(mixed $options, …)` with no `$maxSize` parameter, so a plain rename to named arguments would fatal (`Unknown named parameter`) on Drupal < 11.4. The BC wrapper emits named arguments on Drupal ≥ 11.4 and the original options array on older versions. The named-args side never re-matches, so the transformation is idempotent.

## Tests

- `testAboveVersion` (Drupal 99.99.99 → wrapper fires) and `testBelowVersion` (Drupal 1.0.0 → unchanged)
- Fixtures: `basic` (transform + preserves trailing positional args like `groups`), `no_change_unrelated` (different class is skipped), `no_change_already_named` (idempotency), `fixture-below-version/basic`
- PHPUnit: 4 tests / 5 assertions pass · PHPStan: no errors · php-cs-fixer: clean

## Live validation

No contrib module instantiates `UploadedFileConstraint` with an options array (it's an internal core validation constraint). Verified end-to-end by running the rule via the Rector binary against a probe instantiation backed by real Drupal 11.4 core classes — both call shapes transformed correctly with the expected BC wrapper.

The deprecation is runtime-only (`@trigger_error` on `is_array($options)`, no static `@deprecated` annotation), so PHPStan emits no message; `PHPSTAN_MESSAGES` is intentionally empty and documented.