### PR TITLE
feat: composer-based sets + register as rector-extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ release-by-release.
   It loads before your `rector.php`, so your own config always takes precedence,
   and the bundled `rector.php` template remains fully self-sufficient when the
   installer is absent. The PHPUnit bootstrap is intentionally not auto-loaded
-  (it requires a Drupal install) and stays tied to the deprecation sets.
+  (it requires a Drupal install) — under composer-based selection it is loaded by
+  a dedicated `config/drupal-bootstrap.php` set instead.
 - **Composer-based sets ([rectorphp/rector#9778](https://github.com/rectorphp/rector/issues/9778))** —
   new `DrupalRector\Set\DrupalSetProvider` lets Rector select Drupal deprecation
   sets automatically from the installed `drupal/core` version, via
@@ -31,8 +32,10 @@ release-by-release.
   Matching is cumulative downward (a site on 11.4 loads the 11.0 → 11.4 sets and
   never a future minor), which is backward-compatibility safe. Because the
   installed version is known exactly, the per-minor *breaking* sets are folded in
-  and applied automatically. Covers `drupal/core` 10.0–10.3 and 11.0–11.4.
-  Requires a Rector release that ships `SetGroup::DRUPAL` and the
+  and applied automatically. The PHPUnit bootstrap (which the per-minor configs
+  don't register) is supplied by a dedicated `config/drupal-bootstrap.php` set,
+  matched once per major (`^10.0` / `^11.0`). Covers `drupal/core` 10.0–10.3 and
+  11.0–11.4. Requires a Rector release that ships `SetGroup::DRUPAL` and the
   `withComposerBased(drupal: ...)` toggle.
 
 ## [1.0.0-beta1] — 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,29 @@ release-by-release.
 
 ## [Unreleased]
 
+### Added
+
+- **drupal-rector now registers as a Rector extension** — the package `type` is
+  `rector-extension` and it ships `config/extension.php` (via
+  `extra.rector.includes`). For projects that have `rector/extension-installer`,
+  Rector auto-loads it to supply sensible Drupal defaults — the extra PHP file
+  extensions (`module`, `theme`, `install`, …), class-import conventions, the
+  `upgrade_status` skip, Drupal autoloading and (when present) phpstan-drupal.
+  It loads before your `rector.php`, so your own config always takes precedence,
+  and the bundled `rector.php` template remains fully self-sufficient when the
+  installer is absent. The PHPUnit bootstrap is intentionally not auto-loaded
+  (it requires a Drupal install) and stays tied to the deprecation sets.
+- **Composer-based sets ([rectorphp/rector#9778](https://github.com/rectorphp/rector/issues/9778))** —
+  new `DrupalRector\Set\DrupalSetProvider` lets Rector select Drupal deprecation
+  sets automatically from the installed `drupal/core` version, via
+  `->withSetProviders(DrupalSetProvider::class)->withComposerBased(drupal: true)`.
+  Matching is cumulative downward (a site on 11.4 loads the 11.0 → 11.4 sets and
+  never a future minor), which is backward-compatibility safe. Because the
+  installed version is known exactly, the per-minor *breaking* sets are folded in
+  and applied automatically. Covers `drupal/core` 10.0–10.3 and 11.0–11.4.
+  Requires a Rector release that ships `SetGroup::DRUPAL` and the
+  `withComposerBased(drupal: ...)` toggle.
+
 ## [1.0.0-beta1] — 2026-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,17 +26,23 @@ release-by-release.
   (it requires a Drupal install) — under composer-based selection it is loaded by
   a dedicated `config/drupal-bootstrap.php` set instead.
 - **Composer-based sets ([rectorphp/rector#9778](https://github.com/rectorphp/rector/issues/9778))** —
-  new `DrupalRector\Set\DrupalSetProvider` lets Rector select Drupal deprecation
-  sets automatically from the installed `drupal/core` version, via
-  `->withSetProviders(DrupalSetProvider::class)->withComposerBased(drupal: true)`.
-  Matching is cumulative downward (a site on 11.4 loads the 11.0 → 11.4 sets and
-  never a future minor), which is backward-compatibility safe. Because the
+  `DrupalRector\Set\DrupalSetProvider` lets Rector pick the Drupal deprecation
+  sets automatically from the installed `drupal/core` version:
+
+  ```php
+  return RectorConfig::configure()
+      ->withSetProviders(DrupalSetProvider::class)
+      ->withComposerBased(drupal: true);
+  ```
+
+  Matching is cumulative downward — a site on 11.4 loads the 11.0 → 11.4 sets and
+  never a future minor — so it is backward-compatibility safe. Because the
   installed version is known exactly, the per-minor *breaking* sets are folded in
-  and applied automatically. The PHPUnit bootstrap (which the per-minor configs
-  don't register) is supplied by a dedicated `config/drupal-bootstrap.php` set,
-  matched once per major (`^10.0` / `^11.0`). Covers `drupal/core` 10.0–10.3 and
-  11.0–11.4. Requires a Rector release that ships `SetGroup::DRUPAL` and the
-  `withComposerBased(drupal: ...)` toggle.
+  automatically, and the PHPUnit bootstrap (which the per-minor configs don't
+  register) is supplied by a dedicated `config/drupal-bootstrap.php` set matched
+  once per major. Covers `drupal/core` 10.0–10.3 and 11.0–11.4. Requires a Rector
+  release that ships `SetGroup::DRUPAL` and the `withComposerBased(drupal: ...)`
+  toggle.
 
 ## [1.0.0-beta1] — 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ $rectorConfig->sets([
 
 This is more granular than the `Drupal10SetList::DRUPAL_10` set. Since Drupal 10.1 there is not real reason not to include later versions. It will detect the installed Drupal version and supply BC wrappers as needed if you enable it in the config.
 
+### Composer-based sets (automatic version selection)
+
+Instead of listing sets by hand, you can let Rector pick them from the installed
+`drupal/core` version. Register the set provider and enable the `drupal` group:
+
+```php
+return RectorConfig::configure()
+    ->withSetProviders(\DrupalRector\Set\DrupalSetProvider::class)
+    ->withComposerBased(drupal: true);
+```
+
+Rector reads the installed `drupal/core` version and loads every set up to and
+including that minor — a site on 11.4 loads the 11.0 → 11.4 rules, a site on
+11.2 loads 11.0 → 11.2, and a future minor's rules are never applied. Because the
+matched version is known exactly, the otherwise opt-in *breaking* sets (renames
+whose replacement only exists from a given minor onward) are included
+automatically — they cannot fatal on a core that is guaranteed to have the
+replacement.
+
+This is the backward-compatibility-safe counterpart to listing sets manually:
+it fixes what is deprecated on *your* installed core. To look ahead and prepare
+for the next major before upgrading, keep using the explicit `Drupal11SetList`
+sets with `setDrupalVersion()` as described above.
+
+> **Requires** a Rector release that ships `SetGroup::DRUPAL` and the
+> `withComposerBased(drupal: ...)` toggle (see
+> [rectorphp/rector#9778](https://github.com/rectorphp/rector/issues/9778)).
+
 ### DrupalRectorSettings
 
 The copied `rector.php` includes a `DrupalRectorSettings` block that controls two behaviours:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "palantirnet/drupal-rector",
     "description": "Instant fixes for your Drupal code by using Rector.",
-    "type": "library",
+    "type": "rector-extension",
     "keywords": [
         "code style",
         "rector",
@@ -75,7 +75,12 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "extra": {
-        "enable-patching": true
+        "enable-patching": true,
+        "rector": {
+            "includes": [
+                "config/extension.php"
+            ]
+        }
     },
     "require-dev": {
         "php": "^8.2",

--- a/config/drupal-bootstrap.php
+++ b/config/drupal-bootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+/**
+ * Registers the Drupal PHPUnit bootstrap file.
+ *
+ * Standalone set used by composer-based selection (see
+ * \DrupalRector\Set\DrupalSetProvider). The per-minor deprecation configs do
+ * not register the bootstrap themselves — only the aggregated
+ * `drupal-{10,11}-all-deprecations.php` sets do. Composer-based selection loads
+ * the per-minor configs directly, so this set is matched once per Drupal major
+ * (drupal/core ^10.0 and ^11.0) to guarantee the bootstrap is present.
+ *
+ * Kept separate from the deprecation configs on purpose: the bootstrap file
+ * throws when it cannot detect a Drupal installation, and composer-based sets
+ * only ever load when drupal/core is installed, so the throw can never fire
+ * here. Folding it into the shared per-minor configs would change behaviour for
+ * users who load a single set manually against a non-Drupal project.
+ */
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->bootstrapFiles([
+        __DIR__.'/drupal-phpunit-bootstrap-file.php',
+    ]);
+};

--- a/config/extension.php
+++ b/config/extension.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+/**
+ * Drupal infrastructure config, auto-loaded for every project that requires
+ * drupal-rector ("type": "rector-extension" + "extra.rector.includes").
+ *
+ * It supplies the Drupal-specific Rector plumbing that otherwise has to be
+ * copied into every project's rector.php: the extra PHP file extensions, class
+ * import conventions, the upgrade_status skip, Drupal autoloading and (when
+ * available) phpstan-drupal.
+ *
+ * Loading order is: Rector core defaults -> this file -> the project's
+ * rector.php. Because the project's config is applied last it always wins:
+ * fileExtensions(), autoloadPaths() and importNames() use "last call wins"
+ * semantics, while skip() and phpstanConfigs() are additive. So everything here
+ * is a default the project can still override.
+ *
+ * Imported via $rectorConfig->import(), hence the RectorConfig closure form
+ * rather than RectorConfig::configure().
+ *
+ * NOTE: this deliberately does NOT register config/drupal-phpunit-bootstrap-file.php.
+ * That bootstrap throws when it cannot detect a Drupal installation, which would
+ * break Rector in any non-Drupal context. The bootstrap is registered by the
+ * deprecation sets instead (see \DrupalRector\Set\DrupalSetProvider and the
+ * *-all-deprecations sets), which only run against an actual Drupal codebase.
+ */
+return static function (RectorConfig $rectorConfig): void {
+    // Drupal executes PHP from several non-.php extensions.
+    $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
+
+    // Drupal convention: import class names, but leave docblock names untouched.
+    $rectorConfig->importNames(true, false);
+    $rectorConfig->importShortClasses(false);
+
+    // upgrade_status ships intentionally broken test modules.
+    $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);
+
+    // Autoloading and phpstan-drupal only make sense when Drupal is actually
+    // present. Bail out otherwise — DrupalFinderComposerRuntime::getDrupalRoot()
+    // calls Composer\InstalledVersions::getInstallPath('drupal/core'), which
+    // THROWS (not returns null) when the package is not installed, so this must
+    // be guarded before the lookup.
+    if (! \Composer\InstalledVersions::isInstalled('drupal/core')) {
+        return;
+    }
+
+    $drupalFinder = new \DrupalFinder\DrupalFinderComposerRuntime();
+
+    $drupalRoot = $drupalFinder->getDrupalRoot();
+    if (is_string($drupalRoot) && $drupalRoot !== '') {
+        $rectorConfig->autoloadPaths([
+            $drupalRoot.'/core',
+            $drupalRoot.'/modules',
+            $drupalRoot.'/profiles',
+            $drupalRoot.'/themes',
+        ]);
+    }
+
+    // phpstan-drupal lives in the analysed project's vendor dir, not ours.
+    $vendorDir = $drupalFinder->getVendorDir();
+    if (is_string($vendorDir) && $vendorDir !== '') {
+        $phpstanDrupalExtension = $vendorDir.'/mglaman/phpstan-drupal/extension.neon';
+        if (file_exists($phpstanDrupalExtension)) {
+            $rectorConfig->phpstanConfigs([$phpstanDrupalExtension]);
+        }
+    }
+};

--- a/config/extension.php
+++ b/config/extension.php
@@ -15,9 +15,9 @@ use Rector\Config\RectorConfig;
  *
  * Loading order is: Rector core defaults -> this file -> the project's
  * rector.php. Because the project's config is applied last it always wins:
- * fileExtensions(), autoloadPaths() and importNames() use "last call wins"
- * semantics, while skip() and phpstanConfigs() are additive. So everything here
- * is a default the project can still override.
+ * fileExtensions() and autoloadPaths() use "last call wins" semantics, while
+ * skip() and phpstanConfigs() are additive. So everything here is a default the
+ * project can still override.
  *
  * Imported via $rectorConfig->import(), hence the RectorConfig closure form
  * rather than RectorConfig::configure().
@@ -31,10 +31,6 @@ use Rector\Config\RectorConfig;
 return static function (RectorConfig $rectorConfig): void {
     // Drupal executes PHP from several non-.php extensions.
     $rectorConfig->fileExtensions(['php', 'module', 'theme', 'install', 'profile', 'inc', 'engine']);
-
-    // Drupal convention: import class names, but leave docblock names untouched.
-    $rectorConfig->importNames(true, false);
-    $rectorConfig->importShortClasses(false);
 
     // upgrade_status ships intentionally broken test modules.
     $rectorConfig->skip(['*/upgrade_status/tests/modules/*']);

--- a/src/Set/DrupalSetProvider.php
+++ b/src/Set/DrupalSetProvider.php
@@ -22,14 +22,6 @@ use Rector\Set\ValueObject\ComposerTriggeredSet;
  * installed core, the otherwise opt-in "breaking" sets are safe to include here
  * and are folded into the same group.
  *
- * Enable in rector.php:
- *
- *     return RectorConfig::configure()
- *         ->withSetProviders(\DrupalRector\Set\DrupalSetProvider::class)
- *         ->withComposerBased(drupal: true);
- *
- * @api used by Rector through withSetProviders()
- *
  * @see https://github.com/rectorphp/rector/issues/9778
  */
 final class DrupalSetProvider implements SetProviderInterface

--- a/src/Set/DrupalSetProvider.php
+++ b/src/Set/DrupalSetProvider.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Set;
+
+use Rector\Set\Contract\SetInterface;
+use Rector\Set\Contract\SetProviderInterface;
+use Rector\Set\ValueObject\ComposerTriggeredSet;
+
+/**
+ * Provides composer-based Drupal sets.
+ *
+ * Each set is keyed to a `drupal/core` minor and is loaded automatically when
+ * the installed core satisfies `^<version>` (see
+ * \Rector\Set\ValueObject\ComposerTriggeredSet). The caret is a lower bound, so
+ * a site on e.g. 11.4 loads every set from 11.0 up to 11.4 and never a future
+ * minor's rules — you only ever get rules for deprecations that are live on the
+ * installed core, which is inherently backward-compatibility safe.
+ *
+ * Because the matched version guarantees the replacement symbols exist on the
+ * installed core, the otherwise opt-in "breaking" sets are safe to include here
+ * and are folded into the same group.
+ *
+ * Enable in rector.php:
+ *
+ *     return RectorConfig::configure()
+ *         ->withSetProviders(\DrupalRector\Set\DrupalSetProvider::class)
+ *         ->withComposerBased(drupal: true);
+ *
+ * @api used by Rector through withSetProviders()
+ *
+ * @see https://github.com/rectorphp/rector/issues/9778
+ */
+final class DrupalSetProvider implements SetProviderInterface
+{
+    /**
+     * Must match \Rector\Set\Enum\SetGroup::DRUPAL once that constant lands.
+     */
+    private const GROUP_NAME = 'drupal';
+
+    private const PACKAGE_NAME = 'drupal/core';
+
+    private const BOOTSTRAP_SET = __DIR__.'/../../config/drupal-bootstrap.php';
+
+    /**
+     * Minor version => deprecation set file. Add a line when a new minor's
+     * deprecation config is created.
+     *
+     * @var array<string, string>
+     */
+    private const DEPRECATION_SETS = [
+        '10.0' => Drupal10SetList::DRUPAL_100,
+        '10.1' => Drupal10SetList::DRUPAL_101,
+        '10.2' => Drupal10SetList::DRUPAL_102,
+        '10.3' => Drupal10SetList::DRUPAL_103,
+        '11.0' => Drupal11SetList::DRUPAL_110,
+        '11.1' => Drupal11SetList::DRUPAL_111,
+        '11.2' => Drupal11SetList::DRUPAL_112,
+        '11.3' => Drupal11SetList::DRUPAL_113,
+        '11.4' => Drupal11SetList::DRUPAL_114,
+    ];
+
+    /**
+     * Minor version => breaking set file. Safe to apply automatically here:
+     * the version match guarantees the replacement symbol exists on the
+     * installed core, so the rewrite cannot fatal.
+     *
+     * @var array<string, string>
+     */
+    private const BREAKING_SETS = [
+        '11.1' => Drupal11SetList::DRUPAL_111_BREAKING,
+        '11.2' => Drupal11SetList::DRUPAL_112_BREAKING,
+        '11.3' => Drupal11SetList::DRUPAL_113_BREAKING,
+        '11.4' => Drupal11SetList::DRUPAL_114_BREAKING,
+    ];
+
+    /**
+     * Lowest minor of each supported major. The bootstrap set is matched here
+     * so it loads exactly once for any site in that major (the `X.0` set is
+     * always loaded by cumulative downward matching).
+     *
+     * @var string[]
+     */
+    private const MAJOR_FLOORS = ['10.0', '11.0'];
+
+    /**
+     * @return SetInterface[]
+     */
+    public function provide(): array
+    {
+        $sets = [];
+
+        foreach (self::DEPRECATION_SETS as $version => $setFilePath) {
+            $sets[] = new ComposerTriggeredSet(self::GROUP_NAME, self::PACKAGE_NAME, $version, $setFilePath);
+        }
+
+        foreach (self::BREAKING_SETS as $version => $setFilePath) {
+            $sets[] = new ComposerTriggeredSet(self::GROUP_NAME, self::PACKAGE_NAME, $version, $setFilePath);
+        }
+
+        foreach (self::MAJOR_FLOORS as $version) {
+            $sets[] = new ComposerTriggeredSet(self::GROUP_NAME, self::PACKAGE_NAME, $version, self::BOOTSTRAP_SET);
+        }
+
+        return $sets;
+    }
+}

--- a/tests/src/Set/DrupalSetProviderTest.php
+++ b/tests/src/Set/DrupalSetProviderTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DrupalRector\Tests\Set;
+
+use DrupalRector\Set\DrupalSetProvider;
+use PHPUnit\Framework\TestCase;
+use Rector\Composer\ValueObject\InstalledPackage;
+use Rector\Set\ValueObject\ComposerTriggeredSet;
+
+final class DrupalSetProviderTest extends TestCase
+{
+    /**
+     * @return ComposerTriggeredSet[]
+     */
+    private function provide(): array
+    {
+        return (new DrupalSetProvider())->provide();
+    }
+
+    public function testEverySetIsADrupalCoreComposerTriggeredSet(): void
+    {
+        $sets = $this->provide();
+        self::assertNotEmpty($sets);
+
+        foreach ($sets as $set) {
+            self::assertInstanceOf(ComposerTriggeredSet::class, $set);
+            self::assertSame('drupal', $set->getGroupName());
+            // getName() is "<package> <version>".
+            self::assertStringStartsWith('drupal/core ', $set->getName());
+            self::assertFileExists($set->getSetFilePath());
+        }
+    }
+
+    /**
+     * @return array<string, array{string, string[]}>
+     */
+    public static function installedVersionProvider(): array
+    {
+        return [
+            // A site on 11.4 gets every 11.x set up to 11.4 (deprecations +
+            // breaking) plus the bootstrap, and nothing from Drupal 10.
+            '11.4.0 loads 11.0-11.4 cumulatively' => ['11.4.0', [
+                'drupal-11.0-deprecations.php',
+                'drupal-11.1-deprecations.php',
+                'drupal-11.2-deprecations.php',
+                'drupal-11.3-deprecations.php',
+                'drupal-11.4-deprecations.php',
+                'drupal-11.1-breaking.php',
+                'drupal-11.2-breaking.php',
+                'drupal-11.3-breaking.php',
+                'drupal-11.4-breaking.php',
+                'drupal-bootstrap.php',
+            ]],
+            // A mid-range minor stops at its own version — 11.4 must not leak in.
+            '11.3.0 loads 11.0-11.3, not 11.4' => ['11.3.0', [
+                'drupal-11.0-deprecations.php',
+                'drupal-11.1-deprecations.php',
+                'drupal-11.2-deprecations.php',
+                'drupal-11.3-deprecations.php',
+                'drupal-11.1-breaking.php',
+                'drupal-11.2-breaking.php',
+                'drupal-11.3-breaking.php',
+                'drupal-bootstrap.php',
+            ]],
+            // The major floor loads only its own set + bootstrap.
+            '11.0.0 loads only 11.0' => ['11.0.0', [
+                'drupal-11.0-deprecations.php',
+                'drupal-bootstrap.php',
+            ]],
+            // Drupal 10 gets only 10.x deprecations + bootstrap; no breaking sets exist.
+            '10.3.0 loads 10.0-10.3, no 11.x' => ['10.3.0', [
+                'drupal-10.0-deprecations.php',
+                'drupal-10.1-deprecations.php',
+                'drupal-10.2-deprecations.php',
+                'drupal-10.3-deprecations.php',
+                'drupal-bootstrap.php',
+            ]],
+            // Pre-release / dev core still matches (composer/semver is lenient).
+            '11.4.x-dev matches like 11.4' => ['11.4.x-dev', [
+                'drupal-11.0-deprecations.php',
+                'drupal-11.1-deprecations.php',
+                'drupal-11.2-deprecations.php',
+                'drupal-11.3-deprecations.php',
+                'drupal-11.4-deprecations.php',
+                'drupal-11.1-breaking.php',
+                'drupal-11.2-breaking.php',
+                'drupal-11.3-breaking.php',
+                'drupal-11.4-breaking.php',
+                'drupal-bootstrap.php',
+            ]],
+            // A future major out of range matches nothing.
+            '12.0.0 matches nothing' => ['12.0.0', []],
+        ];
+    }
+
+    /**
+     * @param string[] $expectedFiles
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('installedVersionProvider')]
+    public function testCumulativeMatchingByInstalledCoreVersion(string $installedVersion, array $expectedFiles): void
+    {
+        $installedPackages = [
+            'drupal/core' => new InstalledPackage('drupal/core', $installedVersion),
+        ];
+
+        $matched = [];
+        foreach ($this->provide() as $set) {
+            if ($set->matchInstalledPackages($installedPackages)) {
+                $matched[] = basename($set->getSetFilePath());
+            }
+        }
+
+        sort($matched);
+        $expected = $expectedFiles;
+        sort($expected);
+
+        self::assertSame($expected, $matched);
+    }
+
+    public function testNoMatchWhenDrupalCoreAbsent(): void
+    {
+        foreach ($this->provide() as $set) {
+            self::assertFalse($set->matchInstalledPackages([]));
+        }
+    }
+}


### PR DESCRIPTION
## What

Two related changes that let Rector configure Drupal deprecation fixes from the installed `drupal/core` version.

### 1. Composer-based sets (`DrupalSetProvider`)
A `SetProviderInterface` exposing the per-minor deprecation **and** breaking configs as `ComposerTriggeredSet`s keyed on `drupal/core`. Enable with:

```php
return RectorConfig::configure()
    ->withSetProviders(\DrupalRector\Set\DrupalSetProvider::class)
    ->withComposerBased(drupal: true);
```

- Cumulative-downward via `^version`: a site on 11.4 loads 11.0→11.4 and **never** a future minor — inherently BC-safe (only rules for deprecations that are live on the installed core). Verified incl. dev/beta core.
- The exact-version match makes the **breaking** sets safe to fold into the same `drupal` group.
- The PHPUnit bootstrap is supplied by a dedicated `config/drupal-bootstrap.php` set, matched once per major (`drupal/core ^10.0` / `^11.0`). The per-minor deprecation configs don't register it (only the aggregated `*-all-deprecations.php` sets do), and composer-based selection loads the per-minor configs directly — so the bootstrap is registered separately. Kept apart on purpose: the bootstrap throws without a Drupal install, and composer-based sets only ever load when `drupal/core` is present, so the throw can never fire here.
- Covers `drupal/core` 10.0–10.3 and 11.0–11.4.

### 2. Register as a `rector-extension` (progressive enhancement)
`type: rector-extension` + `extra.rector.includes` ships `config/extension.php`, which supplies sensible Drupal defaults (file extensions, autoloading, the `upgrade_status` skip, phpstan-drupal). It loads **before** the project's `rector.php`, so the project config always wins.

**The bundled `rector.php` template is left unchanged / self-sufficient on purpose** — see the testing note below.

## Why the template wasn't slimmed (empirical finding)

I tested whether the auto-config loads in a real consumer (scratch project, sentinel in `config/extension.php`, ran `rector --dry-run`):

| Consumer setup | `extension.php` auto-loaded? |
|---|---|
| `rector/rector` + `drupal-rector` | ❌ No |
| + `rector/extension-installer` | ✅ Yes |

So the auto-config **only** activates when the consumer has `rector/extension-installer` (`rector/rector` doesn't pull it in, and Composer silently skips plugins not in `allow-plugins`). Slimming the template would therefore risk silently dropping `.module`/`.theme` coverage for projects without the installer. The template stays the reliable source of truth; the extension is a bonus for projects that have the installer.

The same test caught a bug: `DrupalFinderComposerRuntime::getDrupalRoot()` **throws** (`Package "drupal/core" is not installed`) rather than returning null, so the lookup is now guarded with `InstalledVersions::isInstalled('drupal/core')` and re-verified to not throw on non-Drupal projects.

## Upstream dependency
`withComposerBased(drupal: true)` needs Rector core to ship `SetGroup::DRUPAL` + the `drupal:` toggle — rectorphp/rector-src#8041. Until then the provider is dormant. Plan per @TomasVotruba: get the provider into `main`, then kick off testing upstream.

## Verification
- Full PHPStan clean, full unit suite green (659 tests), `composer validate` OK.
- `DrupalSetProviderTest`: 8 tests / 82 assertions incl. the cumulative-matching matrix (deprecation + breaking + bootstrap) and the no-`drupal/core` case.
- Auto-config load behaviour + the non-Drupal no-throw path verified by hand in a scratch consumer project.