### PR TITLE
feat(11.4): add NodeSearch → SearchNode rename to DRUPAL_114_BREAKING (#3587564)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ release-by-release.
 
 ## [Unreleased]
 
+### Added
+
+- **`DRUPAL_114_BREAKING`: `NodeSearch` → `SearchNode` class rename.**
+  `Drupal\node\Plugin\Search\NodeSearch` was moved out of the `node` module and
+  renamed to `Drupal\search_node\Plugin\Search\SearchNode` in the new
+  `search_node` core sub-module (drupal:11.4.0). Added as a `RenameClassRector`
+  entry to `drupal-11.4-breaking.php`. Unlike the `HelpSearch` move, the old
+  `NodeSearch` class is **not** removed in 11.4 — it survives as a `@deprecated`
+  subclass of `SearchNode` until removal in drupal:12.0.0. It is still in the
+  breaking set because `SearchNode` does not exist on any Drupal minor below
+  11.4, and a `use` / `extends` / `::class` rename is structural and cannot be
+  BC-wrapped, so applying it against code that must still run on an older minor
+  would fatal there. Known D11 contrib subclasses affected: `trash`
+  (`TrashNodeSearch`) and `search_exclude` (`SearchExcludeNodeSearch`). Opt in
+  via `Drupal11SetList::DRUPAL_114_BREAKING` only after dropping support for
+  Drupal < 11.4 ([#3587564](https://www.drupal.org/i/3587564) /
+  [change record](https://www.drupal.org/node/3590298)).
+
 ## [1.0.0-beta1] — 2026-06-11
 
 ### Added

--- a/config/drupal-11/drupal-11.4-breaking.php
+++ b/config/drupal-11/drupal-11.4-breaking.php
@@ -50,6 +50,30 @@ return static function (RectorConfig $rectorConfig): void {
     //   deprecation message — only a plain "class not found" once a site is on
     //   11.4. There is no message for upgrade_status to match against.
     //
+    // https://www.drupal.org/node/3587564
+    // https://www.drupal.org/node/3590298 (change record)
+    // Drupal\node\Plugin\Search\NodeSearch moved out of the node module into
+    // the new search_node core sub-module and renamed to
+    // Drupal\search_node\Plugin\Search\SearchNode (drupal-core bcb6694582, on
+    // 11.x only). Unlike HelpSearch above, the old NodeSearch class is NOT
+    // removed in 11.4 — it survives as a deprecated subclass of SearchNode
+    // (@deprecated, with a class-level @trigger_error) until removal in 12.0.0.
+    // It still belongs in the breaking set: SearchNode does not exist on any
+    // Drupal minor below 11.4, so rewriting `use` / `extends` / `::class`
+    // references to it produces a "class not found" fatal on < 11.4, and a
+    // `class X extends Y` declaration is a structural node, not an Expr → Expr
+    // rewrite, so it cannot be BC-wrapped.
+    //
+    // PHPSTAN_MESSAGES RenameClassRector: because the NodeSearch shim is
+    //   annotated `@deprecated in drupal:11.4.0` at the class level,
+    //   phpstan-deprecation-rules emits "Class ... extends deprecated class
+    //   Drupal\node\Plugin\Search\NodeSearch: in drupal:11.4.0 and is removed
+    //   from drupal:12.0.0. Instead, use
+    //   \Drupal\search_node\Plugin\Search\SearchNode." for subclasses (e.g.
+    //   contrib trash's TrashNodeSearch, search_exclude's
+    //   SearchExcludeNodeSearch) and "Instantiation of deprecated class ..."
+    //   for direct `new` calls.
+    //
     // https://www.drupal.org/node/3589630
     // https://www.drupal.org/node/3589636 (change record)
     // Drupal\node\Controller\NodeViewController deprecated in drupal:11.4.0,
@@ -79,6 +103,7 @@ return static function (RectorConfig $rectorConfig): void {
         'Drupal\menu_link_content\Plugin\migrate\process\LinkOptions' => 'Drupal\migrate\Plugin\migrate\process\LinkOptions',
         'Drupal\menu_link_content\Plugin\migrate\process\LinkUri' => 'Drupal\migrate\Plugin\migrate\process\LinkUri',
         'Drupal\help\Plugin\Search\HelpSearch' => 'Drupal\search_help\Plugin\Search\SearchHelpSearch',
+        'Drupal\node\Plugin\Search\NodeSearch' => 'Drupal\search_node\Plugin\Search\SearchNode',
         'Drupal\node\Controller\NodeViewController' => 'Drupal\Core\Entity\Controller\EntityViewController',
     ]);
 

--- a/docs/implemented-digests.yml
+++ b/docs/implemented-digests.yml
@@ -641,6 +641,11 @@ digests:
     phase: '3'
     class: RemovePhpUnitCompatibilityTraitRector
     digest_file: remove-deprecated-phpunitcompatibilitytrait-from-test-3582118.php
+  '3587564':
+    status: config-only
+    phase: '4'
+    digest_file: rename-nodesearch-to-searchnode-from-search-node-module-3587564.php
+    note: 'NodeSearch→SearchNode via RenameClassRector in DRUPAL_114_BREAKING config. SearchNode lives in the new search_node sub-module (introduced by this issue, absent < 11.4), so the rename is non-BC-wrappable. Real D11 contrib users: trash (TrashNodeSearch), search_exclude (SearchExcludeNodeSearch).'
   '3589047':
     status: implemented
     phase: '2'


### PR DESCRIPTION
## Summary

Adds the `NodeSearch` → `SearchNode` class rename to the opt-in `DRUPAL_114_BREAKING` set.

`Drupal\node\Plugin\Search\NodeSearch` was moved out of the `node` module into the new `search_node` core sub-module and renamed to `Drupal\search_node\Plugin\Search\SearchNode` in **drupal:11.4.0** ([#3587564](https://www.drupal.org/i/3587564) / [change record #3590298](https://www.drupal.org/node/3590298)). Registered as a `RenameClassRector` mapping alongside the existing `HelpSearch` → `SearchHelpSearch` entry.

## Why the breaking set (not the default deprecation set)

- `SearchNode` does **not** exist on any Drupal minor below 11.4, so rewriting `use` / `extends` / `::class` references to it would produce a "class not found" fatal on < 11.4.
- A `class X extends Y` declaration is a structural (Name-node) change, not an `Expr → Expr` rewrite, so it **cannot** be BC-wrapped via `DeprecationHelper`.

This is the same shape as the `HelpSearch` precedent already in this file. One difference, documented inline: unlike HelpSearch (moved away with no shim), `NodeSearch` survives in 11.4 as a `@deprecated` subclass of `SearchNode` (removed in 12.0.0), so PHPStan *does* emit a deprecation message for it.

## Verification

- `php -l`, `composer fix-style` (0 changes), `composer phpstan` (no errors) — all clean.
- **Live test** (`rector-live-test`) against real D11 contrib confirmed correct transformation:
  - `trash` (~19k installs) — `TrashNodeSearch extends NodeSearch` → `extends \Drupal\search_node\Plugin\Search\SearchNode`
  - `search_exclude` (~4.7k installs) — `SearchExcludeNodeSearch` likewise
- PHPStan message capture was not possible in the test env (its `11.4-dev` core snapshot predates the move); the expected message form is documented as a prose comment, intentionally outside the coverage-registry capture format (matching the HelpSearch/NodeViewController precedent).

## Files

- `config/drupal-11/drupal-11.4-breaking.php` — `RenameClassRector` mapping + documenting comment
- `docs/implemented-digests.yml` — recorded `#3587564` as `config-only`
- `CHANGELOG.md` — `[Unreleased]` entry