### PR TITLE
feat: disable BC wrapping by default for composer-based sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ release-by-release.
 
 ## [Unreleased]
 
+### Changed
+
+- **Composer-based sets now disable backward-compatibility wrapping by default.**
+  Composer-based selection pins the rules to the exact installed Drupal version
+  and only loads sets for deprecations live on it, so the rewritten code only ever
+  runs against that one version — there is no older minor to stay compatible with,
+  which makes the `DeprecationHelper` BC wrappers pure noise. The
+  `DrupalRectorSettings` singleton is now registered with BC disabled in
+  `config/drupal-bootstrap.php` (the set matched once per Drupal major by
+  `DrupalSetProvider`). A project that does need the wrappers can re-register the
+  singleton in its own `rector.php`. (Still inert until a Rector release ships the
+  composer-based set support — see beta2.)
+
 ## [1.0.0-beta2] — 2026-06-18
 
 ### Added

--- a/config/drupal-bootstrap.php
+++ b/config/drupal-bootstrap.php
@@ -2,17 +2,18 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Services\DrupalRectorSettings;
 use Rector\Config\RectorConfig;
 
 /**
- * Registers the Drupal PHPUnit bootstrap file.
+ * Composer-based selection defaults: PHPUnit bootstrap + settings.
  *
  * Standalone set used by composer-based selection (see
  * \DrupalRector\Set\DrupalSetProvider). The per-minor deprecation configs do
  * not register the bootstrap themselves — only the aggregated
  * `drupal-{10,11}-all-deprecations.php` sets do. Composer-based selection loads
  * the per-minor configs directly, so this set is matched once per Drupal major
- * (drupal/core ^10.0 and ^11.0) to guarantee the bootstrap is present.
+ * (drupal/core ^10.0 and ^11.0) to guarantee the defaults below are present.
  *
  * Kept separate from the deprecation configs on purpose: the bootstrap file
  * throws when it cannot detect a Drupal installation, and composer-based sets
@@ -24,4 +25,13 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->bootstrapFiles([
         __DIR__.'/drupal-phpunit-bootstrap-file.php',
     ]);
+
+    // Composer-based selection pins the rules to the exact installed Drupal
+    // version and only loads sets for deprecations that are live on it, so the
+    // rewritten code only ever runs against that one version. There is no older
+    // minor to stay compatible with, which makes the DeprecationHelper BC
+    // wrappers pure noise here — disable them by default. (A project that does
+    // need them can re-register this singleton in its own rector.php.)
+    $rectorConfig->singleton(DrupalRectorSettings::class, fn () => (new DrupalRectorSettings())
+        ->disableBackwardCompatibility());
 };


### PR DESCRIPTION
Follow-up to the composer-based sets groundwork shipped in 1.0.0-beta2 (#370, #372).

## Why

Under composer-based selection (`withSetProviders(DrupalSetProvider::class)` + `withComposerBased(drupal: true)`), Rector loads only the sets for deprecations that are live on the **exact** installed `drupal/core` version. The rewritten code therefore only ever runs against that one version — there's no older minor to stay compatible with, so the `DeprecationHelper::backwardsCompatibleCall()` wrappers are pure noise on that path.

Previously nothing registered the `DrupalRectorSettings` singleton on the composer-based path, so it fell back to the class default (BC **enabled**) — the opposite of what makes sense there.

## What

Register the `DrupalRectorSettings` singleton with `disableBackwardCompatibility()` in `config/drupal-bootstrap.php` — the set already matched once per Drupal major by `DrupalSetProvider`, so it's the right place and cardinality. A project that does need the wrappers can re-register the singleton in its own `rector.php`.

## Notes

- Still inert until a Rector release ships `SetGroup::DRUPAL` and the `withComposerBased(drupal: ...)` toggle (same as the rest of the composer-based groundwork).
- CHANGELOG note added under `[Unreleased]`.

## Verification

- PHPUnit: 659 tests, 898 assertions — pass.
- PHPStan: 221 files — no errors.
- `DrupalSetProviderTest`: 8 tests — pass (set file path/matching unchanged).