### PR TITLE
docs: prepare CHANGELOG and README for 1.0.0-beta1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ release-by-release.
 
 ## [Unreleased]
 
+## [1.0.0-beta1] — 2026-06-11
+
 ### Added
 
 - **`template_preprocess_*()` family (Drupal 11.3, [#3504125](https://www.drupal.org/node/3504125))** —
@@ -619,6 +621,7 @@ release-by-release.
   This unblocks running the full, bundled rule set — including the D10-era
   deprecations that live in the Drupal 11 set — against Drupal 10 sites.
 
+[1.0.0-beta1]: https://github.com/palantirnet/drupal-rector/releases/tag/1.0.0-beta1
 ## [1.0.0-alpha1] — 2026-06-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ For contribution suggestions, please see the later section of this document.
 $ composer require --dev palantirnet/drupal-rector
 ```
 
-> **Trying the 1.0 pre-release?** The 1.0.x line is currently published as an alpha. Until a stable `1.0.0` is tagged, the command above resolves to the latest stable release — request the pre-release explicitly instead:
+> **Trying the 1.0 pre-release?** The 1.0.x line is currently published as a beta. Until a stable `1.0.0` is tagged, the command above resolves to the latest stable release — request the pre-release explicitly instead:
 >
 > ```bash
-> $ composer require --dev "palantirnet/drupal-rector:^1.0@alpha"
+> $ composer require --dev "palantirnet/drupal-rector:^1.0@beta"
 > ```
 
 ### Create a configuration file in your project


### PR DESCRIPTION
- CHANGELOG: stamp [1.0.0-beta1] heading with release date, add tag link reference, and open a fresh [Unreleased] section
- README: switch the 1.0 pre-release install hint from @alpha to @beta

## Description
Explain the technical implementation of the work done.


## To Test
- Add steps to test this feature

## Drupal.org issue
Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.
