### PR TITLE
feat: add ReplaceUserOneTimeAuthFunctionsRector for #3581056

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ release-by-release.
 
 ## [Unreleased]
 
+### Added
+
+- **`ReplaceUserOneTimeAuthFunctionsRector` (Drupal 11.4, [#3581056](https://www.drupal.org/node/3581056))** —
+  replaces the deprecated user one-time authentication functions
+  `user_pass_rehash()`, `user_pass_reset_url()` and `user_cancel_url()` (deprecated
+  in drupal:11.4.0, removed in drupal:13.0.0) with the new
+  `\Drupal\user\OneTimeAuthentication` service methods `generateHmac()`,
+  `generateOneTimeLoginUrl()` and `generateCancelConfirmUrl()`. BC-wrapped via
+  `DeprecationHelper` because the service does not exist on Drupal < 11.4. The two
+  URL methods return a `Url` object, so the rewrite chains `->toString()`.
+  `user_mail_tokens()` (deprecated in the same issue) is intentionally not handled —
+  it is used as a string callback and its replacement needs a `BubbleableMetadata`
+  argument that cannot be synthesised.
+
 ## [1.0.0-beta1] — 2026-06-11
 
 ### Added

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -33,6 +33,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNonBoolAccessRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceRecipeRunnerInstallModuleRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceSessionManagerDeleteRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceSystemPerformanceGzipKeyRector;
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceUserOneTimeAuthFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceViewsProceduralFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\SystemRegionFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\SystemSortThemesRector;
@@ -583,6 +584,24 @@ return static function (RectorConfig $rectorConfig): void {
     // route discovery moved to the new YamlRouteDiscovery service; the 6-arg
     // constructor form is rewritten to the new 4-arg form.
     $rectorConfig->ruleWithConfiguration(RemoveRouteBuilderDeprecatedArgsRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+
+    // https://www.drupal.org/node/3581056
+    // https://www.drupal.org/node/3581062 (change record)
+    // user_pass_rehash(), user_pass_reset_url() and user_cancel_url()
+    // deprecated in drupal:11.4.0, removed in drupal:13.0.0. Replaced by the
+    // new \Drupal\user\OneTimeAuthentication service (generateHmac(),
+    // generateOneTimeLoginUrl(), generateCancelConfirmUrl()). BC-wrapped
+    // because the service does not exist on Drupal < 11.4. The two URL methods
+    // return a Url object, so the rewrite chains ->toString().
+    // TODO PHPSTAN_MESSAGES ReplaceUserOneTimeAuthFunctionsRector:
+    //   Not yet captured. The functions are @deprecated PHP symbols (so PHPStan
+    //   will emit "Call to deprecated function user_pass_rehash()" etc.), but the
+    //   deprecation only landed in core commit a38f1d17 (committed 2026-06-08) and
+    //   is not in the installed 11.4-dev test core yet. Capture the three messages
+    //   once the test core is updated past that commit.
+    $rectorConfig->ruleWithConfiguration(ReplaceUserOneTimeAuthFunctionsRector::class, [
         new DrupalIntroducedVersionConfiguration('11.4.0'),
     ]);
 };

--- a/docs/implemented-digests.yml
+++ b/docs/implemented-digests.yml
@@ -25,6 +25,26 @@ digests:
     class: RenameHookRankingRector
     digest_file: rename-hook-ranking-to-hook-node-search-ranking-1019966.php
     note: 'Implemented in open PR #352 (not yet merged to main).'
+  '1452100':
+    status: skip
+    phase: '1a'
+    digest_file: replace-drupal-static-reset-file-get-file-references-keys-1452100.php
+    note: >-
+      Won''t implement. The authoritative CR (node/3573884, cited by
+      file.module:460/463 — the digest''s @see node/1452100 is the issue, not
+      the CR) deprecates only file_get_file_references() and
+      file_field_find_file_reference_column(); it says nothing about
+      drupal_static_reset() or a file_references cache-tag migration. The
+      digest invented the drupal_static_reset(''file_get_file_references'') ->
+      cache.memory invalidateTags([''file_references'']) mapping. That rewrite
+      is incorrect: (1) drupal_static_reset() is not deprecated and the old
+      function still uses drupal_static() internally through D12, so the reset
+      still works; (2) the file_references tag is a cacheability tag on the new
+      FileReferenceResolver''s memory-cache entries — a different store, so
+      invalidating it is not equivalent to resetting the old static (silent
+      divergence). The genuine migration (file_get_file_references ->
+      FileReferenceResolver::getReferences(), array -> Generator) is a manual
+      refactor the digest itself declines to automate.
   '1685492':
     status: config-only
     phase: '1a'
@@ -82,6 +102,28 @@ digests:
     phase: '1a'
     class: LocaleCompareIncToServiceRector
     digest_file: replace-deprecated-locale-compare-inc-functions-with-3037031.php
+  '3037156':
+    status: skip
+    phase: '1a'
+    digest_file: replace-locale-translation-update-file-history-and-locale-3037156.php
+    note: >-
+      Won''t implement — not worth the maintenance surface for ~zero real-world
+      benefit. The three deprecated locale history functions
+      (locale_translation_update_file_history, locale_translation_file_history_delete,
+      locale_translation_get_file_history) have effectively no contrib usage: a
+      full search (api.tresbien.tech) found exactly ONE hit — locale_deploy''s
+      LocaleDeployCommands.php calls locale_translation_file_history_delete()
+      with ZERO arguments, which a rector cannot rewrite anyway (the replacement
+      CurrentImportStorage::delete() requires $projects, and the new service +
+      CurrentImport value object are @internal). get_file_history() has no
+      mechanical replacement at all (its own deprecation notice says so), and
+      update_file_history() has no contrib callers. So an implemented rector
+      would transform nothing in practice while adding a BC-wrapped custom class,
+      test suite, and config entry to maintain. A prior implementation passed all
+      gates + rector-qa but was reverted on this reasoning. Note: CR node/3037162
+      is also stale (says CurrentImportStateStorage / update()); merged core uses
+      CurrentImportStorage / save() — another reason to leave this to manual
+      migration if a site ever actually needs it.
   '3038908':
     status: implemented
     phase: '1b'
@@ -622,6 +664,18 @@ digests:
     status: config-only
     phase: '1a'
     digest_file: replace-locale-translate-get-interface-translation-files-3577671.php
+  '3581056':
+    status: implemented
+    phase: '1b'
+    class: ReplaceUserOneTimeAuthFunctionsRector
+    digest_file: replace-user-pass-rehash-user-pass-reset-url-user-cancel-3581056.php
+    note: >-
+      BC-wrapped. Three user.module functions (user_pass_rehash,
+      user_pass_reset_url, user_cancel_url) → \Drupal\user\OneTimeAuthentication
+      service (generateHmac / generateOneTimeLoginUrl / generateCancelConfirmUrl).
+      The two URL methods return a Url object, so the rewrite chains ->toString().
+      user_mail_tokens() intentionally not handled (string-callback usage; needs a
+      BubbleableMetadata arg that cannot be synthesised).
   '3581109':
     status: config-only
     phase: '?'

--- a/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces deprecated user one-time authentication functions with the OneTimeAuthentication service.
+ *
+ * Handles user_pass_rehash(), user_pass_reset_url(), and user_cancel_url().
+ * The two URL-generating functions returned a string, while the new service
+ * methods return a \Drupal\Core\Url object, so the rewrite chains ->toString().
+ *
+ * Deprecated in drupal:11.4.0 and removed in drupal:13.0.0.
+ *
+ * @see https://www.drupal.org/node/3581056
+ * @see https://www.drupal.org/node/3581062
+ */
+class ReplaceUserOneTimeAuthFunctionsRector extends AbstractDrupalCoreRector
+{
+    private const SERVICE_CLASS = 'Drupal\user\OneTimeAuthentication';
+
+    /** @var DrupalIntroducedVersionConfiguration[] */
+    protected array $configuration;
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof FuncCall);
+
+        if (!$node->name instanceof Name) {
+            return null;
+        }
+
+        return match ($node->name->toString()) {
+            'user_pass_rehash' => $this->buildServiceCall('generateHmac', $node->args),
+            'user_pass_reset_url' => $this->wrapToString($this->buildServiceCall('generateOneTimeLoginUrl', $node->args)),
+            'user_cancel_url' => $this->wrapToString($this->buildServiceCall('generateCancelConfirmUrl', $node->args)),
+            default => null,
+        };
+    }
+
+    /** @param Arg[] $args */
+    private function buildServiceCall(string $method, array $args): MethodCall
+    {
+        $serviceCall = new StaticCall(
+            new FullyQualified('Drupal'),
+            'service',
+            [new Arg(new ClassConstFetch(new FullyQualified(self::SERVICE_CLASS), 'class'))]
+        );
+
+        return new MethodCall($serviceCall, $method, $args);
+    }
+
+    private function wrapToString(MethodCall $methodCall): MethodCall
+    {
+        return new MethodCall($methodCall, 'toString', []);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace deprecated user one-time authentication functions with the \Drupal\user\OneTimeAuthentication service.',
+            [
+                new ConfiguredCodeSample(
+                    'user_pass_rehash($account, $timestamp);',
+                    '\Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateHmac($account, $timestamp);',
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+                new ConfiguredCodeSample(
+                    'user_pass_reset_url($account, $options);',
+                    '\Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateOneTimeLoginUrl($account, $options)->toString();',
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+                new ConfiguredCodeSample(
+                    'user_cancel_url($account, $options);',
+                    '\Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateCancelConfirmUrl($account, $options)->toString();',
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+            ]
+        );
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/ReplaceUserOneTimeAuthFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/ReplaceUserOneTimeAuthFunctionsRectorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceUserOneTimeAuthFunctionsRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class ReplaceUserOneTimeAuthFunctionsRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /** @return \Iterator<array<string>> */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /** @return \Iterator<array<string>> */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceUserOneTimeAuthFunctionsRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(ReplaceUserOneTimeAuthFunctionsRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+user_pass_rehash($account, $timestamp);
+user_pass_reset_url($account, $options);
+user_cancel_url($account, $options);
+?>
+-----
+<?php
+
+user_pass_rehash($account, $timestamp);
+user_pass_reset_url($account, $options);
+user_cancel_url($account, $options);
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture/basic.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+user_pass_rehash($account, $timestamp);
+user_pass_reset_url($account, $options);
+user_cancel_url($account, $options);
+?>
+-----
+<?php
+
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateHmac($account, $timestamp), fn() => user_pass_rehash($account, $timestamp));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateOneTimeLoginUrl($account, $options)->toString(), fn() => user_pass_reset_url($account, $options));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateCancelConfirmUrl($account, $options)->toString(), fn() => user_cancel_url($account, $options));
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture/nested_hash_equals.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture/nested_hash_equals.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+// Real-world contrib shape (e.g. tfa, change_pwd_page, simple_pass_reset):
+// user_pass_rehash() nested as an argument inside hash_equals(). The inner
+// call must be rewritten in place and BC-wrapped, leaving hash_equals() intact.
+if (!hash_equals($hash, user_pass_rehash($account, $timestamp))) {
+    throw new \Exception('Invalid');
+}
+?>
+-----
+<?php
+
+// Real-world contrib shape (e.g. tfa, change_pwd_page, simple_pass_reset):
+// user_pass_rehash() nested as an argument inside hash_equals(). The inner
+// call must be rewritten in place and BC-wrapped, leaving hash_equals() intact.
+if (!hash_equals($hash, \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateHmac($account, $timestamp), fn() => user_pass_rehash($account, $timestamp)))) {
+    throw new \Exception('Invalid');
+}
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,15 @@
+<?php
+
+// An unrelated global function with one of the same argument shapes must be
+// left untouched — only the three deprecated user functions are rewritten.
+user_pass_rehash_custom($account, $timestamp);
+some_other_module_pass_reset_url($account, $options);
+?>
+-----
+<?php
+
+// An unrelated global function with one of the same argument shapes must be
+// left untouched — only the three deprecated user functions are rewritten.
+user_pass_rehash_custom($account, $timestamp);
+some_other_module_pass_reset_url($account, $options);
+?>


### PR DESCRIPTION
## Summary

Adds `ReplaceUserOneTimeAuthFunctionsRector` covering Drupal core issue [#3581056](https://www.drupal.org/node/3581056) (change record [#3581062](https://www.drupal.org/node/3581062)).

Three `user.module` functions were deprecated in **drupal:11.4.0** and are removed in **drupal:13.0.0**, replaced by the new `\Drupal\user\OneTimeAuthentication` service:

| Deprecated function | Replacement |
|---|---|
| `user_pass_rehash($account, $timestamp)` | `\Drupal::service(\Drupal\user\OneTimeAuthentication::class)->generateHmac($account, $timestamp)` |
| `user_pass_reset_url($account, $options)` | `…->generateOneTimeLoginUrl($account, $options)->toString()` |
| `user_cancel_url($account, $options)` | `…->generateCancelConfirmUrl($account, $options)->toString()` |

The two URL methods return a `\Drupal\Core\Url` object (the old functions returned strings), so the rewrite chains `->toString()`.

### Why BC-wrapped

The rector extends `AbstractDrupalCoreRector` and wraps each rewrite in `DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', …)`. The `OneTimeAuthentication` service does not exist on Drupal < 11.4, so an unconditional rewrite would fatal on older cores.

### Not handled

`user_mail_tokens()` (deprecated in the same issue) is intentionally excluded — it is used as a string callback (`'callback' => 'user_mail_tokens'`) rather than called directly, and its replacement needs a `BubbleableMetadata` argument that cannot be synthesised.

## Verification against core

The deprecation landed in core commit `a38f1d17` (committed 2026-06-08). I fetched that commit directly and confirmed the method names, signatures (`generateHmac`/`generateOneTimeLoginUrl`/`generateCancelConfirmUrl`), the 11.4.0→13.0.0 window, and that the old functions delegate to the service.

## Live test against real contrib

Ran the rector against 5 D11-compatible contrib modules — all transformed correctly, no false positives:

| Module | Function(s) exercised |
|---|---|
| tfa | `user_pass_rehash` (nested in `hash_equals`) |
| user_registrationpassword | `user_pass_rehash` (in `.module`) |
| change_pwd_page | `user_pass_rehash` (nested in `hash_equals`) |
| rest_password | `user_pass_reset_url` + `user_cancel_url` (both `->toString()`) |
| simple_pass_reset | `user_pass_rehash` (nested in `hash_equals`) |

## Quality gates

- `composer fix-style` — clean
- `composer phpstan` — no errors
- PHPUnit — 3/3 (above-version transform, below-version no-op, unrelated-function no-change)
- rector-qa — all 5 passes green (type-guard SAFE, fixtures PASS, BC PASS, @see PASS, registration PASS)

## Notes

A `TODO PHPSTAN_MESSAGES` block is recorded in the config: the test core (11.4-dev) predates commit `a38f1d17`, so PHPStan does not yet emit the deprecation for these symbols. The three messages should be captured once the test core advances past that commit.