### PR TITLE
feat: add RemoveRouteBuilderDeprecatedArgsRector for #3311365

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,15 @@ release-by-release.
   `class … extends …` declaration cannot be BC-wrapped.
   [#2987159](https://www.drupal.org/i/2987159) /
   [CR](https://www.drupal.org/node/3521459).
+- **`RemoveRouteBuilderDeprecatedArgsRector`** — rewrites the deprecated
+  6-argument `new \Drupal\Core\Routing\RouteBuilder(...)` instantiation to the
+  new 4-argument form (deprecated in drupal:11.4.0, removed in drupal:12.0.0).
+  The `$module_handler` (arg 3) and `$controller_resolver` (arg 4) arguments
+  were removed and `$check_provider` shifted from position 5 to position 3;
+  YAML route discovery moved to the new `YamlRouteDiscovery` service. Only
+  6-argument positional calls to `RouteBuilder` are matched; the new signature
+  only exists on Drupal ≥ 11.4, so the change is BC-wrapped via
+  `DeprecationHelper::backwardsCompatibleCall()`.
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -18,6 +18,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\RemoveFilterTipsLongParamRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveInstallSchemaSystemSequencesRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveLinkWidgetValidateTitleElementRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemovePhpUnitCompatibilityTraitRector;
+use DrupalRector\Drupal11\Rector\Deprecation\RemoveRouteBuilderDeprecatedArgsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveSetUriCallbackRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveToolkitArgFromImageToolkitOperationConstructorRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveTrustDataCallRector;
@@ -572,6 +573,16 @@ return static function (RectorConfig $rectorConfig): void {
     // the '#attributes' variable was only added to these hooks in 11.4.0, so a
     // plain rename silently drops the attributes on Drupal < 11.4.
     $rectorConfig->ruleWithConfiguration(ReplaceItemAttributesWithAttributesRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+
+    // https://www.drupal.org/node/3311365
+    // https://www.drupal.org/node/3324751 (change record)
+    // RouteBuilder::__construct() $module_handler and $controller_resolver
+    // arguments deprecated in drupal:11.4.0, removed in drupal:12.0.0. YAML
+    // route discovery moved to the new YamlRouteDiscovery service; the 6-arg
+    // constructor form is rewritten to the new 4-arg form.
+    $rectorConfig->ruleWithConfiguration(RemoveRouteBuilderDeprecatedArgsRector::class, [
         new DrupalIntroducedVersionConfiguration('11.4.0'),
     ]);
 };

--- a/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Removes the deprecated $module_handler and $controller_resolver arguments
+ * from RouteBuilder::__construct().
+ *
+ * The 6-argument form is rewritten to the new 4-argument form introduced in
+ * Drupal 11.4.0. The $module_handler (arg 3) and $controller_resolver (arg 4)
+ * parameters were deprecated and removed; $check_provider shifts from position
+ * 5 to position 3. YAML route discovery moved to the new YamlRouteDiscovery
+ * service.
+ *
+ * Only rewrites calls with exactly 6 positional arguments. Named arguments or
+ * calls with a different argument count are left untouched. Does not handle
+ * parent::__construct() calls inside subclasses of RouteBuilder, which would
+ * require walking up to the enclosing class to verify the parent chain.
+ *
+ * @see https://www.drupal.org/node/3311365
+ * @see https://www.drupal.org/node/3324751
+ */
+class RemoveRouteBuilderDeprecatedArgsRector extends AbstractDrupalCoreRector
+{
+    /**
+     * @var array|DrupalIntroducedVersionConfiguration[]
+     */
+    protected array $configuration;
+
+    // TODO PHPSTAN_MESSAGES RemoveRouteBuilderDeprecatedArgsRector:
+    // RouteBuilder::__construct() is not annotated @deprecated — only passing
+    // the (now removed) $module_handler/$controller_resolver arguments triggers
+    // a runtime trigger_error in core, keyed on the argument *count* and the
+    // $check_provider argument being a ModuleHandlerInterface. PHPStan emits no
+    // static deprecation message for this call shape, so upgrade_status cannot
+    // match this rector via the standard $rector_covered lookup. Verified
+    // against the drupal-core 11.4 RouteBuilder constructor.
+    public const PHPSTAN_MESSAGES = [];
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Remove deprecated $module_handler and $controller_resolver arguments from RouteBuilder::__construct()',
+            [
+                new ConfiguredCodeSample(
+                    <<<'CODE_BEFORE'
+new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $checkProvider);
+CODE_AFTER,
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+            ]
+        );
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [New_::class];
+    }
+
+    protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof New_);
+        if (!$node->class instanceof Name) {
+            return null;
+        }
+        if (!$this->isName($node->class, 'Drupal\Core\Routing\RouteBuilder')) {
+            return null;
+        }
+        if (count($node->args) !== 6) {
+            return null;
+        }
+
+        // Old signature: ($dumper, $lock, $dispatcher, $module_handler, $controller_resolver, $check_provider)
+        // New signature: ($dumper, $lock, $dispatcher, $check_provider)
+        // Clone the node and reassign args on the clone so the original node is
+        // left intact for the backwards-compatible call's "old" branch.
+        $cloned = clone $node;
+        $cloned->args = [$node->args[0], $node->args[1], $node->args[2], $node->args[5]];
+
+        return $cloned;
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/RemoveRouteBuilderDeprecatedArgsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/RemoveRouteBuilderDeprecatedArgsRectorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveRouteBuilderDeprecatedArgsRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class RemoveRouteBuilderDeprecatedArgsRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /**
+     * @return \Iterator<<string>>
+     */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\RemoveRouteBuilderDeprecatedArgsRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(RemoveRouteBuilderDeprecatedArgsRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$builder = new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider);
+
+?>
+-----
+<?php
+
+$builder = new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/basic.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$builder = new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider);
+
+?>
+-----
+<?php
+
+$builder = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $checkProvider), fn() => new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider));
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/no_change_already_migrated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/no_change_already_migrated.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Already on the 4-argument form — leave untouched.
+$builder = new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $checkProvider);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Unrelated class with the same 6-argument shape — must not be transformed.
+$builder = new \Drupal\other\SomeOtherBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider);
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/no_change_wrong_arg_count.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/fixture/no_change_wrong_arg_count.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+// RouteBuilder with an unexpected argument count — must not be transformed.
+$builder = new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver);
+
+?>


