### PR TITLE
feat(hooks): declare $this-free hook methods static and migrate t() to $this->t()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -419,6 +419,16 @@ release-by-release.
 - Guide: [Running against a Drupal 10 project](docs/running-against-drupal-10.md) — covers the
   direct install and a standalone-runner recipe for sites whose PHPStan 1 tooling conflicts with
   Rector 2's PHPStan 2 requirement.
+- **`HookConvertRector`** now produces lint-clean hook classes:
+  - Methods whose body never references `$this` are declared `static`
+    (satisfies the `canvas.requireStaticMethods` / "method does not use `$this`
+    and should be declared static" check). The body originates from a
+    procedural function, so this is safe by construction.
+  - Global `t()` calls are rewritten to `$this->t()` and the generated class
+    gains `use Drupal\Core\StringTranslation\StringTranslationTrait;` (clears
+    the `DrupalPractice.Objects.GlobalFunction.GlobalFunction` warning). Because
+    `$this->t()` introduces `$this`, those methods correctly remain
+    non-static — the two rules compose rather than conflict.
 
 ### Fixed
 

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -41,6 +41,14 @@ class HookConvertRector extends AbstractRector
     protected string $moduleDir = '';
 
     /**
+     * Whether any converted method needed StringTranslationTrait.
+     *
+     * Set when a t() call is rewritten to $this->t(); consumed when the hook
+     * class is assembled to add the trait import and use statement.
+     */
+    protected bool $needsTranslationTrait = false;
+
+    /**
      * The Drupal service call.
      *
      * For example \Drupal::service(UserHooks::CLASS)
@@ -209,6 +217,7 @@ CODE_SAMPLE
             $classConst = new Node\Expr\ClassConstFetch(new FullyQualified("$namespace\\$candidate"), 'class');
             $this->drupalServiceCall = new Node\Expr\StaticCall(new FullyQualified('Drupal'), 'service', [new Node\Arg($classConst)]);
             $this->useStmts = [];
+            $this->needsTranslationTrait = false;
         }
     }
 
@@ -216,19 +225,8 @@ CODE_SAMPLE
     {
         if ($this->module && $this->hookClass->stmts) {
             $className = $this->hookClass->name->toString();
-            // Put the file together.
             $namespace = "Drupal\\$this->module\\Hook";
-            $hookClassStmts = [
-                new Node\Stmt\Namespace_(new Node\Name($namespace)),
-                ...$this->useStmts,
-                new Use_([
-                    class_exists('PhpParser\Node\UseItem')
-                    ? new Node\UseItem(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))
-                    : new Node\Stmt\UseUse(new Node\Name('Drupal\Core\Hook\Attribute\Hook')),
-                ]),
-                $this->hookClass,
-            ];
-            $this->hookClass->setDocComment(new \PhpParser\Comment\Doc("/**\n * Hook implementations for $this->module.\n */"));
+            $hookClassStmts = $this->buildHookClassStmts();
             // Write it out if not a dry run
             if ($this->isDryRun === false) {
                 @mkdir("$this->moduleDir/src");
@@ -241,6 +239,43 @@ CODE_SAMPLE
             }
         }
         $this->module = '';
+    }
+
+    /**
+     * Assembles the statements for the generated hook class file.
+     *
+     * Adds the Hook attribute import, the class doc comment, and - when any
+     * converted method needed it - the StringTranslationTrait import plus a
+     * `use StringTranslationTrait;` statement at the top of the class body.
+     *
+     * @return Node\Stmt[]
+     */
+    protected function buildHookClassStmts(): array
+    {
+        $namespace = "Drupal\\$this->module\\Hook";
+        $useImports = [
+            new Use_([
+                class_exists('PhpParser\Node\UseItem')
+                ? new Node\UseItem(new Node\Name('Drupal\Core\Hook\Attribute\Hook'))
+                : new Node\Stmt\UseUse(new Node\Name('Drupal\Core\Hook\Attribute\Hook')),
+            ]),
+        ];
+        if ($this->needsTranslationTrait) {
+            $useImports[] = new Use_([
+                class_exists('PhpParser\Node\UseItem')
+                ? new Node\UseItem(new Node\Name('Drupal\Core\StringTranslation\StringTranslationTrait'))
+                : new Node\Stmt\UseUse(new Node\Name('Drupal\Core\StringTranslation\StringTranslationTrait')),
+            ]);
+            array_unshift($this->hookClass->stmts, new Node\Stmt\TraitUse([new Node\Name('StringTranslationTrait')]));
+        }
+        $this->hookClass->setDocComment(new \PhpParser\Comment\Doc("/**\n * Hook implementations for $this->module.\n */"));
+
+        return [
+            new Node\Stmt\Namespace_(new Node\Name($namespace)),
+            ...$this->useStmts,
+            ...$useImports,
+            $this->hookClass,
+        ];
     }
 
     protected function createMethodFromFunction(Function_ $node): ?ClassMethod
