### PR TITLE
feat: add ReplaceNodeViewControllerRector (NodeViewController → EntityViewController, #3589630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,28 @@ release-by-release.
   new call would be a silent no-op there — the wrapper keeps the original
   `drupal_static_reset()` on older versions and only switches to the
   `cache.memory` invalidation on drupal:11.4.0 and above.
+- **`ReplaceNodeViewControllerRector`** (+ a companion `RenameClassRector`
+  entry) — migrates the deprecated
+  `Drupal\node\Controller\NodeViewController` to
+  `Drupal\Core\Entity\Controller\EntityViewController` (deprecated in
+  drupal:11.4.0, removed in drupal:13.0.0). The custom rector rewrites
+  `new NodeViewController($etm, $renderer, $currentUser, $entityRepository)`
+  to `new EntityViewController($etm, $renderer)`, dropping the two extra
+  constructor arguments that `EntityViewController` does not accept; it matches
+  both the old and new class names so the argument trim is order-independent
+  w.r.t. the rename pass. The `RenameClassRector` entry handles the structural
+  references (`use` / `extends` / `::class` / type hints). Ships in the opt-in
+  `DRUPAL_114_BREAKING` set: unlike the other entries there, the replacement
+  class exists on every supported minor (so it never fatals on a missing
+  symbol), but reparenting `extends NodeViewController` to
+  `extends EntityViewController` is *behaviorally* breaking on every minor —
+  subclasses lose the node-specific `create()` / `currentUser` /
+  `entityRepository` / `title()` / `view()` members and can throw an
+  `ArgumentCountError` or call an undefined `title()`, so it needs manual
+  review. A subclass's own `parent::__construct($a, $b, $c, $d)` is not
+  rewritten (PHP silently discards the extra arguments).
+  [#3589630](https://www.drupal.org/i/3589630) /
+  [CR](https://www.drupal.org/node/3589636).
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-breaking.php
+++ b/config/drupal-11/drupal-11.4-breaking.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  * introduced version.
  */
 
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNodeViewControllerRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
@@ -32,6 +33,7 @@ return static function (RectorConfig $rectorConfig): void {
     // do not exist on any Drupal 10.x branch. Running this rule against code
     // that still needs to work on Drupal 10 will produce a "class not found"
     // fatal there.
+    //
     // https://www.drupal.org/node/3581109
     // Drupal\help\Plugin\Search\HelpSearch moved out of the help module and
     // renamed to Drupal\search_help\Plugin\Search\SearchHelpSearch in the new
@@ -46,9 +48,43 @@ return static function (RectorConfig $rectorConfig): void {
     //   appears nowhere in 11.4 core), so phpstan-deprecation-rules emits no
     //   deprecation message — only a plain "class not found" once a site is on
     //   11.4. There is no message for upgrade_status to match against.
+    //
+    // https://www.drupal.org/node/3589630
+    // https://www.drupal.org/node/3589636 (change record)
+    // Drupal\node\Controller\NodeViewController deprecated in drupal:11.4.0,
+    // removed in drupal:13.0.0. Use
+    // Drupal\Core\Entity\Controller\EntityViewController instead.
+    //
+    // Unlike the migrate renames above, the replacement class exists on every
+    // supported minor (EntityViewController has been the parent of
+    // NodeViewController since Drupal 8), so the rewrite never fatals on a
+    // missing symbol. It is in the breaking set because the rename is
+    // *behaviorally* breaking, identically on every minor: rewriting
+    // `extends NodeViewController` to `extends EntityViewController` drops the
+    // node-specific overrides (4-service create(), the currentUser /
+    // entityRepository properties, the title() callback, the node view()
+    // signature). A subclass relying on them can throw an ArgumentCountError
+    // (inherited 2-arg create() vs a 4-arg constructor) or call an undefined
+    // title(). These need manual review, so the rule is opt-in.
+    //
+    // PHPSTAN_MESSAGES RenameClassRector: NodeViewController is annotated
+    //   `@deprecated in drupal:11.4.0` at the class level, so
+    //   phpstan-deprecation-rules emits "Class ... extends deprecated class
+    //   Drupal\node\Controller\NodeViewController: ..." for subclasses and
+    //   "Instantiation of deprecated class ..." for direct `new` calls. The
+    //   instantiation message is carried by
+    //   ReplaceNodeViewControllerRector::PHPSTAN_MESSAGES.
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Drupal\menu_link_content\Plugin\migrate\process\LinkOptions' => 'Drupal\migrate\Plugin\migrate\process\LinkOptions',
         'Drupal\menu_link_content\Plugin\migrate\process\LinkUri' => 'Drupal\migrate\Plugin\migrate\process\LinkUri',
         'Drupal\help\Plugin\Search\HelpSearch' => 'Drupal\search_help\Plugin\Search\SearchHelpSearch',
+        'Drupal\node\Controller\NodeViewController' => 'Drupal\Core\Entity\Controller\EntityViewController',
     ]);
+
+    // ReplaceNodeViewControllerRector additionally trims the extra
+    // $current_user / $entity_repository constructor arguments from
+    // `new NodeViewController(...)`, which RenameClassRector cannot do. It
+    // matches both class names, so the trim is order-independent w.r.t. the
+    // RenameClassRector pass above.
+    $rectorConfig->rule(ReplaceNodeViewControllerRector::class);
 };

--- a/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces `new NodeViewController(...)` with `new EntityViewController(...)`,
+ * dropping the extra $current_user and $entity_repository constructor
+ * arguments that EntityViewController does not accept.
+ *
+ * This is the instantiation half of the NodeViewController removal. A
+ * RenameClassRector entry (registered alongside this rule in
+ * `config/drupal-11/drupal-11.4-breaking.php`) handles the structural
+ * references: `use` imports, type hints, `::class`, and `extends`
+ * declarations.
+ *
+ * BREAKING: this rule lives in the opt-in DRUPAL_114_BREAKING set, not the
+ * default deprecation set. EntityViewController exists on every supported
+ * Drupal minor, so the rewritten instantiation never fatals on a missing
+ * symbol. The break is *behavioral* and is carried by the companion
+ * RenameClassRector pass: reparenting a `class X extends NodeViewController`
+ * to `extends EntityViewController` loses NodeViewController's node-specific
+ * overrides on every minor — its 4-service `create()`, the `currentUser` /
+ * `entityRepository` properties, the `title()` callback, and the node
+ * `view()` signature. A subclass that relied on those can throw an
+ * ArgumentCountError (inherited 2-arg `create()` vs a 4-arg constructor) or
+ * call an undefined `title()`. Those require manual review, hence opt-in.
+ *
+ * This rule matches both the old (`Drupal\node\Controller\NodeViewController`)
+ * and the new (`Drupal\Core\Entity\Controller\EntityViewController`) class
+ * names so the argument trim is correct regardless of whether the companion
+ * RenameClassRector has already rewritten the `new` expression's class name.
+ *
+ * Caveat: a subclass that overrides __construct and calls
+ * `parent::__construct($a, $b, $c, $d)` keeps all four arguments — PHP
+ * silently discards the extras, so $current_user / $entity_repository are no
+ * longer forwarded. Those parent calls are not rewritten.
+ *
+ * @see https://www.drupal.org/node/3589630
+ * @see https://www.drupal.org/node/3589636
+ */
+class ReplaceNodeViewControllerRector extends AbstractRector
+{
+    private const OLD_CLASS = 'Drupal\node\Controller\NodeViewController';
+
+    private const NEW_CLASS = 'Drupal\Core\Entity\Controller\EntityViewController';
+
+    // NodeViewController is annotated `@deprecated in drupal:11.4.0` at the
+    // class level, so phpstan-deprecation-rules flags both instantiation and
+    // `extends`. The verbatim strings below follow the standard
+    // phpstan/phpstan-deprecation-rules format; verify against a real call
+    // site with the rector-extract-phpstan-error skill before relying on them
+    // for upgrade_status matching.
+    public const PHPSTAN_MESSAGES = [
+        'Instantiation of deprecated class Drupal\node\Controller\NodeViewController: in drupal:11.4.0 and is removed from drupal:13.0.0. Use \Drupal\Core\Entity\Controller\EntityViewController instead.',
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace new NodeViewController(...) with new EntityViewController(...) and drop the extra constructor arguments.',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+new \Drupal\node\Controller\NodeViewController($entityTypeManager, $renderer, $currentUser, $entityRepository);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+new \Drupal\Core\Entity\Controller\EntityViewController($entityTypeManager, $renderer);
+CODE_AFTER
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof New_);
+        if (!$node->class instanceof Name) {
+            return null;
+        }
+
+        $isOldClass = $this->isName($node->class, self::OLD_CLASS);
+        $isNewClass = $this->isName($node->class, self::NEW_CLASS);
+        if (!$isOldClass && !$isNewClass) {
+            return null;
+        }
+
+        $changed = false;
+
+        if ($isOldClass) {
+            $node->class = new FullyQualified(self::NEW_CLASS);
+            $changed = true;
+        }
+
+        // EntityViewController::__construct only accepts ($entity_type_manager,
+        // $renderer); drop any extra arguments carried over from
+        // NodeViewController's 4-argument constructor.
+        if (count($node->args) > 2) {
+            $node->args = array_slice($node->args, 0, 2);
+            $changed = true;
+        }
+
+        return $changed ? $node : null;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/ReplaceNodeViewControllerRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/ReplaceNodeViewControllerRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNodeViewControllerRector;
+
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class ReplaceNodeViewControllerRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/config/configured_rule.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNodeViewControllerRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    // Only the custom instantiation rule is exercised here. The companion
+    // RenameClassRector pass (use / extends / type-hint / ::class rewrites) is
+    // a trusted Rector-core rule registered alongside this one in
+    // config/drupal-11/drupal-11.4-breaking.php.
+    DeprecationBase::addClass(ReplaceNodeViewControllerRector::class, $rectorConfig, false);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/already_renamed_extra_args.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/already_renamed_extra_args.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+// Simulates the companion RenameClassRector having already rewritten the class
+// name: the argument trim must still apply.
+$controller = new \Drupal\Core\Entity\Controller\EntityViewController($entityTypeManager, $renderer, $currentUser, $entityRepository);
+?>
+-----
+<?php
+
+// Simulates the companion RenameClassRector having already rewritten the class
+// name: the argument trim must still apply.
+$controller = new \Drupal\Core\Entity\Controller\EntityViewController($entityTypeManager, $renderer);
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/basic.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+$controller = new \Drupal\node\Controller\NodeViewController($entityTypeManager, $renderer, $currentUser, $entityRepository);
+?>
+-----
+<?php
+
+$controller = new \Drupal\Core\Entity\Controller\EntityViewController($entityTypeManager, $renderer);
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/no_change_two_args.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/no_change_two_args.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+// Already the correct 2-argument EntityViewController call — left untouched.
+$controller = new \Drupal\Core\Entity\Controller\EntityViewController($entityTypeManager, $renderer);
+?>
+-----
+<?php
+
+// Already the correct 2-argument EntityViewController call — left untouched.
+$controller = new \Drupal\Core\Entity\Controller\EntityViewController($entityTypeManager, $renderer);
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+// An unrelated controller with four arguments — not NodeViewController or
+// EntityViewController, so it is left untouched.
+$controller = new \Drupal\node\Controller\NodeController($entityTypeManager, $renderer, $currentUser, $entityRepository);
+?>
+-----
+<?php
+
+// An unrelated controller with four arguments — not NodeViewController or
+// EntityViewController, so it is left untouched.
+$controller = new \Drupal\node\Controller\NodeController($entityTypeManager, $renderer, $currentUser, $entityRepository);
+?>


### PR DESCRIPTION
## What

Migrates the deprecated `Drupal\node\Controller\NodeViewController` to `Drupal\Core\Entity\Controller\EntityViewController` (deprecated in drupal:11.4.0, removed in drupal:13.0.0).

- **`ReplaceNodeViewControllerRector`** (custom `AbstractRector`) rewrites `new NodeViewController($etm, $renderer, $currentUser, $entityRepository)` → `new EntityViewController($etm, $renderer)`, dropping the two extra constructor arguments `EntityViewController` does not accept. It matches **both** the old and new class names, so the argument trim is order-independent w.r.t. the rename pass.
- A companion **`RenameClassRector`** entry handles the structural references (`use` / `extends` / `::class` / type hints).

## Why the opt-in breaking set (not the default deprecation set)

This is the interesting classification call. Unlike the other `DRUPAL_114_BREAKING` entries, the replacement class **exists on every supported minor** — `EntityViewController` has been the parent of `NodeViewController` since Drupal 8, and its 2-arg constructor `(EntityTypeManagerInterface, RendererInterface)` has been signature-stable since D8. So the rewrite **never fatals on a missing symbol** on any minor (10.x → 13.0+).

It's breaking because the rename is **behaviorally** breaking, identically on every minor. Reparenting `class X extends NodeViewController` to `extends EntityViewController` drops the node-specific members:

| Member on `NodeViewController` | After reparenting to `EntityViewController` |
|---|---|
| 4-arg `__construct` (sets `currentUser`, `entityRepository`) | 2-arg parent ctor; those properties never declared/assigned |
| `create()` injects 4 services | inherited `create()` does `new static($etm, $renderer)` — 2 services |
| `view($node, $view_mode, $langcode)` | different inherited signature |
| `title($node)` | **gone** — no `title()` on `EntityViewController` |

Subclass failure modes (all version-independent): `ArgumentCountError` (inherited 2-arg `create()` vs a 4-arg constructor), undefined `title()` if used as a `_title_callback`, and lost `currentUser`/`entityRepository`. A subclass's own `parent::__construct($a, $b, $c, $d)` is **not** rewritten (PHP silently discards the extras). Hence opt-in + manual review.

## Verification

- New unit test (4 fixtures): basic 4→2-arg rewrite, order-independence (already-renamed + extra args), and two no-change cases (correct 2-arg call, unrelated class). `phpunit` green.
- `composer phpstan` — no errors. `composer fix-style` — no changes.
- Dry-ran the full `drupal-11.4-breaking.php` config against a probe with `use` + `extends` + two `new` forms: `extends` reparented and both `new` forms renamed **and** trimmed to 2 args, confirming the custom rule + `RenameClassRector` compose correctly in either order.

Refs: [#3589630](https://www.drupal.org/i/3589630) · CR [#3589636](https://www.drupal.org/node/3589636)