### PR TITLE
feat: add BlockContentSelectionExtendsRector to DRUPAL_114_BREAKING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,23 @@ release-by-release.
   therefore lives in the opt-in `Drupal11SetList::DRUPAL_113_BREAKING` set, not
   the default deprecation set. [#1019966](https://www.drupal.org/i/1019966) /
   [change record](https://www.drupal.org/node/2690393)
+- **`BlockContentSelectionExtendsRector`** — reparents entity reference
+  selection plugins for the `block_content` entity type from
+  `Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection` to
+  `Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection`.
+  The hook that automatically filtered non-reusable blocks out of those
+  selections (`block_content_query_entity_reference_alter()`) is deprecated and
+  removed in drupal:12.0.0; `BlockContentSelection` performs that filtering
+  itself. The rewrite is gated on the `EntityReferenceSelection` attribute
+  carrying `entity_types: ["block_content"]`, so `DefaultSelection` subclasses
+  for other entity types are left untouched, and the canonical core
+  `BlockContentSelection` is skipped so it is not made to extend itself. Ships
+  in the opt-in `DRUPAL_114_BREAKING` set: `BlockContentSelection` was added to
+  core alongside the deprecation (a new class, so 11.4.0) and does not exist on
+  any minor below 11.4, so reparenting onto it would fatal there, and a
+  `class … extends …` declaration cannot be BC-wrapped.
+  [#2987159](https://www.drupal.org/i/2987159) /
+  [CR](https://www.drupal.org/node/3521459).
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-breaking.php
+++ b/config/drupal-11/drupal-11.4-breaking.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
  * introduced version.
  */
 
+use DrupalRector\Drupal11\Rector\Deprecation\BlockContentSelectionExtendsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNodeViewControllerRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -87,4 +88,31 @@ return static function (RectorConfig $rectorConfig): void {
     // matches both class names, so the trim is order-independent w.r.t. the
     // RenameClassRector pass above.
     $rectorConfig->rule(ReplaceNodeViewControllerRector::class);
+
+    // https://www.drupal.org/node/2987159
+    // https://www.drupal.org/node/3521459 (change record)
+    // block_content_query_entity_reference_alter() — the hook that
+    // automatically filtered non-reusable blocks out of every entity reference
+    // selection targeting block_content — is deprecated, removed in
+    // drupal:12.0.0. Entity reference selection plugins that extend
+    // Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection
+    // directly must now extend
+    // Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection
+    // instead, which performs the reusable-block filtering itself.
+    //
+    // BlockContentSelection was ADDED to core alongside the deprecation
+    // (drupal-core 7f9570dba9, on the 11.4-dev branch — a new class ships in a
+    // minor, so 11.4.0, even though the runtime deprecation message text reads
+    // "11.3.0"). It does not exist on any earlier minor, so reparenting a
+    // subclass onto it produces a "class not found" fatal on Drupal < 11.4. A
+    // `class X extends Y` declaration is a structural node, not an Expr → Expr
+    // rewrite, so it cannot be BC-wrapped.
+    //
+    // PHPSTAN_MESSAGES BlockContentSelectionExtendsRector: none. The deprecation
+    // is a runtime @trigger_error raised inside the query_entity_reference_alter
+    // hook when the auto-filtering happens, not a static @deprecated annotation
+    // on any symbol the plugin references, so phpstan-deprecation-rules /
+    // upgrade_status cannot flag a `class X extends DefaultSelection`
+    // declaration. There is no static message to match.
+    $rectorConfig->rule(BlockContentSelectionExtendsRector::class);
 };

--- a/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector.php
+++ b/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Class_;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Reparents entity reference selection plugins for the block_content entity
+ * type from DefaultSelection to BlockContentSelection.
+ *
+ * In Drupal 11.4 block_content_query_entity_reference_alter() was deprecated.
+ * That hook is what automatically filtered non-reusable blocks out of every
+ * entity reference selection targeting block_content. Plugins that extend
+ * DefaultSelection directly must now extend BlockContentSelection instead,
+ * which performs the reusable-block filtering in buildEntityQuery() /
+ * validateReferenceableNewEntities() rather than relying on the hook.
+ *
+ * BREAKING: this rule lives in the opt-in DRUPAL_114_BREAKING set, not the
+ * default deprecation set. BlockContentSelection
+ * (Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection)
+ * was ADDED to core in the same change as the deprecation (drupal-core
+ * 7f9570dba9, 11.4.0) and does not exist on any earlier minor. Reparenting a
+ * subclass onto it produces a "class not found" fatal on Drupal < 11.4, and a
+ * `class X extends Y` declaration is a structural node, not an Expr → Expr
+ * rewrite, so it cannot be BC-wrapped with DeprecationHelper. Consumers must
+ * opt in only after committing to drop support for any minor below 11.4.
+ *
+ * The rewrite is gated on the EntityReferenceSelection PHP attribute carrying
+ * `entity_types: ["block_content"]`, so DefaultSelection subclasses that
+ * target other entity types are left untouched. The canonical core
+ * BlockContentSelection (which itself extends DefaultSelection and carries the
+ * same attribute) is skipped explicitly so the rule does not try to make it
+ * extend itself.
+ *
+ * @see https://www.drupal.org/node/2987159
+ * @see https://www.drupal.org/node/3521459
+ */
+class BlockContentSelectionExtendsRector extends AbstractRector
+{
+    private const DEFAULT_SELECTION_CLASS = 'Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection';
+
+    private const BLOCK_CONTENT_SELECTION_CLASS = 'Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection';
+
+    private const ENTITY_REFERENCE_SELECTION_ATTR = 'Drupal\Core\Entity\Attribute\EntityReferenceSelection';
+
+    // The deprecation is a *runtime* @trigger_error raised inside the
+    // query_entity_reference_alter hook (BlockContentHooks) when a block_content
+    // entity reference selection is auto-filtered — "Automatically filtering
+    // block_content entity reference selection queries to only reusable blocks
+    // is deprecated in drupal:11.3.0 and is removed from drupal:12.0.0. … See
+    // https://www.drupal.org/node/3521459". It is not a static @deprecated
+    // annotation on any symbol the plugin references, so phpstan-deprecation-rules
+    // / upgrade_status cannot flag a `class X extends DefaultSelection`
+    // declaration. There is no static message to match.
+    public const PHPSTAN_MESSAGES = [];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Entity reference selection plugins for block_content that extend DefaultSelection must extend BlockContentSelection instead, to avoid the deprecated automatic reusable-block filtering hook.',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+  id: "mymodule:block_content",
+  label: new TranslatableMarkup("My block content selection"),
+  group: "mymodule",
+  entity_types: ["block_content"],
+)]
+class MyBlockContentSelection extends DefaultSelection {
+}
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+  id: "mymodule:block_content",
+  label: new TranslatableMarkup("My block content selection"),
+  group: "mymodule",
+  entity_types: ["block_content"],
+)]
+class MyBlockContentSelection extends \Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection {
+}
+CODE_AFTER
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [Class_::class];
+    }
+
+    /** @param Class_ $node */
+    public function refactor(Node $node): ?Node
+    {
+        // Must extend DefaultSelection (resolved via the name resolver, so a
+        // short alias or a fully-qualified `extends` both match).
+        if ($node->extends === null) {
+            return null;
+        }
+        if (!$this->isName($node->extends, self::DEFAULT_SELECTION_CLASS)) {
+            return null;
+        }
+
+        // Skip the canonical core BlockContentSelection itself — it extends
+        // DefaultSelection by design and carries the same attribute, so without
+        // this guard the rule would try to make it extend itself.
+        if ($this->isName($node, self::BLOCK_CONTENT_SELECTION_CLASS)) {
+            return null;
+        }
+
+        // Only reparent plugins whose EntityReferenceSelection attribute targets
+        // the block_content entity type.
+        if (!$this->hasBlockContentEntityReferenceSelectionAttribute($node)) {
+            return null;
+        }
+
+        $node->extends = new FullyQualified(self::BLOCK_CONTENT_SELECTION_CLASS);
+
+        return $node;
+    }
+
+    private function hasBlockContentEntityReferenceSelectionAttribute(Class_ $class): bool
+    {
+        foreach ($class->attrGroups as $attrGroup) {
+            foreach ($attrGroup->attrs as $attr) {
+                $attrName = $attr->name->toString();
+                // Match both the short name (resolved via use-statement) and the
+                // fully-qualified attribute name.
+                if ($attrName !== 'EntityReferenceSelection'
+                    && $attrName !== self::ENTITY_REFERENCE_SELECTION_ATTR
+                ) {
+                    continue;
+                }
+                foreach ($attr->args as $arg) {
+                    // Named argument: entity_types: [...]
+                    if ($arg->name === null || $arg->name->toString() !== 'entity_types') {
+                        continue;
+                    }
+                    if (!$arg->value instanceof Array_) {
+                        continue;
+                    }
+                    foreach ($arg->value->items as $item) {
+                        if ($item->value instanceof String_
+                            && $item->value->value === 'block_content'
+                        ) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/BlockContentSelectionExtendsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/BlockContentSelectionExtendsRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\BlockContentSelectionExtendsRector;
+
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class BlockContentSelectionExtendsRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\BlockContentSelectionExtendsRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(BlockContentSelectionExtendsRector::class, $rectorConfig, false);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/basic.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "mymodule:block_content",
+    label: new TranslatableMarkup("My block content selection"),
+    group: "mymodule",
+    entity_types: ["block_content"],
+)]
+class MyBlockContentSelection extends DefaultSelection
+{
+}
+
+?>
+-----
+<?php
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "mymodule:block_content",
+    label: new TranslatableMarkup("My block content selection"),
+    group: "mymodule",
+    entity_types: ["block_content"],
+)]
+class MyBlockContentSelection extends \Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection
+{
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_no_attribute.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_no_attribute.php.inc
@@ -1,0 +1,29 @@
+<?php
+
+// A DefaultSelection subclass with no EntityReferenceSelection attribute — the
+// rule cannot confirm it targets block_content, so it is left untouched.
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+
+class UnannotatedSelection extends DefaultSelection
+{
+}
+
+?>
+-----
+<?php
+
+// A DefaultSelection subclass with no EntityReferenceSelection attribute — the
+// rule cannot confirm it targets block_content, so it is left untouched.
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+
+class UnannotatedSelection extends DefaultSelection
+{
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_other_entity.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_other_entity.php.inc
@@ -1,0 +1,45 @@
+<?php
+
+// A DefaultSelection subclass that targets a different entity type — the
+// block_content gate does not match, so it is left untouched.
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "mymodule:node",
+    label: new TranslatableMarkup("My node selection"),
+    group: "mymodule",
+    entity_types: ["node"],
+)]
+class MyNodeSelection extends DefaultSelection
+{
+}
+
+?>
+-----
+<?php
+
+// A DefaultSelection subclass that targets a different entity type — the
+// block_content gate does not match, so it is left untouched.
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "mymodule:node",
+    label: new TranslatableMarkup("My node selection"),
+    group: "mymodule",
+    entity_types: ["node"],
+)]
+class MyNodeSelection extends DefaultSelection
+{
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_self.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_self.php.inc
@@ -1,0 +1,47 @@
+<?php
+
+// The canonical core BlockContentSelection extends DefaultSelection and carries
+// the same block_content attribute, but must not be rewritten to extend itself.
+
+namespace Drupal\block_content\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "default:block_content",
+    label: new TranslatableMarkup("Block content selection"),
+    group: "default",
+    weight: 1,
+    entity_types: ["block_content"],
+)]
+class BlockContentSelection extends DefaultSelection
+{
+}
+
+?>
+-----
+<?php
+
+// The canonical core BlockContentSelection extends DefaultSelection and carries
+// the same block_content attribute, but must not be rewritten to extend itself.
+
+namespace Drupal\block_content\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "default:block_content",
+    label: new TranslatableMarkup("Block content selection"),
+    group: "default",
+    weight: 1,
+    entity_types: ["block_content"],
+)]
+class BlockContentSelection extends DefaultSelection
+{
+}
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_unrelated_parent.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/fixture/no_change_unrelated_parent.php.inc
@@ -1,0 +1,43 @@
+<?php
+
+// A block_content selection plugin that does NOT extend DefaultSelection — the
+// parent-class gate does not match, so it is left untouched.
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "mymodule:block_content",
+    label: new TranslatableMarkup("My block content selection"),
+    group: "mymodule",
+    entity_types: ["block_content"],
+)]
+class MyBlockContentSelection extends \Drupal\some_module\SomeOtherBase
+{
+}
+
+?>
+-----
+<?php
+
+// A block_content selection plugin that does NOT extend DefaultSelection — the
+// parent-class gate does not match, so it is left untouched.
+
+namespace Drupal\mymodule\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Attribute\EntityReferenceSelection;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+
+#[EntityReferenceSelection(
+    id: "mymodule:block_content",
+    label: new TranslatableMarkup("My block content selection"),
+    group: "mymodule",
+    entity_types: ["block_content"],
+)]
+class MyBlockContentSelection extends \Drupal\some_module\SomeOtherBase
+{
+}
+
+?>


