### PR TITLE
feat: add RemoveSourceModuleFromMigrateSourceAttributeRector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,23 @@ release-by-release.
 
 ### Added
 
+- **`RemoveSourceModuleFromMigrateSourceAttributeRector`** — removes the
+  `source_module` named argument from `#[MigrateSource]` attribute usages. Only
+  the `Drupal\migrate\Attribute\MigrateSource` attribute is targeted (an
+  attribute of the same short name from another namespace is left untouched).
+  The `source_module` constructor parameter was removed from the attribute in
+  drupal:11.2.0; passing `#[MigrateSource(source_module: '...')]` now raises an
+  "Unknown named parameter" error at plugin discovery time. The rewrite cannot
+  be BC-wrapped (an attribute is not an `Expr → Expr` transformation) and the
+  argument is mutually exclusive across minors, so the rule lives in the opt-in
+  `Drupal11SetList::DRUPAL_112_BREAKING` set, not the default deprecation set.
+  For plugins extending `DrupalSqlBase` the `source_module` value must be
+  re-declared via the `@MigrateSource` annotation or the migration YAML after
+  removal — a manual follow-up this rule does not automate. Apply only after
+  dropping support for Drupal minors that predate 11.2.0.
+  [#3009349](https://www.drupal.org/i/3009349) /
+  [change record](https://www.drupal.org/node/3306373)
+
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.2-breaking.php
+++ b/config/drupal-11/drupal-11.2-breaking.php
@@ -15,10 +15,37 @@ declare(strict_types=1);
  * Opt in via `Drupal11SetList::DRUPAL_112_BREAKING`.
  */
 
+use DrupalRector\Drupal11\Rector\Deprecation\RemoveSourceModuleFromMigrateSourceAttributeRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
 
 return static function (RectorConfig $rectorConfig): void {
+    // https://www.drupal.org/node/3009349
+    // https://www.drupal.org/node/3306373 (change record)
+    // The source_module constructor parameter was removed from
+    // Drupal\migrate\Attribute\MigrateSource in drupal:11.2.0. Passing
+    // #[MigrateSource(source_module: '...')] raises an "Unknown named
+    // parameter" error at plugin discovery on 11.2.0+. This rule strips the
+    // source_module named argument from #[MigrateSource] usages.
+    //
+    // Non-BC: an Attribute is not an Expr → Expr transformation, so it cannot
+    // be BC-wrapped, and the argument is mutually exclusive across minors —
+    // keeping it fatals on 11.2.0+, removing it drops the requirement metadata
+    // DrupalSqlBase uses to enforce the source module for D6/D7 migrations on
+    // older Drupal. For DrupalSqlBase plugins the value must be re-declared via
+    // the @MigrateSource annotation or the migration YAML after removal; that
+    // is a manual follow-up this rule does not automate. Apply only after
+    // dropping support for Drupal minors that predate 11.2.0.
+    //
+    // TODO PHPSTAN_MESSAGES RemoveSourceModuleFromMigrateSourceAttributeRector:
+    //   none. source_module was hard-removed (not @deprecated), so phpstan-
+    //   deprecation-rules has no deprecation to report. Verified against a
+    //   Drupal 11 test env: phpstan instead emits the hard error "Unknown
+    //   parameter $source_module in call to Drupal\migrate\Attribute\
+    //   MigrateSource constructor." (argument.unknownParameter, not a
+    //   deprecation). Intentionally no coverage message.
+    $rectorConfig->rule(RemoveSourceModuleFromMigrateSourceAttributeRector::class);
+
     // https://www.drupal.org/node/3488572
     // https://www.drupal.org/node/3488580 (change record)
     // Drupal\Core\Entity\Query\Sql\pgsql\* deprecated in drupal:11.2.0,

--- a/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use PhpParser\Node;
+use PhpParser\Node\Attribute;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Removes the deprecated source_module named argument from
+ * #[MigrateSource] attribute usages.
+ *
+ * The source_module constructor parameter was removed from
+ * Drupal\migrate\Attribute\MigrateSource in drupal:11.2.0; passing
+ * #[MigrateSource(source_module: '...')] now raises an "Unknown named
+ * parameter" error at plugin discovery time on Drupal 11.2.0 and later.
+ *
+ * This is a NON-backward-compatible rewrite. An Attribute is not an
+ * Expr → Expr transformation, so it cannot be BC-wrapped with
+ * DeprecationHelper, and the constructor argument is mutually exclusive
+ * across minors: keeping source_module fatals on 11.2.0+, while removing it
+ * drops the requirement metadata that Drupal\migrate_drupal\…\DrupalSqlBase
+ * relies on to enforce the source module for Drupal 6/7 migrations on older
+ * Drupal. The rule therefore lives in the opt-in DRUPAL_112_BREAKING set, not
+ * the default deprecation set. Apply it only after dropping support for the
+ * Drupal minors that predate 11.2.0.
+ *
+ * Caveat: for plugins extending DrupalSqlBase the source_module value must
+ * still be declared somewhere after this rule removes it from the attribute —
+ * either via the @MigrateSource annotation or the source_module key in the
+ * migration YAML. That re-declaration is not automated here and remains a
+ * manual follow-up.
+ *
+ * @see https://www.drupal.org/node/3009349
+ * @see https://www.drupal.org/node/3306373
+ */
+final class RemoveSourceModuleFromMigrateSourceAttributeRector extends AbstractRector
+{
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove the source_module named argument from #[MigrateSource] attribute usages, as it was removed from the attribute class in drupal:11.2.0.',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+#[MigrateSource(
+    id: 'd7_node',
+    source_module: 'node',
+)]
+class Node extends DrupalSqlBase {}
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+#[MigrateSource(
+    id: 'd7_node',
+)]
+class Node extends DrupalSqlBase {}
+CODE_AFTER
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [Attribute::class];
+    }
+
+    /** @param Attribute $node */
+    public function refactor(Node $node): ?Node
+    {
+        // Only target \Drupal\migrate\Attribute\MigrateSource attributes.
+        if ($this->getName($node->name) !== 'Drupal\\migrate\\Attribute\\MigrateSource') {
+            return null;
+        }
+
+        foreach ($node->args as $key => $arg) {
+            if ($arg->name !== null && $arg->name->toString() === 'source_module') {
+                unset($node->args[$key]);
+                // Re-index to avoid gaps.
+                $node->args = array_values($node->args);
+
+                return $node;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/RemoveSourceModuleFromMigrateSourceAttributeRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/RemoveSourceModuleFromMigrateSourceAttributeRectorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveSourceModuleFromMigrateSourceAttributeRector;
+
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class RemoveSourceModuleFromMigrateSourceAttributeRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\RemoveSourceModuleFromMigrateSourceAttributeRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(RemoveSourceModuleFromMigrateSourceAttributeRector::class, $rectorConfig, false);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/fixture/basic.php.inc
@@ -1,0 +1,28 @@
+<?php
+
+namespace Drupal\mymodule\Plugin\migrate\source;
+
+use Drupal\migrate\Attribute\MigrateSource;
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
+
+#[MigrateSource(
+    id: 'd7_node',
+    source_module: 'node',
+)]
+class Node extends DrupalSqlBase {}
+
+?>
+-----
+<?php
+
+namespace Drupal\mymodule\Plugin\migrate\source;
+
+use Drupal\migrate\Attribute\MigrateSource;
+use Drupal\migrate_drupal\Plugin\migrate\source\DrupalSqlBase;
+
+#[MigrateSource(
+    id: 'd7_node',
+)]
+class Node extends DrupalSqlBase {}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/fixture/no_change_no_source_module.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/fixture/no_change_no_source_module.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\mymodule\Plugin\migrate\source;
+
+use Drupal\migrate\Attribute\MigrateSource;
+use Drupal\migrate\Plugin\migrate\source\SourcePluginBase;
+
+// A core MigrateSource attribute that never declared source_module — nothing
+// to remove, left untouched (idempotent).
+#[MigrateSource(
+    id: 'my_source',
+)]
+class MySource extends SourcePluginBase {}

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+namespace Drupal\mymodule\Plugin\migrate\source;
+
+// A different "MigrateSource" attribute (NOT Drupal\migrate\Attribute\MigrateSource)
+// that happens to accept a source_module argument must NOT be rewritten.
+use Drupal\mymodule\Attribute\MigrateSource;
+
+#[MigrateSource(
+    id: 'custom',
+    source_module: 'node',
+)]
+class Custom {}


