### PR TITLE
feat: add UserLoadByNameAndMailRector for #3555936

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ release-by-release.
 
 ## [Unreleased]
 
+### Added
+
+- **`UserLoadByNameAndMailRector` (Drupal 11.4, [#3555936](https://www.drupal.org/node/3555936))** —
+  rewrites the deprecated `user_load_by_name()` and `user_load_by_mail()`
+  functions (deprecated in drupal:11.4.0, removed in drupal:13.0.0) to the
+  equivalent entity-storage lookup
+  `\Drupal::entityTypeManager()->getStorage('user')->loadByProperties([...])`.
+  Because `loadByProperties()` returns an array keyed by user ID while the old
+  functions returned a single user object or `FALSE`, the result is normalised
+  with `array_values(...)[0] ?? FALSE` to preserve the original return contract.
+  The replacement uses only long-standing entity APIs and pure PHP, so it runs
+  on every supported Drupal version and is not BC-wrapped.
+
 ## [1.0.0-beta1] — 2026-06-11
 
 ### Added

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -38,6 +38,7 @@ use DrupalRector\Drupal11\Rector\Deprecation\SystemRegionFunctionsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\SystemSortThemesRector;
 use DrupalRector\Drupal11\Rector\Deprecation\UploadedFileConstraintArrayOptionsToNamedArgsRector;
 use DrupalRector\Drupal11\Rector\Deprecation\UseEntityTypeHasIntegerIdRector;
+use DrupalRector\Drupal11\Rector\Deprecation\UserLoadByNameAndMailRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ViewsPluginHandlerManagerRector;
 use DrupalRector\Rector\Deprecation\ClassConstantToClassConstantRector;
 use DrupalRector\Rector\Deprecation\ConstantToClassConstantRector;
@@ -585,4 +586,12 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->ruleWithConfiguration(RemoveRouteBuilderDeprecatedArgsRector::class, [
         new DrupalIntroducedVersionConfiguration('11.4.0'),
     ]);
+
+    // https://www.drupal.org/node/3555936
+    // user_load_by_name() and user_load_by_mail() deprecated in drupal:11.4.0,
+    // removed in drupal:13.0.0. Replaced by an entity storage loadByProperties()
+    // lookup, normalised with array_values(...)[0] ?? FALSE to preserve the
+    // original single-object-or-FALSE return contract. Pure entity-API + PHP —
+    // runs on every supported Drupal version, so no BC wrapper.
+    $rectorConfig->rule(UserLoadByNameAndMailRector::class);
 };

--- a/docs/coverage-registry.php
+++ b/docs/coverage-registry.php
@@ -20,27 +20,36 @@ declare(strict_types=1);
  */
 
 return array (
-  'GetDrupalRootToRootPropertyRector' =>
+  'GetDrupalRootToRootPropertyRector' => 
   array (
     0 => 'Call to deprecated method getDrupalRoot() of class Drupal\\KernelTests\\KernelTestBase. Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Access $this->root directly.',
     1 => 'Call to deprecated method getDrupalRoot() of class Drupal\\Tests\\BrowserTestBase. Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Access $this->root directly.',
     2 => 'Call to deprecated method getDrupalRoot() of class Drupal\\Tests\\UnitTestCase. Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Access $this->root directly.',
   ),
-  'RemoveAliasManagerCacheMethodCallsRector' =>
+  'RemoveAliasManagerCacheMethodCallsRector' => 
   array (
     0 => 'Call to deprecated method setCacheKey() of class Drupal\\path_alias\\AliasManager. Deprecated in drupal:11.3.0 and is removed from drupal:13.0.0. There is no replacement.',
     1 => 'Call to deprecated method writeCache() of class Drupal\\path_alias\\AliasManager. Deprecated in drupal:11.3.0 and is removed from drupal:13.0.0. There is no replacement.',
   ),
-  'RemoveDrupalToStringTraitRector' =>
+  'RemoveDrupalToStringTraitRector' => 
   array (
     0 => 'Usage of deprecated trait Drupal\\Component\\Utility\\ToStringTrait. Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Implement the __toString() method directly, exception handling is no longer required.',
   ),
-  'RemoveRendererAddCacheableDependencyNonObjectRector' =>
+  'RemoveRendererAddCacheableDependencyNonObjectRector' => 
   array (
     0 => 'Calling Drupal\\Core\\Render\\Renderer::addCacheableDependency() with an object that doesn\'t implement Drupal\\Core\\Cache\\CacheableDependencyInterface is deprecated in drupal:11.3.0 and will throw an error in drupal:13.0.0. See https://www.drupal.org/node/3525389',
   ),
-  'ReplaceExpectDeprecationRector' =>
+  'ReplaceExpectDeprecationRector' => 
   array (
     0 => 'Call to deprecated method expectDeprecation() of class Drupal\\KernelTests\\KernelTestBase. Deprecated in drupal:11.4.0 and is removed from drupal:12.0.0. Use $this->expectUserDeprecationMessage() or $this->expectUserDeprecationMessageMatches() instead.',
+  ),
+  'ReplaceNodeViewControllerRector' => 
+  array (
+    0 => 'Instantiation of deprecated class Drupal\\node\\Controller\\NodeViewController. Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal\\Core\\Entity\\Controller\\EntityViewController instead.',
+  ),
+  'UserLoadByNameAndMailRector' => 
+  array (
+    0 => 'Call to deprecated function user_load_by_mail(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::entityTypeManager()->getStorage(\'user\')->loadByProperties() instead.',
+    1 => 'Call to deprecated function user_load_by_name(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::entityTypeManager()->getStorage(\'user\')->loadByProperties() instead.',
   ),
 );

--- a/docs/implemented-digests.yml
+++ b/docs/implemented-digests.yml
@@ -421,6 +421,11 @@ digests:
     class: ReplaceItemAttributesWithAttributesRector
     digest_file: replace-item-attributes-with-attributes-in-image-render-3554447.php
     note: 'Implemented in open PR #348 (not yet merged to main).'
+  '3555936':
+    status: implemented
+    phase: '2'
+    class: UserLoadByNameAndMailRector
+    note: 'No upstream drupal-digests rule exists; authored from scratch. user_load_by_name()/user_load_by_mail() → entity storage loadByProperties() normalised with array_values(...)[0] ?? FALSE to preserve the single-object-or-FALSE return contract. AbstractRector (no BC wrapper).'
   '3557461':
     status: implemented
     phase: '2'

--- a/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector.php
+++ b/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Drupal11\Rector\Deprecation;
+
+use PhpParser\Node;
+use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
+use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+
+/**
+ * Replaces the deprecated user_load_by_name() and user_load_by_mail() functions
+ * with the equivalent entity storage loadByProperties() lookup.
+ *
+ * The deprecated functions return a single user object, or FALSE when no match
+ * is found. loadByProperties() returns an array keyed by user ID, so the result
+ * is normalised with array_values(...)[0] ?? FALSE to preserve the original
+ * single-object-or-FALSE return contract.
+ *
+ * @see https://www.drupal.org/node/3555936
+ */
+class UserLoadByNameAndMailRector extends AbstractRector
+{
+    public const PHPSTAN_MESSAGES = [
+        'Call to deprecated function user_load_by_name(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::entityTypeManager()->getStorage(\'user\')->loadByProperties() instead.',
+        'Call to deprecated function user_load_by_mail(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::entityTypeManager()->getStorage(\'user\')->loadByProperties() instead.',
+    ];
+
+    /**
+     * Maps each deprecated function to the user entity property it queries.
+     *
+     * @var array<string, string>
+     */
+    private const PROPERTY_MAP = [
+        'user_load_by_name' => 'name',
+        'user_load_by_mail' => 'mail',
+    ];
+
+    public function getRuleDefinition(): RuleDefinition
+    {
+        return new RuleDefinition(
+            'Replaces deprecated user_load_by_name() and user_load_by_mail() with entity storage loadByProperties()',
+            [
+                new CodeSample(
+                    <<<'CODE_BEFORE'
+$account = user_load_by_name($name);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$account = array_values(\Drupal::entityTypeManager()->getStorage('user')->loadByProperties(['name' => $name]))[0] ?? FALSE;
+CODE_AFTER
+                ),
+            ]
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getNodeTypes(): array
+    {
+        return [
+            Node\Expr\FuncCall::class,
+        ];
+    }
+
+    public function refactor(Node $node): ?Node
+    {
+        assert($node instanceof Node\Expr\FuncCall);
+
+        $functionName = $this->getName($node->name);
+        if ($functionName === null || !isset(self::PROPERTY_MAP[$functionName])) {
+            return null;
+        }
+
+        $args = $node->getArgs();
+        if (!isset($args[0])) {
+            return null;
+        }
+
+        $property = self::PROPERTY_MAP[$functionName];
+
+        $entityTypeManager = $this->nodeFactory->createStaticCall('Drupal', 'entityTypeManager');
+        $storage = $this->nodeFactory->createMethodCall($entityTypeManager, 'getStorage', $this->nodeFactory->createArgs(['user']));
+        $loadByProperties = $this->nodeFactory->createMethodCall($storage, 'loadByProperties', $this->nodeFactory->createArgs([
+            $this->nodeFactory->createArray([$property => $args[0]]),
+        ]));
+
+        $firstUser = new Node\Expr\ArrayDimFetch(
+            $this->nodeFactory->createFuncCall('array_values', [$loadByProperties]),
+            new Node\Scalar\Int_(0)
+        );
+
+        return new Node\Expr\BinaryOp\Coalesce($firstUser, new Node\Expr\ConstFetch(new Node\Name('FALSE')));
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/UserLoadByNameAndMailRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/UserLoadByNameAndMailRectorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\UserLoadByNameAndMailRector;
+
+use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+
+class UserLoadByNameAndMailRectorTest extends AbstractDrupalRectorTestCase
+{
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): \Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__.'/fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__.'/config/configured_rule.php';
+    }
+}

--- a/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/config/configured_rule.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/config/configured_rule.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+use DrupalRector\Drupal11\Rector\Deprecation\UserLoadByNameAndMailRector;
+use DrupalRector\Tests\Rector\Deprecation\DeprecationBase;
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    DeprecationBase::addClass(UserLoadByNameAndMailRector::class, $rectorConfig, false);
+};

--- a/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/fixture/basic.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+$account = user_load_by_name($name);
+$account_by_mail = user_load_by_mail($mail);
+?>
+-----
+<?php
+
+$account = array_values(\Drupal::entityTypeManager()->getStorage('user')->loadByProperties(['name' => $name]))[0] ?? FALSE;
+$account_by_mail = array_values(\Drupal::entityTypeManager()->getStorage('user')->loadByProperties(['mail' => $mail]))[0] ?? FALSE;
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/fixture/no_change_unrelated.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/fixture/no_change_unrelated.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+// Unrelated function calls with similar names must be left untouched.
+$account = user_load($uid);
+$accounts = user_load_multiple($uids);
+?>


### PR DESCRIPTION
## Summary

Adds `UserLoadByNameAndMailRector`, covering the two functions deprecated by change record [#3555936](https://www.drupal.org/node/3555936):

- `user_load_by_name()` — deprecated in drupal:11.4.0, removed in drupal:13.0.0
- `user_load_by_mail()` — deprecated in drupal:11.4.0, removed in drupal:13.0.0

No upstream drupal-digests rule existed for this, so the rector is authored from scratch.

## Transformation

```php
// before
$account = user_load_by_name($name);

// after
$account = array_values(\Drupal::entityTypeManager()->getStorage('user')->loadByProperties(['name' => $name]))[0] ?? FALSE;
```

`loadByProperties()` returns an array keyed by user ID, whereas the old functions returned a single user object or `FALSE`. The result is normalised with `array_values(...)[0] ?? FALSE` to preserve the original single-object-or-`FALSE` contract in any call context (assignment, `if (!…)`, argument), without an intermediate variable and without passing an rvalue to `reset()`.

## BC decision

`AbstractRector` (no `DeprecationHelper` wrapper). The replacement uses only long-standing entity APIs (`entityTypeManager()`, `getStorage()`, `loadByProperties()`) plus pure PHP. Verified against the `10.1.0` core tag: all three symbols exist with identical signatures, `loadByProperties()` already returns an id-keyed array, and `user_load_by_name()` itself is implemented with the exact same lookup — so the output runs unchanged on every supported Drupal version.

## Validation

- Unit test passes (`testAboveVersion`-style happy path + `no_change_unrelated` fixture).
- `phpstan` clean, `fix-style` no changes.
- **Live-tested** against 6 D11 contrib modules — 13 call sites across `.module`, `.install`, Controller, Form, FieldFormatter, and Plugin contexts (login_security, login_emailusername, linkchecker, workbench_access, restrict_password_change, show_email). Operator precedence verified correct (`!(… ?? FALSE)` parenthesized; `if ($x = … ?? FALSE)` left bare).
- Real PHPStan deprecation messages for both functions captured in `docs/coverage-registry.php`.

## Notes

- Registered in the `DRUPAL_114` deprecation set.
- Recorded in `docs/implemented-digests.yml` (#3555936) and `CHANGELOG.md`.
- `docs/coverage-registry.php` is regenerated; besides this rector's two entries it also syncs previously-unregenerated messages for already-merged rectors whose source consts were already on `main`.