### PR DESCRIPTION
## What

Adds `BlockContentSelectionExtendsRector` — reparents entity reference selection plugins for the `block_content` entity type from `Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection` to `Drupal\block_content\Plugin\EntityReferenceSelection\BlockContentSelection`.

In Drupal 11.4 the hook that automatically filtered non-reusable blocks out of every entity reference selection targeting `block_content` (`block_content_query_entity_reference_alter()`) was deprecated (removed in drupal:12.0.0). `BlockContentSelection` performs that filtering itself (in `buildEntityQuery()` / `validateReferenceableNewEntities()`), so plugins that extended `DefaultSelection` directly must now extend `BlockContentSelection`.

Issue: https://www.drupal.org/i/2987159
Change record: https://www.drupal.org/node/3521459

## How it's gated

The rewrite only fires when **both** hold, so it never touches `DefaultSelection` subclasses for other entity types:

- the class `extends DefaultSelection` (resolved via the name resolver, so a short alias or an FQCN both match), and
- it carries an `#[EntityReferenceSelection(...)]` attribute with `entity_types: ["block_content"]`.

The canonical core `BlockContentSelection` (which itself extends `DefaultSelection` and carries the same attribute) is skipped explicitly so the rule never makes it extend itself.

## Why the BREAKING set (not the default deprecation set)

