### PR TITLE
feat: add ReplaceLocaleBatchProceduralFunctionsRector for #3581303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ release-by-release.
 
 ## [Unreleased]
 
+### Added
+
+- **Locale batch procedural functions (Drupal 11.4, [#3581303](https://www.drupal.org/node/3581303))** —
+  added `ReplaceLocaleBatchProceduralFunctionsRector`, which rewrites the 17
+  deprecated batch callbacks from `locale.batch.inc`, `locale.bulk.inc`, and
+  `locale.compare.inc` (deprecated in drupal:11.4.0, removed in drupal:13.0.0)
+  to the equivalent methods on the `LocaleFetch`, `LocaleImportBatch`,
+  `LocaleConfigBatch`, and `LocaleProjectChecker` services. BC-wrapped via
+  `DeprecationHelper` because the new services do not exist on Drupal < 11.4.
+  `locale_config_batch_build()` and `locale_translation_batch_status_build()`
+  are intentionally left for manual migration (changed signature/behavior).
+
 ## [1.0.0-beta1] — 2026-06-11
 
 ### Added

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -28,6 +28,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\ReplaceEntityReferenceRecursiveLimi
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceExpectDeprecationRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceHideShowWithPrintedRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceItemAttributesWithAttributesRector;
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceLocaleBatchProceduralFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceLocaleTranslationPathConfigRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNonBoolAccessRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceRecipeRunnerInstallModuleRector;
@@ -457,6 +458,21 @@ return static function (RectorConfig $rectorConfig): void {
     // and locale_translation_check_projects_local() deprecated in drupal:11.4.0, removed in drupal:13.0.0.
     // Replaced by LocaleProjectRepository and LocaleProjectChecker service methods.
     $rectorConfig->ruleWithConfiguration(LocaleCompareIncToServiceRector::class, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+
+    // https://www.drupal.org/node/3581303
+    // https://www.drupal.org/node/3589759 (change record)
+    // The locale batch procedural callbacks in locale.batch.inc, locale.bulk.inc,
+    // and locale.compare.inc deprecated in drupal:11.4.0, removed in drupal:13.0.0.
+    // Replaced by methods on the LocaleFetch, LocaleImportBatch, LocaleConfigBatch,
+    // and LocaleProjectChecker services. BC-wrapped because the LocaleImportBatch
+    // and LocaleConfigBatch services (and the new methods on the existing services)
+    // do not exist on Drupal < 11.4. locale_config_batch_build() and
+    // locale_translation_batch_status_build() are intentionally not rewritten:
+    // their signature/behavior changed and they require manual migration.
+    // PHPStan deprecation messages captured in the rector's PHPSTAN_MESSAGES const.
+    $rectorConfig->ruleWithConfiguration(ReplaceLocaleBatchProceduralFunctionsRector::class, [
         new DrupalIntroducedVersionConfiguration('11.4.0'),
     ]);
 

--- a/docs/implemented-digests.yml
+++ b/docs/implemented-digests.yml
@@ -627,6 +627,12 @@ digests:
     phase: '?'
     digest_file: rename-helpsearch-to-searchhelpsearch-in-search-help-sub-3581109.php
     note: 'HelpSearch→SearchHelpSearch via RenameClassRector in DRUPAL_114_BREAKING config; open PR #349.'
+  '3581303':
+    status: implemented
+    phase: '2'
+    class: ReplaceLocaleBatchProceduralFunctionsRector
+    digest_file: replace-deprecated-locale-batch-procedural-functions-with-3581303.php
+    note: 'BC-wrapped; 17 locale batch callbacks → LocaleFetch/LocaleImportBatch/LocaleConfigBatch/LocaleProjectChecker services. Implemented on feat/locale-batch-procedural-3581303.'
   '3582106':
     status: config-only
     phase: '1a'

--- a/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\AbstractDrupalCoreRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Name\FullyQualified;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces deprecated locale batch procedural functions from locale.batch.inc,
+ * locale.bulk.inc, and locale.compare.inc with equivalent methods on the
+ * LocaleFetch, LocaleImportBatch, LocaleConfigBatch, and LocaleProjectChecker
+ * services.
+ *
+ * Each deprecated function delegates directly to the service method with
+ * identical arguments, so the rewrite is a mechanical 1-to-1 mapping.
+ *
+ * locale_config_batch_build() and locale_translation_batch_status_build() are
+ * intentionally NOT handled: the former changed its argument signature and the
+ * latter changed its behavior (the replacement calls batch_set() immediately
+ * rather than returning the array). Those two require manual migration.
+ *
+ * Deprecated in drupal:11.4.0 and removed in drupal:13.0.0.
+ *
+ * @see https://www.drupal.org/node/3581303
+ * @see https://www.drupal.org/node/3589759 (change record)
+ */
+class ReplaceLocaleBatchProceduralFunctionsRector extends AbstractDrupalCoreRector
+{
+    /**
+     * PHPStan deprecation messages this rector covers (one per function).
+     *
+     * @var string[]
+     */
+    public const PHPSTAN_MESSAGES = [
+        'Call to deprecated function locale_translation_batch_version_check(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleFetch::class)->batchVersionCheck() instead.',
+        'Call to deprecated function locale_translation_batch_status_check(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleFetch::class)->batchStatusCheck() instead.',
+        'Call to deprecated function locale_translation_batch_fetch_download(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleFetch::class)->batchDownload() instead.',
+        'Call to deprecated function locale_translation_batch_fetch_import(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleFetch::class)->batchImport() instead.',
+        'Call to deprecated function locale_translation_batch_fetch_finished(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleFetch::class)->batchFinished() instead.',
+        'Call to deprecated function _locale_translation_batch_status_operations(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleFetch::class)->getStatusOperations() instead.',
+        'Call to deprecated function locale_translate_batch_build(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleImportBatch::class)->buildBatch() instead.',
+        'Call to deprecated function locale_translate_batch_import(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleImportBatch::class)->batchImport() instead.',
+        'Call to deprecated function locale_translate_batch_import_save(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleImportBatch::class)->batchSave() instead.',
+        'Call to deprecated function locale_translate_batch_refresh(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleImportBatch::class)->batchRefresh() instead.',
+        'Call to deprecated function locale_translate_batch_finished(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleImportBatch::class)->batchFinished() instead.',
+        'Call to deprecated function locale_config_batch_update_components(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleConfigBatch::class)->buildBatch() instead.',
+        'Call to deprecated function locale_config_batch_update_default_config_langcodes(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleConfigBatch::class)->batchUpdateDefaultConfigLangcodes() instead.',
+        'Call to deprecated function locale_config_batch_update_config_translations(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleConfigBatch::class)->batchUpdateConfigTranslations() instead.',
+        'Call to deprecated function locale_config_batch_finished(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleConfigBatch::class)->batchFinished() instead.',
+        'Call to deprecated function locale_translation_check_projects_batch(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleProjectChecker::class)->triggerBatch() instead.',
+        'Call to deprecated function locale_translation_batch_status_finished(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::service(LocaleProjectChecker::class)->batchFinished() instead.',
+    ];
+
+    /**
+     * Maps each deprecated function name to [service FQCN, method name].
+     *
+     * @var array<string, array{string, string}>
+     */
+    private const FUNCTION_MAP = [
+        // locale.batch.inc
+        'locale_translation_batch_version_check' => ['Drupal\locale\LocaleFetch', 'batchVersionCheck'],
+        'locale_translation_batch_status_check' => ['Drupal\locale\LocaleFetch', 'batchStatusCheck'],
+        'locale_translation_batch_fetch_download' => ['Drupal\locale\LocaleFetch', 'batchDownload'],
+        'locale_translation_batch_fetch_import' => ['Drupal\locale\LocaleFetch', 'batchImport'],
+        'locale_translation_batch_fetch_finished' => ['Drupal\locale\LocaleFetch', 'batchFinished'],
+        '_locale_translation_batch_status_operations' => ['Drupal\locale\LocaleFetch', 'getStatusOperations'],
+        // locale.bulk.inc
+        'locale_translate_batch_build' => ['Drupal\locale\LocaleImportBatch', 'buildBatch'],
+        'locale_translate_batch_import' => ['Drupal\locale\LocaleImportBatch', 'batchImport'],
+        'locale_translate_batch_import_save' => ['Drupal\locale\LocaleImportBatch', 'batchSave'],
+        'locale_translate_batch_refresh' => ['Drupal\locale\LocaleImportBatch', 'batchRefresh'],
+        'locale_translate_batch_finished' => ['Drupal\locale\LocaleImportBatch', 'batchFinished'],
+        'locale_config_batch_update_components' => ['Drupal\locale\LocaleConfigBatch', 'buildBatch'],
+        'locale_config_batch_update_default_config_langcodes' => ['Drupal\locale\LocaleConfigBatch', 'batchUpdateDefaultConfigLangcodes'],
+        'locale_config_batch_update_config_translations' => ['Drupal\locale\LocaleConfigBatch', 'batchUpdateConfigTranslations'],
+        'locale_config_batch_finished' => ['Drupal\locale\LocaleConfigBatch', 'batchFinished'],
+        // locale.compare.inc
+        'locale_translation_check_projects_batch' => ['Drupal\locale\LocaleProjectChecker', 'triggerBatch'],
+        'locale_translation_batch_status_finished' => ['Drupal\locale\LocaleProjectChecker', 'batchFinished'],
+    ];
+
+    /** @var DrupalIntroducedVersionConfiguration[] */
+    protected array $configuration;
+
+    public function configure(array $configuration): void
+    {
+        foreach ($configuration as $value) {
+            if (!$value instanceof DrupalIntroducedVersionConfiguration) {
+                throw new \InvalidArgumentException(sprintf('Each configuration item must be an instance of "%s"', DrupalIntroducedVersionConfiguration::class));
+            }
+        }
+        parent::configure($configuration);
+    }
+
+    /** @return array<class-string<Node>> */
+    public function getNodeTypes(): array
+    {
+        return [FuncCall::class];
+    }
+
+    protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
+    {
+        assert($node instanceof FuncCall);
+
+        if (!$node->name instanceof Name) {
+            return null;
+        }
+
+        $functionName = $node->name->toString();
+        if (!isset(self::FUNCTION_MAP[$functionName])) {
+            return null;
+        }
+
+        [$serviceClass, $method] = self::FUNCTION_MAP[$functionName];
+
+        $serviceCall = new StaticCall(
+            new FullyQualified('Drupal'),
+            'service',
+            [new Arg(new ClassConstFetch(new FullyQualified($serviceClass), 'class'))]
+        );
+
+        return new MethodCall($serviceCall, $method, $node->args);
+    }
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replace deprecated locale batch procedural functions with LocaleFetch, LocaleImportBatch, LocaleConfigBatch, and LocaleProjectChecker service methods.',
+            [
+                new ConfiguredCodeSample(
+                    'locale_translate_batch_build($files, $options);',
+                    '\Drupal::service(\Drupal\locale\LocaleImportBatch::class)->buildBatch($files, $options);',
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+                new ConfiguredCodeSample(
+                    'locale_config_batch_update_components($options, $langcodes, $components, $update_default_config_langcodes);',
+                    '\Drupal::service(\Drupal\locale\LocaleConfigBatch::class)->buildBatch($options, $langcodes, $components, $update_default_config_langcodes);',
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+                new ConfiguredCodeSample(
+                    'locale_translation_check_projects_batch($projects, $langcodes);',
+                    '\Drupal::service(\Drupal\locale\LocaleProjectChecker::class)->triggerBatch($projects, $langcodes);',
+                    [new DrupalIntroducedVersionConfiguration('11.4.0')]
+                ),
+            ]
+        );
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/ReplaceLocaleBatchProceduralFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/ReplaceLocaleBatchProceduralFunctionsRectorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceLocaleBatchProceduralFunctionsRector;
+
+use DrupalRector\Services\DrupalRectorSettings;
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class ReplaceLocaleBatchProceduralFunctionsRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function testAboveVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
+        $this->doTestFile($filePath);
+    }
+
+    /** @return \Iterator<array<string>> */
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    public function testBelowVersion(string $filePath): void
+    {
+        static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');
+        $this->doTestFile($filePath);
+    }
+
+    /** @return \Iterator<array<string>> */
+    public static function provideDataBelowVersion(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture-below-version');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/config/configured_rule.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\ReplaceLocaleBatchProceduralFunctionsRector;
+use DrupalRector\Rector\ValueObject\DrupalIntroducedVersionConfiguration;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(ReplaceLocaleBatchProceduralFunctionsRector::class, $rectorConfig, false, [
+        new DrupalIntroducedVersionConfiguration('11.4.0'),
+    ]);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/fixture-below-version/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/fixture-below-version/basic.php.inc
@@ -1,0 +1,13 @@
+<?php
+
+locale_translate_batch_build($files, $options);
+locale_config_batch_update_components($options, $langcodes, $components, $update_default_config_langcodes);
+locale_translation_check_projects_batch($projects, $langcodes);
+?>
+-----
+<?php
+
+locale_translate_batch_build($files, $options);
+locale_config_batch_update_components($options, $langcodes, $components, $update_default_config_langcodes);
+locale_translation_check_projects_batch($projects, $langcodes);
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/fixture/basic.php.inc
@@ -1,0 +1,41 @@
+<?php
+
+locale_translation_batch_version_check($project, $langcode, $context);
+locale_translation_batch_status_check($project, $langcode, $options, $context);
+locale_translation_batch_fetch_download($project, $langcode, $context);
+locale_translation_batch_fetch_import($project, $langcode, $options, $context);
+locale_translation_batch_fetch_finished($success, $results);
+_locale_translation_batch_status_operations($projects, $langcodes, $options);
+locale_translate_batch_build($files, $options);
+locale_translate_batch_import($file, $options, $context);
+locale_translate_batch_import_save($context);
+locale_translate_batch_refresh($context);
+locale_translate_batch_finished($success, $results);
+locale_config_batch_update_components($options, $langcodes, $components, $update_default_config_langcodes);
+locale_config_batch_update_default_config_langcodes($context);
+locale_config_batch_update_config_translations($names, $langcodes, $context);
+locale_config_batch_finished($success, $results);
+locale_translation_check_projects_batch($projects, $langcodes);
+locale_translation_batch_status_finished($success, $results);
+?>
+-----
+<?php
+
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleFetch::class)->batchVersionCheck($project, $langcode, $context), fn() => locale_translation_batch_version_check($project, $langcode, $context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleFetch::class)->batchStatusCheck($project, $langcode, $options, $context), fn() => locale_translation_batch_status_check($project, $langcode, $options, $context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleFetch::class)->batchDownload($project, $langcode, $context), fn() => locale_translation_batch_fetch_download($project, $langcode, $context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleFetch::class)->batchImport($project, $langcode, $options, $context), fn() => locale_translation_batch_fetch_import($project, $langcode, $options, $context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleFetch::class)->batchFinished($success, $results), fn() => locale_translation_batch_fetch_finished($success, $results));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleFetch::class)->getStatusOperations($projects, $langcodes, $options), fn() => _locale_translation_batch_status_operations($projects, $langcodes, $options));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleImportBatch::class)->buildBatch($files, $options), fn() => locale_translate_batch_build($files, $options));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleImportBatch::class)->batchImport($file, $options, $context), fn() => locale_translate_batch_import($file, $options, $context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleImportBatch::class)->batchSave($context), fn() => locale_translate_batch_import_save($context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleImportBatch::class)->batchRefresh($context), fn() => locale_translate_batch_refresh($context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleImportBatch::class)->batchFinished($success, $results), fn() => locale_translate_batch_finished($success, $results));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleConfigBatch::class)->buildBatch($options, $langcodes, $components, $update_default_config_langcodes), fn() => locale_config_batch_update_components($options, $langcodes, $components, $update_default_config_langcodes));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleConfigBatch::class)->batchUpdateDefaultConfigLangcodes($context), fn() => locale_config_batch_update_default_config_langcodes($context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleConfigBatch::class)->batchUpdateConfigTranslations($names, $langcodes, $context), fn() => locale_config_batch_update_config_translations($names, $langcodes, $context));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleConfigBatch::class)->batchFinished($success, $results), fn() => locale_config_batch_finished($success, $results));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleProjectChecker::class)->triggerBatch($projects, $langcodes), fn() => locale_translation_check_projects_batch($projects, $langcodes));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\locale\LocaleProjectChecker::class)->batchFinished($success, $results), fn() => locale_translation_batch_status_finished($success, $results));
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,19 @@
+<?php
+
+// Intentionally excluded: signature/behavior changed, requires manual migration.
+locale_config_batch_build($options, $langcodes);
+locale_translation_batch_status_build($projects, $langcodes);
+// Unrelated functions with similar prefixes must not be touched.
+locale_translation_check_projects($projects);
+locale_translate_batch_something_else($context);
+?>
+-----
+<?php
+
+// Intentionally excluded: signature/behavior changed, requires manual migration.
+locale_config_batch_build($options, $langcodes);
+locale_translation_batch_status_build($projects, $langcodes);
+// Unrelated functions with similar prefixes must not be touched.
+locale_translation_check_projects($projects);
+locale_translate_batch_something_else($context);
+?>