@@ -266,12 +301,27 @@ CODE_SAMPLE
             // Resolve __FUNCTION__ and unqualify things so TRUE doesn't
             // become \TRUE.
             $visitor = new class(new String_($node->name->toString())) extends NodeVisitorAbstract {
+                /**
+                 * Whether a t() call was rewritten to $this->t().
+                 */
+                public bool $usedTranslation = false;
+
                 public function __construct(protected String_ $functionName)
                 {
                 }
 
                 public function leaveNode(Node $node)
                 {
+                    // Rewrite the global t() to $this->t() so the method uses
+                    // StringTranslationTrait. This intentionally introduces
+                    // $this, which keeps the method non-static. Matches both
+                    // t() and \t().
+                    if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name && $node->name->toString() === 't') {
+                        $this->usedTranslation = true;
+
+                        return new Node\Expr\MethodCall(new Node\Expr\Variable('this'), new Node\Identifier('t'), $node->args);
+                    }
+
                     if (isset($node->name) && $node->name instanceof FullyQualified) {
                         $name = new Node\Name($node->name);
                         if ($name->isUnqualified()) {
@@ -291,9 +341,20 @@ CODE_SAMPLE
             $traverser = new NodeTraverser();
             $traverser->addVisitor($visitor);
             $traverser->traverse([$node]);
+            if ($visitor->usedTranslation) {
+                $this->needsTranslationTrait = true;
+            }
             // Convert the function to a method.
             $method = new ClassMethod($this->getMethodName($node), get_object_vars($node), $node->getAttributes());
-            $method->flags = Modifiers::PUBLIC;
+            // Declare the method static when its body never touches $this. The
+            // body comes from a procedural function, so the only $this it can
+            // contain is the one introduced by the t() -> $this->t() rewrite
+            // above; that case correctly keeps the method non-static.
+            $usesThis = (bool) (new NodeFinder())->findFirst(
+                $method->stmts ?? [],
+                fn (Node $n) => $n instanceof Node\Expr\Variable && \is_string($n->name) && $n->name === 'this'
+            );
+            $method->flags = $usesThis ? Modifiers::PUBLIC : Modifiers::PUBLIC | Modifiers::STATIC;
             // Assemble the arguments for the #[Hook] attribute.
             $arguments = [new Node\Arg(new String_($hook))];
             if ($implementsModule !== $this->module) {

--- a/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks.php
+++ b/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks.php
@@ -13,7 +13,7 @@ class HookconvertrectorHooks
      * Implements hook_user_cancel().
      */
     #[Hook('user_cancel')]
-    public function userCancel($edit, \UserInterface $account, $method)
+    public static function userCancel($edit, \UserInterface $account, $method)
     {
         $red = 'red';
         $method = [
@@ -32,7 +32,7 @@ class HookconvertrectorHooks
      * Implements hook_page_attachments().
      */
     #[Hook('page_attachments')]
-    public function pageAttachments(array &$page)
+    public static function pageAttachments(array &$page)
     {
         // Routes that don't use BigPipe also don't need no-JS detection.
         if (\Drupal::routeMatch()->getRouteObject()->getOption('_no_big_pipe')) {

--- a/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks1.php
+++ b/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks1.php
@@ -13,7 +13,7 @@ class HookconvertrectorHooks1
      * Implements hook_theme_suggestions_HOOK_alter().
      */
     #[Hook('theme_suggestions_form_element_alter')]
-    public function themeSuggestionsFormElementAlter(&$suggestions, $variables)
+    public static function themeSuggestionsFormElementAlter(&$suggestions, $variables)
     {
         $red = 'red';
         $method = [
@@ -32,7 +32,7 @@ class HookconvertrectorHooks1
      * Implements hook_page_attachments_alter().
      */
     #[Hook('page_attachments_alter')]
-    public function pageAttachmentsAlter(array &$page)
+    public static function pageAttachmentsAlter(array &$page)
     {
         // Routes that don't use BigPipe also don't need no-JS detection.
         if (\Drupal::routeMatch()->getRouteObject()->getOption('_no_big_pipe')) {

--- a/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
+++ b/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
@@ -125,4 +125,206 @@ class HookConvertRectorTest extends TestCase
         $exprStmt = $result->stmts[0];
         $this->assertInstanceOf(Node\Expr\MethodCall::class, $exprStmt->expr);
     }
+
+    private function createMethod(string $code): Node\Stmt\ClassMethod
+    {
+        $fn = $this->parseFunction($code);
+        $method = new \ReflectionMethod($this->rector, 'createMethodFromFunction');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->rector, $fn);
+    }
+
+    public function testMethodWithoutThisIsDeclaredStatic(): void
+    {
+        $method = $this->createMethod(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_cancel().
+ */
+function mymodule_user_cancel($edit, $account, $method) {
+    $account->block();
+}
+CODE);
+
+        $this->assertTrue($method->isStatic(), 'A method that never uses $this should be static.');
+    }
+
+    public function testTranslationCallMakesMethodInstanceAndFlagsTrait(): void
+    {
+        $method = $this->createMethod(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_cancel().
+ */
+function mymodule_user_cancel($edit, $account, $method) {
+    $label = t('Cancelled');
+}
+CODE);
+
+        // t() became $this->t(), so the method must stay an instance method.
+        $this->assertFalse($method->isStatic(), 'A method using $this->t() must not be static.');
+
+        $finder = new \PhpParser\NodeFinder();
+        $thisT = $finder->findFirst(
+            $method->stmts ?? [],
+            fn (Node $n) => $n instanceof Node\Expr\MethodCall
+                && $n->var instanceof Node\Expr\Variable
+                && $n->var->name === 'this'
+                && $n->name instanceof Node\Identifier
+                && $n->name->toString() === 't'
+        );
+        $this->assertNotNull($thisT, 'Expected t() to be rewritten to $this->t().');
+
+        $ref = new \ReflectionProperty($this->rector, 'needsTranslationTrait');
+        $ref->setAccessible(true);
+        $this->assertTrue($ref->getValue($this->rector), 'StringTranslationTrait should be flagged for the class.');
+    }
+
+    public function testFullyQualifiedTranslationCallIsRewritten(): void
+    {
+        $method = $this->createMethod(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_cancel().
+ */
+function mymodule_user_cancel($edit, $account, $method) {
+    $label = \t('Cancelled');
+}
+CODE);
+
+        $this->assertFalse($method->isStatic(), '\t() must be rewritten to $this->t() and keep the method instance.');
+
+        $finder = new \PhpParser\NodeFinder();
+        $funcCall = $finder->findFirst(
+            $method->stmts ?? [],
+            fn (Node $n) => $n instanceof Node\Expr\FuncCall
+        );
+        $this->assertNull($funcCall, 'No bare t()/\t() FuncCall should survive the rewrite.');
+    }
+
+    public function testMethodWithoutTranslationDoesNotFlagTrait(): void
+    {
+        $this->createMethod(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_cancel().
+ */
+function mymodule_user_cancel($edit, $account, $method) {
+    $account->block();
+}
+CODE);
+
+        $ref = new \ReflectionProperty($this->rector, 'needsTranslationTrait');
+        $ref->setAccessible(true);
+        $this->assertFalse($ref->getValue($this->rector), 'A hook without t() must not flag StringTranslationTrait.');
+    }
+
+    public function testTranslationRewritePreservesArgumentsAcrossMultipleCalls(): void
+    {
+        $method = $this->createMethod(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_cancel().
+ */
+function mymodule_user_cancel($edit, $account, $method) {
+    $a = t('One', ['@x' => 1]);
+    $b = t('Two');
+}
+CODE);
+
+        $finder = new \PhpParser\NodeFinder();
+        $thisCalls = $finder->find(
+            $method->stmts ?? [],
+            fn (Node $n) => $n instanceof Node\Expr\MethodCall
+                && $n->var instanceof Node\Expr\Variable
+                && $n->var->name === 'this'
+                && $n->name instanceof Node\Identifier
+                && $n->name->toString() === 't'
+        );
+        $this->assertCount(2, $thisCalls, 'Both t() calls should be rewritten to $this->t().');
+
+        // The first call must keep both arguments (text + placeholders array).
+        $this->assertCount(2, $thisCalls[0]->args, 'Arguments must be preserved through the rewrite.');
+        $firstArg = $thisCalls[0]->args[0]->value;
+        $this->assertInstanceOf(Node\Scalar\String_::class, $firstArg);
+        $this->assertSame('One', $firstArg->value);
+    }
+
+    /**
+     * Builds a real printer without the full Rector DI chain.
+     *
+     * BetterStandardPrinter::__construct() runs the nikic parent constructor
+     * (which sets up printing state), so prettyPrintFile() works. Its
+     * ExprAnalyzer dependency is only consulted while printing arrays, so it is
+     * safe to stub here as long as the asserted method bodies contain none.
+     */
+    private function realPrinter(): BetterStandardPrinter
+    {
+        // Indent parameters are normally seeded by the Rector container; set
+        // them so the standalone printer can lay out statements.
+        \Rector\Configuration\Parameter\SimpleParameterProvider::setParameter(\Rector\Configuration\Option::INDENT_CHAR, ' ');
+        \Rector\Configuration\Parameter\SimpleParameterProvider::setParameter(\Rector\Configuration\Option::INDENT_SIZE, 4);
+
+        $exprAnalyzer = (new \ReflectionClass(\Rector\NodeAnalyzer\ExprAnalyzer::class))->newInstanceWithoutConstructor();
+
+        return new BetterStandardPrinter($exprAnalyzer, new \Rector\Util\Reflection\PrivatesAccessor());
+    }
+
+    public function testGeneratedHookClassFileIsPrintedCorrectly(): void
+    {
+        $rector = new HookConvertRector($this->realPrinter());
+        // Prevent the destructor from writing the generated file to disk.
+        $isDryRun = new \ReflectionProperty($rector, 'isDryRun');
+        $isDryRun->setAccessible(true);
+        $isDryRun->setValue($rector, true);
+
+        $module = new \ReflectionProperty($rector, 'module');
+        $module->setAccessible(true);
+        $module->setValue($rector, 'mymodule');
+
+        $hookClass = new \ReflectionProperty($rector, 'hookClass');
+        $hookClass->setAccessible(true);
+        $class = new Class_(new Identifier('MymoduleHooks'));
+        $hookClass->setValue($rector, $class);
+
+        $create = new \ReflectionMethod($rector, 'createMethodFromFunction');
+        $create->setAccessible(true);
+
+        // One hook that translates (instance + $this->t()), one that does not
+        // (static). Bodies are array-free so the stubbed ExprAnalyzer is unused.
+        $class->stmts[] = $create->invoke($rector, $this->parseFunction(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_cancel().
+ */
+function mymodule_user_cancel($edit, $account, $method) {
+    $label = t('Cancelled');
+}
+CODE));
+        $class->stmts[] = $create->invoke($rector, $this->parseFunction(<<<'CODE'
+<?php
+/**
+ * Implements hook_user_login().
+ */
+function mymodule_user_login($account) {
+    $account->block();
+}
+CODE));
+
+        $build = new \ReflectionMethod($rector, 'buildHookClassStmts');
+        $build->setAccessible(true);
+        $output = $this->realPrinter()->prettyPrintFile($build->invoke($rector));
+
+        // Imports.
+        $this->assertStringContainsString('use Drupal\Core\Hook\Attribute\Hook;', $output);
+        $this->assertStringContainsString('use Drupal\Core\StringTranslation\StringTranslationTrait;', $output);
+        // Trait used inside the class body.
+        $this->assertMatchesRegularExpression('/class MymoduleHooks\s*\{\s*use StringTranslationTrait;/', $output);
+        // Translating hook stays an instance method and uses $this->t().
+        $this->assertStringContainsString('public function userCancel(', $output);
+        $this->assertStringContainsString('$this->t(\'Cancelled\')', $output);
+        // Non-translating hook is static.
+        $this->assertStringContainsString('public static function userLogin(', $output);
+    }
 }

--- a/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
+++ b/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
@@ -171,7 +171,7 @@ CODE);
             fn (Node $n) => $n instanceof Node\Expr\MethodCall
                 && $n->var instanceof Node\Expr\Variable
                 && $n->var->name === 'this'
-                && $n->name instanceof Node\Identifier
+                && $n->name instanceof Identifier
                 && $n->name->toString() === 't'
         );
         $this->assertNotNull($thisT, 'Expected t() to be rewritten to $this->t().');
@@ -239,7 +239,7 @@ CODE);
             fn (Node $n) => $n instanceof Node\Expr\MethodCall
                 && $n->var instanceof Node\Expr\Variable
                 && $n->var->name === 'this'
-                && $n->name instanceof Node\Identifier
+                && $n->name instanceof Identifier
                 && $n->name->toString() === 't'
         );
         $this->assertCount(2, $thisCalls, 'Both t() calls should be rewritten to $this->t().');


### PR DESCRIPTION
## What

Two coordinated improvements to `HookConvertRector` so the OOP hook classes it generates are lint-clean out of the box:

1. **Static detection** — a converted method whose body never references `$this` is now declared `static`. The body comes from a procedural function (which cannot legally reference `$this`), so this is safe by construction. Clears the `canvas.requireStaticMethods` / "method does not use `$this` and should be declared static" check.
2. **`t()` migration** — global `t()` / `\t()` calls inside converted hooks are rewritten to `$this->t()`, and the generated class gains a `use Drupal\Core\StringTranslation\StringTranslationTrait;` import plus a `use StringTranslationTrait;` statement. Clears the `DrupalPractice.Objects.GlobalFunction.GlobalFunction` warning.

## Why these don't conflict

`$this->t()` reintroduces `$this`, which at first glance fights the static rule. The passes are ordered so the `t()` rewrite runs **before** the static check:

- A hook that calls `t()` → becomes `$this->t()` → uses `$this` → correctly stays an **instance** method (the static rule only fires when `$this` is unused).
- A hook with no `t()` / no `$this` → becomes **`static`**.

So they compose rather than conflict.

## Implementation notes

- The class-assembly logic was extracted from `__destruct()` into `buildHookClassStmts()` so the printed output can be asserted in a unit test (behavior-preserving).

## Testing

**Unit** (`HookConvertRectorTest`, 13 tests):
- static applied when no `$this`
- `t()` and `\t()` rewritten; method stays instance; trait flagged
- negative case (no `t()` → no trait)
- multiple `t()` calls + argument preservation
- full generated-file printing asserted (imports, `use StringTranslationTrait;` placement, `static` vs instance methods)

**Live test** against real contrib (Drupal 11):
- `canvas/themes/canvas_stark` (static path): all 9 hook methods that previously tripped `canvas.requireStaticMethods` are now `static`.
- `maxlength` (t() path): `StringTranslationTrait` added; `t()`-using `help()` stays instance; all `t()` (incl. inside arrays/ternaries/nested args) rewritten to `$this->t()`.
- Verified with the **actual** tools: Canvas's `RequireStaticMethodsRule` (phpstan) and `DrupalPractice.Objects.GlobalFunction` (phpcs) both report **0 violations** on the generated classes; each was confirmed to fire against a synthetic bad fixture.

## Known limitation

A `t()` call inside a hook function that lacks an `Implements hook_...` docblock is (correctly) not converted, so its `t()` stays procedural — `HookConvertRector` only converts recognized hook implementations.