### PR TITLE
chore: record #3037156 (locale translation history) as skip

### DIFF
--- a/docs/implemented-digests.yml
+++ b/docs/implemented-digests.yml
@@ -82,6 +82,11 @@ digests:
     phase: '1a'
     class: LocaleCompareIncToServiceRector
     digest_file: replace-deprecated-locale-compare-inc-functions-with-3037031.php
+  '3037156':
+    status: skip
+    phase: '1a'
+    digest_file: replace-locale-translation-update-file-history-and-locale-3037156.php
+    note: 'SKIP — LocaleTranslationHistoryFunctionsRector was built + reverted Jun 2026. Zero contrib usage (the three functions are core-internal); the sole contrib call (locale_deploy LocaleDeployCommands.php:133, zero-arg locale_translation_file_history_delete()) is unrewritable because CurrentImportStorage::delete() requires $projects. No mechanical replacement for locale_translation_get_file_history(); replacement service is @internal. CR node/3037162 is stale (cites CurrentImportStateStorage; core merged as CurrentImportStorage). Manual migration only — not worth the maintenance surface.'
   '3038908':
     status: implemented
     phase: '1b'


### PR DESCRIPTION
## What

Records drupal.org issue [#3037156](https://www.drupal.org/i/3037156) as `status: skip` in `docs/implemented-digests.yml`, so `/rector-discover` stops surfacing it as a pending rector.

## Why

`LocaleTranslationHistoryFunctionsRector` was **fully built and passed all quality gates** in June 2026, then **reverted** on a cost-benefit analysis. The decision lived only in session history and was never persisted to the source-of-truth file on `main` — so the index kept marking it pending and it kept coming up as the "next suggested" rector.

The rule would transform nothing in practice:

- The three deprecated functions are **core-internal**; a full contrib search (`api.tresbien.tech`) found **zero callers** for `locale_translation_update_file_history()` and `locale_translation_get_file_history()`.
- The **sole** contrib call (`locale_deploy` `LocaleDeployCommands.php:133`) is a **zero-arg** `locale_translation_file_history_delete()`, which the rector correctly skips because the replacement `CurrentImportStorage::delete()` **requires** `$projects`. Manual migration is required regardless.
- There is **no mechanical replacement** for `locale_translation_get_file_history()`; the replacement service is `@internal`.
- The change record (node/3037162) is **stale** — it cites `CurrentImportStateStorage`, but core merged it as `CurrentImportStorage`.

A rector here would add BC-wrapped code, a test suite, and ongoing config maintenance surface for no real-world benefit. Manual migration is the appropriate path if any site ever needs it.

## Note on the `skip` status

`docs/implemented-digests.yml` is consumed only by the `rector-discover` skill, which treats *any* issue listed under `digests:` as not-pending. `skip` is used here rather than `config-only` because no config rule actually covers this — it's a deliberate non-implementation.