### PR DESCRIPTION
## What

Adds `ReplaceLocaleBatchProceduralFunctionsRector`, covering [#3581303](https://www.drupal.org/node/3581303) ([change record](https://www.drupal.org/node/3589759)).

It rewrites the **17** deprecated locale batch procedural callbacks from `locale.batch.inc`, `locale.bulk.inc`, and `locale.compare.inc` to the equivalent methods on the four locale services. Each deprecated function delegates directly to its service method with identical arguments, so the rewrite is a mechanical 1-to-1 mapping (args forwarded verbatim).

| Deprecated function | Replacement |
|---|---|
| `locale_translation_batch_version_check()` | `LocaleFetch::batchVersionCheck()` |
| `locale_translation_batch_status_check()` | `LocaleFetch::batchStatusCheck()` |
| `locale_translation_batch_fetch_download()` | `LocaleFetch::batchDownload()` |
| `locale_translation_batch_fetch_import()` | `LocaleFetch::batchImport()` |
| `locale_translation_batch_fetch_finished()` | `LocaleFetch::batchFinished()` |
| `_locale_translation_batch_status_operations()` | `LocaleFetch::getStatusOperations()` |
| `locale_translate_batch_build()` | `LocaleImportBatch::buildBatch()` |
| `locale_translate_batch_import()` | `LocaleImportBatch::batchImport()` |
| `locale_translate_batch_import_save()` | `LocaleImportBatch::batchSave()` |
| `locale_translate_batch_refresh()` | `LocaleImportBatch::batchRefresh()` |
| `locale_translate_batch_finished()` | `LocaleImportBatch::batchFinished()` |
| `locale_config_batch_update_components()` | `LocaleConfigBatch::buildBatch()` |
| `locale_config_batch_update_default_config_langcodes()` | `LocaleConfigBatch::batchUpdateDefaultConfigLangcodes()` |
| `locale_config_batch_update_config_translations()` | `LocaleConfigBatch::batchUpdateConfigTranslations()` |
| `locale_config_batch_finished()` | `LocaleConfigBatch::batchFinished()` |
| `locale_translation_check_projects_batch()` | `LocaleProjectChecker::triggerBatch()` |
| `locale_translation_batch_status_finished()` | `LocaleProjectChecker::batchFinished()` |

## BC

Deprecated in drupal:11.4.0, removed in drupal:13.0.0. The rector extends `AbstractDrupalCoreRector` and is **BC-wrapped** via `DeprecationHelper::backwardsCompatibleCall()` — the `LocaleImportBatch`/`LocaleConfigBatch` services and the new methods on the existing services do not exist on Drupal < 11.4, so a bare rewrite would fatal there.

## Intentionally excluded

`locale_config_batch_build()` and `locale_translation_batch_status_build()` are **not** rewritten: the former changed its argument signature and the latter changed its behavior (the replacement calls `batch_set()` immediately rather than returning the array). Both require manual migration. The `no_change_unrelated` fixture proves they (and similarly-prefixed unrelated functions) are left untouched.

## Validation

- **Live-tested against 5 real D11-compatible contrib modules** — 5/5 files transformed correctly, BC-wrapped, args forwarded verbatim (including real 2-arg `locale_config_batch_update_components()` calls and `if ($batch = ...)` assignment contexts):
  - `config_translation_po`, `basket`, `drd_agent`, `translation_bliss`, `bulk_import_export_interface_translation`
- The 17 PHPStan deprecation messages are captured in the rector's `PHPSTAN_MESSAGES` const.

## Quality gates

- `composer fix-style` — clean
- `composer phpstan` — no errors
- `phpunit` — 3/3 pass (`testAboveVersion`, `testBelowVersion`, no-change)
- rector-qa — all five passes green