### PR DESCRIPTION
## What

Adds `RemoveSourceModuleFromMigrateSourceAttributeRector`, which removes the `source_module` named argument from `#[MigrateSource]` attribute usages.

The `source_module` constructor parameter was removed from `Drupal\migrate\Attribute\MigrateSource` in **drupal:11.2.0** ([#3009349](https://www.drupal.org/node/3009349)). Passing `#[MigrateSource(source_module: '...')]` now raises an *"Unknown parameter `$source_module`"* error at plugin discovery time.

**Before**
```php
#[MigrateSource(
  id: 'd7_node',
  source_module: 'node',
)]
class Node extends DrupalSqlBase {}
```

**After**
```php
#[MigrateSource(
  id: 'd7_node',
)]
class Node extends DrupalSqlBase {}
```

## Scope / safety

- Only the `Drupal\migrate\Attribute\MigrateSource` attribute is targeted (FQCN-guarded). The sibling `#[MigrateField(source_module: ...)]` attribute — which **still** accepts `source_module` and is common in contrib — and same-short-name attributes from other namespaces are left untouched.
- Targets the OOP **attribute** form only, not the legacy `@MigrateSource` **annotation** (docblock) form.

## Breaking-set placement

This is a non-BC rewrite, so it ships in the **opt-in** `Drupal11SetList::DRUPAL_112_BREAKING` set rather than the default deprecation set:

- An `Attribute` is not an `Expr → Expr` transformation, so it cannot be `DeprecationHelper`-wrapped.
- The argument is mutually exclusive across minors — keeping it fatals on 11.2.0+, while removing it drops the requirement metadata `DrupalSqlBase` uses to enforce the source module for D6/D7 migrations on older Drupal.

> ⚠️ **Caveat:** for plugins extending `DrupalSqlBase`, `source_module` must be re-declared via the `@MigrateSource` annotation or the migration YAML after removal — a manual follow-up this rule does not automate. Apply only after dropping support for Drupal minors that predate 11.2.0.

## Coverage note

`source_module` was *hard-removed* (not `@deprecated`), so PHPStan emits a hard `Unknown parameter $source_module …` error rather than a deprecation message — there is no coverage string to register. Documented as a `TODO PHPSTAN_MESSAGES` comment in the config.

## Testing

- `vendor/bin/phpunit` for the new rector — 3 tests pass (basic transform, idempotent no-`source_module`, unrelated-namespace no-op).
- `composer phpstan` (level 6) — clean.
- `composer fix-style` — clean.
- **Live test:** ran against real contrib `iframe` / `name` (`#[MigrateField(source_module:)]`) → left untouched (no false positive); synthetic `#[MigrateSource(source_module:)]` probe → correctly transformed.

Ref: https://www.drupal.org/node/3009349
Change record: https://www.drupal.org/node/3306373