### PR TITLE
fix: move RemoveFilterTipsLongParamRector to the breaking set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,23 @@ release-by-release.
   `class … extends …` declaration cannot be BC-wrapped.
   [#2987159](https://www.drupal.org/i/2987159) /
   [CR](https://www.drupal.org/node/3521459).
+- **`RemoveFilterTipsLongParamRector`** — drops the deprecated `$long` parameter
+  from a filter plugin's `tips()` override and the second argument from
+  `_filter_tips()` calls. The `$long` parameter and the long-format "filter
+  tips" page are deprecated in drupal:11.4.0 and removed in drupal:12.0.0.
+  **Moved from the default deprecation set into the opt-in `DRUPAL_114_BREAKING`
+  set.** Removing `$long` from an override is non-BC: `FilterInterface` and
+  `FilterBase` still declare `tips($long = FALSE)` on every Drupal minor below
+  11.4, and PHP rejects a child that *drops* a parameter the parent declares
+  with a fatal at class-declaration time (`Declaration of …::tips() must be
+  compatible with …FilterInterface::tips($long = false)`). Only apply this rule
+  once the consumer's minimum supported Drupal is ≥ 11.4; it must not block
+  Drupal 12 compatibility (on Drupal 12 the parent no longer declares `$long`,
+  so an un-rewritten subclass keeps a harmless extra optional param — phpstan
+  grumbles but it runs). Surfaced by a rejected non-BC change to `token_filter`
+  ([#3603786](https://www.drupal.org/project/token_filter/issues/3603786)).
+  [#3505370](https://www.drupal.org/i/3505370) /
+  [CR](https://www.drupal.org/node/3567879).
 - **`RemoveRouteBuilderDeprecatedArgsRector`** — rewrites the deprecated
   6-argument `new \Drupal\Core\Routing\RouteBuilder(...)` instantiation to the
   new 4-argument form (deprecated in drupal:11.4.0, removed in drupal:12.0.0).
@@ -866,7 +883,6 @@ distinct deprecations in the same minor.
 | `ReplaceEntityReferenceRecursiveLimitRector` | `EntityReferenceEntityFormatter::RECURSIVE_RENDER_LIMIT` → literal `20` | [node/2940605](https://www.drupal.org/node/2940605) |
 | `SystemRegionFunctionsRector` | `system_region_list()` / `system_default_region()` → `theme.region.manager` service | [node/3015812](https://www.drupal.org/node/3015812) |
 | `CheckMarkupToProcessedTextRector` | `check_markup()` → processed-text render array | [node/3588040](https://www.drupal.org/node/3588040) |
-| `RemoveFilterTipsLongParamRector` | `FilterInterface::tips()` — drop the `$long` parameter | [node/3567879](https://www.drupal.org/node/3567879) |
 | `SystemSortThemesRector` | `'system_sort_themes'` string callback → `Closure` (closure callable) | [node/3566774](https://www.drupal.org/node/3566774) |
 | `LocaleCompareIncToServiceRector` | `locale_translation_flush_projects()` / `locale_translation_build_projects()` / `locale_translation_check_projects*()` etc. → `locale.project` and `LocaleSource` services | [node/3037031](https://www.drupal.org/node/3037031) |
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ This is more granular than the `Drupal10SetList::DRUPAL_10` set. Since Drupal 10
 
 ### Composer-based sets (automatic version selection)
 
+> [!WARNING]
+> This feature depends on an unreleased Rector version. Only usable right now using `composer require --dev rector/rector:"dev-main as 2.4.6"`
+
 Instead of listing sets by hand, you can let Rector pick them from the installed
 `drupal/core` version. Register the set provider and enable the `drupal` group:
 

--- a/config/drupal-11/drupal-11.4-breaking.php
+++ b/config/drupal-11/drupal-11.4-breaking.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
  */
 
 use DrupalRector\Drupal11\Rector\Deprecation\BlockContentSelectionExtendsRector;
+use DrupalRector\Drupal11\Rector\Deprecation\RemoveFilterTipsLongParamRector;
 use DrupalRector\Drupal11\Rector\Deprecation\ReplaceNodeViewControllerRector;
 use Rector\Config\RectorConfig;
 use Rector\Renaming\Rector\Name\RenameClassRector;
@@ -115,4 +116,37 @@ return static function (RectorConfig $rectorConfig): void {
     // upgrade_status cannot flag a `class X extends DefaultSelection`
     // declaration. There is no static message to match.
     $rectorConfig->rule(BlockContentSelectionExtendsRector::class);
+
+    // https://www.drupal.org/node/3505370
+    // https://www.drupal.org/node/3567879 (change record)
+    // The $long parameter of FilterInterface::tips() / FilterBase::tips() was
+    // deprecated in drupal:11.4.0 and is removed in drupal:12.0.0. The "filter
+    // tips" long-format page goes away with it.
+    //
+    // RemoveFilterTipsLongParamRector strips $long from a plugin's tips()
+    // override (and drops the second argument from _filter_tips() calls). This
+    // is NOT BC: FilterInterface and FilterBase still declare tips($long = FALSE)
+    // on every Drupal minor below 11.4, and PHP rejects an override that *drops*
+    // a parameter the parent declares with a fatal at class-declaration time:
+    //   "Declaration of MyFilter::tips() must be compatible with
+    //    Drupal\filter\Plugin\FilterInterface::tips($long = false)".
+    // (The reverse — a parent that dropped $long with a subclass that still
+    // declares the optional param — is fine, which is why core can deprecate it
+    // ahead of removal, but a rector that rewrites the *subclass* cannot.)
+    //
+    // So this rule may only be applied once the consumer's minimum supported
+    // Drupal is >= 11.4. It is opt-in here and must NOT block Drupal 12
+    // compatibility: on Drupal 12 the parameter is gone from the parent too, so
+    // the un-rewritten subclass keeps an extra optional param — phpstan will
+    // grumble but it runs. Contrib that still supports Drupal < 11.4 should not
+    // run this rule (it would fatal those sites); see the rejected token_filter
+    // change at https://www.drupal.org/project/token_filter/issues/3603786.
+    //
+    // PHPSTAN_MESSAGES RemoveFilterTipsLongParamRector: the $long parameter is
+    //   annotated `@deprecated in drupal:11.4.0` (a parameter-level deprecation),
+    //   for which phpstan-deprecation-rules emits no discrete message — there is
+    //   no static @deprecated symbol the override references. The runtime
+    //   @trigger_error fires inside core's tips() handling, not at the call site.
+    //   Nothing for upgrade_status to match against.
+    $rectorConfig->rule(RemoveFilterTipsLongParamRector::class);
 };

--- a/config/drupal-11/drupal-11.4-deprecations.php
+++ b/config/drupal-11/drupal-11.4-deprecations.php
@@ -14,7 +14,6 @@ use DrupalRector\Drupal11\Rector\Deprecation\RemoveAutomatedCronSubmitHandlerRec
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveCacheExpireOverrideRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveConfigSaveTrustedDataArgRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveDrupalToStringTraitRector;
-use DrupalRector\Drupal11\Rector\Deprecation\RemoveFilterTipsLongParamRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveInstallSchemaSystemSequencesRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemoveLinkWidgetValidateTitleElementRector;
 use DrupalRector\Drupal11\Rector\Deprecation\RemovePhpUnitCompatibilityTraitRector;
@@ -441,10 +440,12 @@ return static function (RectorConfig $rectorConfig): void {
     // Replaced by a processed_text render array.
     $rectorConfig->rule(CheckMarkupToProcessedTextRector::class);
 
-    // https://www.drupal.org/node/3505370
-    // https://www.drupal.org/node/3567879 (change record)
-    // FilterInterface::tips() $long parameter deprecated in drupal:11.4.0, removed in drupal:12.0.0.
-    $rectorConfig->rule(RemoveFilterTipsLongParamRector::class);
+    // NOTE: RemoveFilterTipsLongParamRector is intentionally NOT registered
+    // here. Removing the $long parameter from a tips() override is non-BC: the
+    // FilterInterface / FilterBase parents still declare tips($long = FALSE) on
+    // every Drupal minor below 11.4, so the narrowed signature fatals there
+    // ("Declaration of ... must be compatible with ..."). It lives in the
+    // opt-in DRUPAL_114_BREAKING set instead (config/drupal-11/drupal-11.4-breaking.php).
 
     // https://www.drupal.org/node/3571172
     // https://www.drupal.org/node/3566774 (change record)


### PR DESCRIPTION
## Problem

`RemoveFilterTipsLongParamRector` was registered in the default Drupal 11.4 deprecation set, but the transformation it performs is **not backward-compatible**.

The rule strips the deprecated `$long` parameter from a filter plugin's `tips()` override. However, `FilterInterface` and `FilterBase` still declare `tips($long = FALSE)` on every Drupal minor **below 11.4**. PHP rejects an override that *drops* a parameter the parent declares, with a fatal at **class-declaration time**:

```
Declaration of MyFilter::tips() must be compatible with
Drupal\filter\Plugin\FilterInterface::tips($long = false)
```

Because it was in the default set, it fired against contrib still supporting Drupal < 11.4 and broke those sites. This was surfaced by a rejected non-BC change to **token_filter** ([#3603786](https://www.drupal.org/project/token_filter/issues/3603786)).

## Fix

Move the rule from the default deprecation set (`drupal-11.4-deprecations.php`) into the opt-in **`DRUPAL_114_BREAKING`** set (`drupal-11.4-breaking.php`), alongside the other non-BC rewrites.

Consequences, documented inline and in the CHANGELOG:

- Apply only once the consumer's **minimum supported Drupal is ≥ 11.4**.
- Must **not block Drupal 12 compatibility** — on D12 the parent no longer declares `$long`, so an un-rewritten subclass simply keeps a harmless extra optional param (phpstan grumbles, but it runs).

The asymmetry is the key point: a *parent* dropping `$long` ahead of a subclass that still declares the optional param is fine (which is how core stages the deprecation), but a rector rewriting the *subclass* to drop it is the fatal direction.

## Scope

- The rector class and its unit test are **unchanged** — the transformation is correct, it was only mis-classified.
- `DrupalSetProvider` (composer-based sets) is intentionally **left untouched**. It still folds `DRUPAL_114_BREAKING` in automatically on an installed 11.4 core, which doesn't account for a module's declared minimum-supported version. Closing that gap belongs in project_analysis, not the set provider.

## Verification

- `php -l` clean on both edited config files.
- `RemoveFilterTipsLongParamRector` test suite: 9 tests, 84 assertions — pass.
- `DrupalSetProviderTest` — pass.