`BlockContentSelection` was **added to core alongside the deprecation** (drupal-core `7f9570dba9`, on the 11.4-dev branch — a new public class, so it ships in 11.4.0 even though the runtime deprecation message text reads "11.3.0"). It does not exist on any earlier minor, so reparenting a subclass onto it produces a **"class not found" fatal on Drupal < 11.4**.

A `class X extends Y` declaration is a structural node, not an `Expr → Expr` rewrite, so it **cannot** be BC-wrapped with `DeprecationHelper`. Hence `AbstractRector` and the opt-in `DRUPAL_114_BREAKING` set — consumers should run it only after committing to drop support for any minor below 11.4.

`PHPSTAN_MESSAGES` is intentionally empty: the deprecation is a runtime `@trigger_error` raised inside the hook, not a static `@deprecated` annotation on any symbol the plugin references, so `phpstan-deprecation-rules` / upgrade_status cannot flag a `class X extends DefaultSelection` declaration. There is no static message to match.

## Testing

- Unit: 5/5 pass — `basic` transform plus four no-change guards (self-skip, other-entity-type, no-attribute, unrelated-parent).
- `phpstan`: no errors. `fix-style`: no changes.
- Live-test against contrib: no module currently triggers the rule (the modern attribute-based block_content selection pattern doesn't yet exist in contrib — the one block_content selection found, `openy_er`, uses the old annotation style and extends `NodeSelection`). No-false-positive check against three real attribute-based `DefaultSelection` plugins (`commerce` ProductVariationSelection/UserSearch, `paragraphs` ParagraphSelection — differing only in `entity_types`) produced **zero changes**, confirming the `entity_types` gate discriminates correctly on real code.