### PR TITLE
feat(11.3): cover remaining template_preprocess_*() deprecations (#3504125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,17 @@ release-by-release.
 
 ### Added
 
+- **`template_preprocess_*()` family (Drupal 11.3, [#3504125](https://www.drupal.org/node/3504125))** —
+  extended `FunctionToServiceRector` coverage with 14 more `template_preprocess_*()`
+  functions deprecated in drupal:11.3.0 and removed in drupal:12.0.0. Each is
+  rewritten (BC-wrapped via `DeprecationHelper`) to the equivalent `*Preprocess`
+  service method: `table`, `tablesort_indicator`, `item_list`, `region`,
+  `maintenance_page`, `maintenance_task_list`, `install_page` → `ThemePreprocess`;
+  `image` → `ImagePreprocess`; `breadcrumb` → `BreadcrumbPreprocess`;
+  `pager` → `PagerPreprocess`; `field`, `field_multiple_value_form` →
+  `FieldPreprocess`; `menu_local_task`, `menu_local_action` → `MenuPreprocess`.
+  (`template_preprocess_authorize_report()` has no replacement and is
+  intentionally excluded.)
 - **`RemoveDrupalToStringTraitRector`** — removes
   `use Drupal\Component\Utility\ToStringTrait;` from a class body and inserts
   an inline `public function __toString(): string { return (string)

--- a/config/drupal-11/drupal-11.3-deprecations.php
+++ b/config/drupal-11/drupal-11.3-deprecations.php
@@ -69,10 +69,26 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     // https://www.drupal.org/node/3504125
-    // template_preprocess_layout() deprecated in drupal:11.3.0, removed in drupal:12.0.0.
-    // Replaced by \Drupal\layout_discovery\Hook\LayoutDiscoveryThemeHooks::preprocessLayout().
+    // The template_preprocess_*() functions deprecated in drupal:11.3.0,
+    // removed in drupal:12.0.0. Initial template_preprocess functions are now
+    // registered directly in hook_theme(); each is replaced by the equivalent
+    // *Preprocess service method.
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class, [
         new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_layout', 'Drupal\layout_discovery\Hook\LayoutDiscoveryThemeHooks', 'preprocessLayout', true),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_table', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessTable'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_tablesort_indicator', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessTablesortIndicator'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_item_list', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessItemList'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_region', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessRegion'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_maintenance_page', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessMaintenancePage'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_maintenance_task_list', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessMaintenanceTaskList'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_install_page', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessInstallPage'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_image', 'Drupal\Core\Theme\ImagePreprocess', 'preprocessImage'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_breadcrumb', 'Drupal\Core\Breadcrumb\BreadcrumbPreprocess', 'preprocessBreadcrumb'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_pager', 'Drupal\Core\Pager\PagerPreprocess', 'preprocessPager'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_field', 'Drupal\Core\Field\FieldPreprocess', 'preprocessField'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_field_multiple_value_form', 'Drupal\Core\Field\FieldPreprocess', 'preprocessFieldMultipleValueForm'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_menu_local_task', 'Drupal\Core\Menu\MenuPreprocess', 'preprocessMenuLocalTask'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_menu_local_action', 'Drupal\Core\Menu\MenuPreprocess', 'preprocessMenuLocalAction'),
     ]);
 
     // https://www.drupal.org/node/1685492

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/config/configured_rule.php
@@ -36,6 +36,21 @@ return static function (RectorConfig $rectorConfig): void {
         new FunctionToServiceConfiguration('11.3.0', 'node_mass_update', 'Drupal\node\NodeBulkUpdate', 'process', true),
         // https://www.drupal.org/node/3571382 (Drupal 11.3)
         new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_layout', 'Drupal\layout_discovery\Hook\LayoutDiscoveryThemeHooks', 'preprocessLayout', true),
+        // https://www.drupal.org/node/3504125 (Drupal 11.3)
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_table', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessTable'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_tablesort_indicator', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessTablesortIndicator'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_item_list', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessItemList'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_region', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessRegion'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_maintenance_page', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessMaintenancePage'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_maintenance_task_list', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessMaintenanceTaskList'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_install_page', 'Drupal\Core\Theme\ThemePreprocess', 'preprocessInstallPage'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_image', 'Drupal\Core\Theme\ImagePreprocess', 'preprocessImage'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_breadcrumb', 'Drupal\Core\Breadcrumb\BreadcrumbPreprocess', 'preprocessBreadcrumb'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_pager', 'Drupal\Core\Pager\PagerPreprocess', 'preprocessPager'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_field', 'Drupal\Core\Field\FieldPreprocess', 'preprocessField'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_field_multiple_value_form', 'Drupal\Core\Field\FieldPreprocess', 'preprocessFieldMultipleValueForm'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_menu_local_task', 'Drupal\Core\Menu\MenuPreprocess', 'preprocessMenuLocalTask'),
+        new FunctionToServiceConfiguration('11.3.0', 'template_preprocess_menu_local_action', 'Drupal\Core\Menu\MenuPreprocess', 'preprocessMenuLocalAction'),
         // https://www.drupal.org/node/1685492 (Drupal 11.3)
         new FunctionToServiceConfiguration('11.3.0', 'twig_render_template', 'Drupal\Core\Template\TwigThemeEngine', 'renderTemplate'),
         // https://www.drupal.org/node/3568088 (Drupal 11.4)

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_3504125.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_3504125.php.inc
@@ -1,0 +1,39 @@
+<?php
+
+function example(&$variables) {
+    template_preprocess_table($variables);
+    template_preprocess_tablesort_indicator($variables);
+    template_preprocess_item_list($variables);
+    template_preprocess_region($variables);
+    template_preprocess_maintenance_page($variables);
+    template_preprocess_maintenance_task_list($variables);
+    template_preprocess_install_page($variables);
+    template_preprocess_image($variables);
+    template_preprocess_breadcrumb($variables);
+    template_preprocess_pager($variables);
+    template_preprocess_field($variables);
+    template_preprocess_field_multiple_value_form($variables);
+    template_preprocess_menu_local_task($variables);
+    template_preprocess_menu_local_action($variables);
+}
+?>
+-----
+<?php
+
+function example(&$variables) {
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessTable($variables), fn() => template_preprocess_table($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessTablesortIndicator($variables), fn() => template_preprocess_tablesort_indicator($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessItemList($variables), fn() => template_preprocess_item_list($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessRegion($variables), fn() => template_preprocess_region($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessMaintenancePage($variables), fn() => template_preprocess_maintenance_page($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessMaintenanceTaskList($variables), fn() => template_preprocess_maintenance_task_list($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessInstallPage($variables), fn() => template_preprocess_install_page($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ImagePreprocess')->preprocessImage($variables), fn() => template_preprocess_image($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Breadcrumb\BreadcrumbPreprocess')->preprocessBreadcrumb($variables), fn() => template_preprocess_breadcrumb($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Pager\PagerPreprocess')->preprocessPager($variables), fn() => template_preprocess_pager($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Field\FieldPreprocess')->preprocessField($variables), fn() => template_preprocess_field($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Field\FieldPreprocess')->preprocessFieldMultipleValueForm($variables), fn() => template_preprocess_field_multiple_value_form($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Menu\MenuPreprocess')->preprocessMenuLocalTask($variables), fn() => template_preprocess_menu_local_task($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Menu\MenuPreprocess')->preprocessMenuLocalAction($variables), fn() => template_preprocess_menu_local_action($variables));
+}
+?>


### PR DESCRIPTION
## What

Completes `FunctionToServiceRector` coverage of the `template_preprocess_*()` family deprecated in **drupal:11.3.0** (removed in 12.0.0), change record [#3504125](https://www.drupal.org/node/3504125).

Previously only the 11.2 members (`time`, `datetime_form`, `datetime_wrapper`, `links`, `container`, `html`, `page`) plus `layout` (11.3) were configured. This adds the **14 remaining** 11.3 functions, each mapped to its `*Preprocess` service method:

| Function(s) | Service |
|---|---|
| `table`, `tablesort_indicator`, `item_list`, `region`, `maintenance_page`, `maintenance_task_list`, `install_page` | `Drupal\Core\Theme\ThemePreprocess` |
| `image` | `Drupal\Core\Theme\ImagePreprocess` |
| `breadcrumb` | `Drupal\Core\Breadcrumb\BreadcrumbPreprocess` |
| `pager` | `Drupal\Core\Pager\PagerPreprocess` |
| `field`, `field_multiple_value_form` | `Drupal\Core\Field\FieldPreprocess` |
| `menu_local_task`, `menu_local_action` | `Drupal\Core\Menu\MenuPreprocess` |

## Why

Running against contrib (e.g. `jsonapi_extras`, which calls `template_preprocess_table()` from a custom preprocess function) surfaced this gap — the function is deprecated but had no rector coverage.

## Notes

- No new rector code — these are config entries on the existing generic `FunctionToServiceRector`. Mappings, deprecation version, and CR were read directly from core's deprecated function bodies (`core/includes/theme.inc`).
- Calls are **BC-wrapped via `DeprecationHelper::backwardsCompatibleCall()`** and version-gated to `11.3.0`, identical to the existing `template_preprocess_*` entries, so generated code is safe on older minors.
- `template_preprocess_authorize_report()` is **intentionally excluded** — its deprecation states "There is no replacement" (manage the code via composer), so it is not a function-to-service candidate.

## Testing

- New fixture `template_preprocess_3504125.php.inc` exercises all 14 functions (before → BC-wrapped after).
- `FunctionToServiceRectorTest`: **31/31 pass**.
- `composer check-style` and `composer phpstan`: clean.
