### PR TITLE
fix: rector php not packaged and old rectors still included

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,5 +12,4 @@
 /fixtures               export-ignore
 /scripts                export-ignore
 /docs                   export-ignore
-/rector.php             export-ignore
 /README-automated-testing.md export-ignore

--- a/rector.php
+++ b/rector.php
@@ -18,8 +18,6 @@ return static function (RectorConfig $rectorConfig): void {
     //   new possible option with ComposerTriggeredSet
     //   https://github.com/rectorphp/rector-src/blob/b5a5739b7d7dde621053adff113449860ed5331f/src/Set/ValueObject/ComposerTriggeredSet.php
     $rectorConfig->sets([
-        Drupal8SetList::DRUPAL_8,
-        Drupal9SetList::DRUPAL_9,
         Drupal10SetList::DRUPAL_10,
         Drupal11SetList::DRUPAL_11,
     ]);


### PR DESCRIPTION
## Description
While trying some things i notices the default adds old rectors and the actual rector.php is not packages properly. Oops.
