### PR TITLE
feat: add RenameHookRankingRector (#[Hook('ranking')] → #[Hook('node_search_ranking')])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,19 @@ release-by-release.
   rewritten (PHP silently discards the extra arguments).
   [#3589630](https://www.drupal.org/i/3589630) /
   [CR](https://www.drupal.org/node/3589636).
+- **`RenameHookRankingRector`** — renames the deprecated OOP hook attribute
+  `#[Hook('ranking')]` to `#[Hook('node_search_ranking')]`. Only the
+  `Drupal\Core\Hook\Attribute\Hook` attribute is targeted (an attribute of the
+  same short name from another namespace is left untouched), and only the
+  `'ranking'` argument is rewritten — the implementing method name and any
+  docblocks are unchanged. `hook_ranking()` is deprecated in drupal:11.3.0 and
+  removed in drupal:12.0.0; use `hook_node_search_ranking()` instead. Because
+  the `node_search_ranking` hook is only invoked on Drupal minors where it
+  exists, a plain rename is a silent no-op on older Drupal, and an attribute is
+  not an `Expr → Expr` transformation so it cannot be BC-wrapped. The rule
+  therefore lives in the opt-in `Drupal11SetList::DRUPAL_113_BREAKING` set, not
+  the default deprecation set. [#1019966](https://www.drupal.org/i/1019966) /
+  [change record](https://www.drupal.org/node/2690393)
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.3-breaking.php
+++ b/config/drupal-11/drupal-11.3-breaking.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
  */
 
 use DrupalRector\Drupal11\Rector\Deprecation\HookRequirementsAlterRenameRector;
+use DrupalRector\Drupal11\Rector\Deprecation\RenameHookRankingRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
@@ -31,6 +32,27 @@ return static function (RectorConfig $rectorConfig): void {
     // breaking set. Apply only after dropping support for Drupal minors that
     // predate hook_runtime_requirements_alter().
     $rectorConfig->rule(HookRequirementsAlterRenameRector::class);
+
+    // https://www.drupal.org/node/1019966
+    // https://www.drupal.org/node/2690393 (change record)
+    // hook_ranking() deprecated in drupal:11.3.0, removed in drupal:12.0.0.
+    // Renames the OOP hook attribute #[Hook('ranking')] to
+    // #[Hook('node_search_ranking')]. The node_search_ranking hook is only
+    // invoked on Drupal minors where it exists, so on older Drupal the renamed
+    // attribute is never invoked (a silent no-op) — a non-BC rewrite. It cannot
+    // be BC-wrapped (an Attribute is not an Expr → Expr transformation), hence
+    // the breaking set. Apply only after dropping support for Drupal minors that
+    // predate hook_node_search_ranking().
+    //
+    // TODO PHPSTAN_MESSAGES RenameHookRankingRector: none. The hook_ranking()
+    //   deprecation is a @deprecated docblock on the node.api.php documentation
+    //   function; the hook system resolves hook names as runtime strings, so
+    //   phpstan-deprecation-rules has nothing to attach to the 'ranking' string
+    //   literal inside #[Hook('ranking')]. Verified against contrib
+    //   download_statistics 1.0.x (the rector transforms it correctly, but
+    //   PHPStan emits no deprecation for the attribute). Runtime-only
+    //   deprecation — intentionally no coverage message.
+    $rectorConfig->rule(RenameHookRankingRector::class);
 
     // https://www.drupal.org/node/3551446
     // https://www.drupal.org/node/3551450 (change record)

--- a/src/Drupal11/Rector/Deprecation/RenameHookRankingRector.php
+++ b/src/Drupal11/Rector/Deprecation/RenameHookRankingRector.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use PhpParser\Node\Scalar\String_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Renames the deprecated OOP hook attribute #[Hook('ranking')] to
+ * #[Hook('node_search_ranking')].
+ *
+ * hook_ranking() is deprecated in drupal:11.3.0 and removed in drupal:12.0.0;
+ * use hook_node_search_ranking() instead. Any method decorated with
+ * #[Hook('ranking')] from Drupal\Core\Hook\Attribute\Hook must be updated to
+ * #[Hook('node_search_ranking')].
+ *
+ * This is a NON-backward-compatible rewrite: the node_search_ranking hook is
+ * only invoked on Drupal minors where it exists, so on older Drupal the renamed
+ * attribute is never invoked (a silent no-op). It cannot be BC-wrapped — an
+ * Attribute is not an Expr → Expr transformation, so DeprecationHelper does not
+ * apply. The rule therefore lives in the opt-in DRUPAL_113_BREAKING set, not the
+ * default deprecation set. Only apply it after dropping support for the Drupal
+ * minors that predate hook_node_search_ranking().
+ *
+ * The rule only changes the #[Hook] attribute argument. It does not rename the
+ * implementing method itself (the method name is not constrained by the hook
+ * system), nor does it update any @deprecated or @see docblock text.
+ *
+ * @see https://www.drupal.org/node/1019966
+ * @see https://www.drupal.org/node/2690393
+ */
+final class RenameHookRankingRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Rename #[Hook(\'ranking\')] to #[Hook(\'node_search_ranking\')] following the deprecation of hook_ranking() in drupal:11.3.0.',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+#[Hook('ranking')]
+public function ranking(): array { return []; }
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+#[Hook('node_search_ranking')]
+public function ranking(): array { return []; }
+CODE_AFTER
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [Attribute::class];
+    }
+
+    /** @param Attribute $node */
+    public function refactor(Node $node): ?Node
+    {
+        // Only target \Drupal\Core\Hook\Attribute\Hook attributes.
+        if ($this->getName($node->name) !== 'Drupal\\Core\\Hook\\Attribute\\Hook') {
+            return null;
+        }
+
+        if ($node->args === []) {
+            return null;
+        }
+
+        $firstArg = $node->args[0]->value;
+        if (!$firstArg instanceof String_) {
+            return null;
+        }
+
+        if ($firstArg->value !== 'ranking') {
+            return null;
+        }
+
+        $firstArg->value = 'node_search_ranking';
+
+        return $node;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/RenameHookRankingRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/RenameHookRankingRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RenameHookRankingRector;
+
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class RenameHookRankingRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\RenameHookRankingRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(RenameHookRankingRector::class, $rectorConfig, false);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/fixture/basic.php.inc
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\mymodule\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+class SearchRankingHooks {
+
+  #[Hook('ranking')]
+  public function ranking(): array {
+    return [];
+  }
+
+}
+
+?>
+-----
+<?php
+
+namespace Drupal\mymodule\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+class SearchRankingHooks {
+
+  #[Hook('node_search_ranking')]
+  public function ranking(): array {
+    return [];
+  }
+
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/fixture/no_change_other_hook.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/fixture/no_change_other_hook.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+namespace Drupal\mymodule\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+
+class SearchRankingHooks {
+
+  // A Core Hook attribute, but a different hook name — left untouched.
+  #[Hook('node_presave')]
+  public function presave(): void {}
+
+  // Already migrated — idempotent, left untouched.
+  #[Hook('node_search_ranking')]
+  public function nodeSearchRanking(): array {
+    return [];
+  }
+
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drupal\mymodule;
+
+// A different "Hook" attribute (NOT Drupal\Core\Hook\Attribute\Hook) that
+// happens to share the 'ranking' argument must NOT be rewritten.
+use Drupal\mymodule\Attribute\Hook;
+
+class Foo {
+
+  #[Hook('ranking')]
+  public function bar(): array {
+    return [];
+  }
+
+}


### PR DESCRIPTION
## What

Adds `RenameHookRankingRector`, which renames the deprecated OOP hook attribute `#[Hook('ranking')]` to `#[Hook('node_search_ranking')]`.

`hook_ranking()` is deprecated in **drupal:11.3.0** and removed in **drupal:12.0.0**; use `hook_node_search_ranking()` instead.

## Scope of the transformation

- Targets only the `Drupal\Core\Hook\Attribute\Hook` attribute (an attribute of the same short name from another namespace is left untouched).
- Rewrites only the `'ranking'` argument — the implementing method name and any docblocks are intentionally unchanged.

## Why the breaking set (not the default deprecation set)

This is a **non-backward-compatible** rewrite. The `node_search_ranking` hook is only invoked on Drupal minors where it exists, so on older Drupal the renamed attribute is never invoked — a silent no-op. It also **cannot be BC-wrapped**: an `Attribute` is not an `Expr → Expr` transformation, so `DeprecationHelper` does not apply.

It therefore extends `AbstractRector` and is registered in the opt-in `Drupal11SetList::DRUPAL_113_BREAKING` set, mirroring the precedent set by `HookRequirementsAlterRenameRector`. Apply only after dropping support for Drupal minors that predate `hook_node_search_ranking()`.

## Coverage message

PHPStan emits no deprecation for `#[Hook('ranking')]` — the `hook_ranking()` deprecation is a `@deprecated` docblock on the `node.api.php` documentation function, and hook names are resolved as runtime strings, so phpstan-deprecation-rules has nothing to attach to the `'ranking'` literal. This is the established runtime-only-deprecation pattern (empty `PHPSTAN_MESSAGES`); a `TODO PHPSTAN_MESSAGES` note documenting this is included in the config.

## Testing

- Unit tests: `basic` (transform), `no_change_unrelated` (different `Hook` namespace), `no_change_other_hook` (other hook names + idempotency). All pass.
- `phpstan`: no errors. `fix-style`: no changes.
- **Live test**: verified against contrib `download_statistics` 1.0.x — `#[Hook('ranking')]` → `#[Hook('node_search_ranking')]` transformed correctly, method name and docblock preserved.

Issue: https://www.drupal.org/node/1019966
Change record: https://www.drupal.org/node/2690393