### PR TITLE
[postponed] feat: rename UserAuthenticationController to RestAuthenticationController (11.4 breaking)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ release-by-release.
 
 ### Added
 
+- **`DRUPAL_114_BREAKING`: `user\Controller\UserAuthenticationController` →
+  `rest\Controller\RestAuthenticationController`** — new `RenameClassRector`
+  entry in the opt-in `drupal-11.4-breaking.php` set. The old controller is
+  deprecated in drupal:11.4.0 and removed in drupal:12.0.0; its replacement was
+  added to the `rest` module in the same commit (drupal-core `c0e71efe93`, 11.x
+  only) and does not exist on any older minor, so the structural
+  `use`/`extends`/`::class` rewrite fatals on Drupal < 11.4 and cannot be
+  BC-wrapped. The `rest` module must also be enabled at runtime. Route name
+  strings (`user.login.http` → `rest.login`, etc.) are not rewritten and must be
+  updated manually. ([#3530640](https://www.drupal.org/i/3530640) /
+  [CR](https://www.drupal.org/node/3552724)).
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.4-breaking.php
+++ b/config/drupal-11/drupal-11.4-breaking.php
@@ -32,8 +32,31 @@ return static function (RectorConfig $rectorConfig): void {
     // do not exist on any Drupal 10.x branch. Running this rule against code
     // that still needs to work on Drupal 10 will produce a "class not found"
     // fatal there.
+    // https://www.drupal.org/node/3530640
+    // https://www.drupal.org/node/3552724 (change record)
+    // Drupal\user\Controller\UserAuthenticationController deprecated in
+    // drupal:11.4.0, removed in drupal:12.0.0. Use
+    // Drupal\rest\Controller\RestAuthenticationController instead. The
+    // replacement controller was ADDED to the rest module in the same commit as
+    // the deprecation (drupal-core c0e71efe93, on 11.x only) and does not exist
+    // on any older minor, so rewriting `use` / `extends` / `::class` references
+    // to it would produce a "class not found" fatal there. The rest module must
+    // also be enabled at runtime for the new controller's routes to exist.
+    //
+    // This renames PHP references to the class only. Route name strings
+    // (user.login.http → rest.login, user.logout.http → rest.logout,
+    // user.login_status.http → rest.login_status, user.pass.http → rest.pass)
+    // passed to Url::fromRoute() etc. are not touched and must be updated
+    // manually.
+    //
+    // PHPSTAN_MESSAGES RenameClassRector: UserAuthenticationController is
+    //   annotated `@deprecated in drupal:11.4.0` at the class level, so
+    //   phpstan-deprecation-rules emits "Class ... extends deprecated class
+    //   Drupal\user\Controller\UserAuthenticationController: ..." for subclasses
+    //   and "Instantiation of deprecated class ..." for direct `new` calls.
     $rectorConfig->ruleWithConfiguration(RenameClassRector::class, [
         'Drupal\menu_link_content\Plugin\migrate\process\LinkOptions' => 'Drupal\migrate\Plugin\migrate\process\LinkOptions',
         'Drupal\menu_link_content\Plugin\migrate\process\LinkUri' => 'Drupal\migrate\Plugin\migrate\process\LinkUri',
+        'Drupal\user\Controller\UserAuthenticationController' => 'Drupal\rest\Controller\RestAuthenticationController',
     ]);
 };


### PR DESCRIPTION
# 🔴 Blocker: targets a reverted core change

## What

Adds a `RenameClassRector` entry to the opt-in **`DRUPAL_114_BREAKING`** set
(`config/drupal-11/drupal-11.4-breaking.php`):

```
Drupal\user\Controller\UserAuthenticationController
  → Drupal\rest\Controller\RestAuthenticationController
```

Source: [#3530640](https://www.drupal.org/node/3530640) · CR [#3552724](https://www.drupal.org/node/3552724)

## Why breaking (not the default deprecation set)

`UserAuthenticationController` is deprecated in drupal:11.4.0 and removed in
drupal:12.0.0. Its replacement, `RestAuthenticationController`, was **added to
the `rest` module in the same commit as the deprecation** (drupal-core
`c0e71efe93`, 11.x only) and does not exist on any older minor. Rewriting the
structural `use` / `extends` / `::class` references to it would produce a
"class not found" fatal on Drupal < 11.4, and a class rename is not an
Expr→Expr transformation so it cannot be BC-wrapped. The `rest` module must
also be enabled at runtime for the new controller's routes to exist.

This mirrors the other entries already in this opt-in set (the
`menu_link_content` migrate-process renames, HelpSearch, NodeViewController).

## Caveat (documented in the config comment + CHANGELOG)

Only PHP class references are rewritten. Route name strings
(`user.login.http` → `rest.login`, `user.logout.http` → `rest.logout`,
`user.login_status.http` → `rest.login_status`, `user.pass.http` → `rest.pass`)
passed to `Url::fromRoute()` etc. are **not** touched and must be updated
manually.

## Verification

- `php -l` clean; targeted dry-run confirms the rename fires.
- **rector-live-test** against real D11 contrib subclasses:

  | Module | Installs | Result |
  |---|---|---|
  | `login_emailusername` (3.0.x) | 9,019 | ✅ subclass reparented onto `RestAuthenticationController` |
  | `email_tfa` (3.0.x) | 243 | ✅ subclass reparented |

  `rest_password` correctly produced no change (references the class only in a
  docblock comment).