### PR DESCRIPTION
## What

Adds `RemoveRouteBuilderDeprecatedArgsRector`, which rewrites the deprecated 6-argument `new \Drupal\Core\Routing\RouteBuilder(...)` instantiation to the new 4-argument form.

```php
// Before
new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider);

// After (BC-wrapped)
\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(
    \Drupal::VERSION, '11.4.0',
    fn() => new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $checkProvider),
    fn() => new \Drupal\Core\Routing\RouteBuilder($dumper, $lock, $dispatcher, $moduleHandler, $controllerResolver, $checkProvider),
);
```

## Why

In drupal:11.4.0 the `RouteBuilder` constructor was simplified — the `$module_handler` (arg 3) and `$controller_resolver` (arg 4) arguments were removed and `$check_provider` moved from position 5 to position 3. YAML route discovery moved to the new `YamlRouteDiscovery` service. The old signature is deprecated in 11.4.0 and removed in 12.0.0.

- **Issue:** https://www.drupal.org/node/3311365
- **Change record:** https://www.drupal.org/node/3324751

## BC handling

The pre-11.4 constructor required **all six** arguments (verified against drupal-core git history), so emitting the bare 4-argument form would fatal on Drupal ≤ 11.3. The transformation is therefore BC-wrapped via `DeprecationHelper::backwardsCompatibleCall()` (`AbstractDrupalCoreRector`, `introducedVersion` 11.4.0) — mirroring the existing `CommentLinkBuilderConstructorRector`.

## Scope

- Only direct 6-argument **positional** `new RouteBuilder(...)` instantiation is matched.
- `parent::__construct()` calls inside subclasses are intentionally not handled (would require walking the parent chain).
- The constructor is not statically `@deprecated`-annotated (only a runtime `trigger_error` on the deprecated arg shape), so PHPStan emits no static message — `PHPSTAN_MESSAGES = []` is documented with a TODO, consistent with `CommentLinkBuilderConstructorRector`.

## Tests

- `testAboveVersion` (version 99.99.99 → transforms) and `testBelowVersion` (version 1.0.0 → no change) per the BC version-gating convention.
- Fixtures: `basic`, `no_change_already_migrated` (already 4-arg), `no_change_unrelated` (different class, same shape), `no_change_wrong_arg_count`, and `fixture-below-version/basic`.
- `phpunit` (5 tests / 6 assertions), `phpstan`, and `fix-style` all pass.

## Live test

No D11-compatible contrib module instantiates `\Drupal\Core\Routing\RouteBuilder` directly — it's a core service obtained via DI, not `new`'d in contrib. The rector is correct; there's simply no real-world call site to exercise it against.