### PR TITLE
fix: drop message arg when converting assertResponse() to statusCodeEquals()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ release-by-release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Drop the surplus message argument when converting `assertResponse()` to
+  `statusCodeEquals()`. `WebAssert::statusCodeEquals(int $code)` takes no message
+  argument, so the second argument is now removed (matching the existing
+  `assertText`/`assertRaw` handling) [#3332090].
+
 ## [1.0.0-beta3] — 2026-06-22
 
 ### Added

--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -60,7 +60,7 @@ return static function (RectorConfig $rectorConfig): void {
         new AssertLegacyTraitConfiguration('assertHeader', 'responseHeaderEquals'),
         new AssertLegacyTraitConfiguration('assertOptionByText', 'optionExists'),
         new AssertLegacyTraitConfiguration('assertOption', 'optionExists'),
-        new AssertLegacyTraitConfiguration('assertResponse', 'statusCodeEquals'),
+        new AssertLegacyTraitConfiguration('assertResponse', 'statusCodeEquals', '', true, true),
         new AssertLegacyTraitConfiguration('assertTitle', 'titleEquals'),
         new AssertLegacyTraitConfiguration('assertUniqueText', 'pageTextContainsOnce'),
         new AssertLegacyTraitConfiguration('assertUrl', 'addressEquals'),

--- a/fixtures/d9/rector_examples/tests/src/Functional/AssertResponseTest.php
+++ b/fixtures/d9/rector_examples/tests/src/Functional/AssertResponseTest.php
@@ -8,6 +8,7 @@ class AssertResponseTest extends BrowserTestBase {
 
     public function testExample() {
         $this->assertResponse(200);
+        $this->assertResponse(200, 'Some message.');
     }
 
 }

--- a/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertResponseTest.php
+++ b/fixtures/d9/rector_examples_updated/tests/src/Functional/AssertResponseTest.php
@@ -13,6 +13,7 @@ class AssertResponseTest extends BrowserTestBase {
 
     public function testExample() {
         $this->assertSession()->statusCodeEquals(200);
+        $this->assertSession()->statusCodeEquals(200);
     }
 
 }

--- a/tests/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector/config/configured_rule.php
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector/config/configured_rule.php
@@ -24,7 +24,7 @@ return static function (RectorConfig $rectorConfig): void {
         new AssertLegacyTraitConfiguration('assertHeader', 'responseHeaderEquals'),
         new AssertLegacyTraitConfiguration('assertOptionByText', 'optionExists'),
         new AssertLegacyTraitConfiguration('assertOption', 'optionExists'),
-        new AssertLegacyTraitConfiguration('assertResponse', 'statusCodeEquals'),
+        new AssertLegacyTraitConfiguration('assertResponse', 'statusCodeEquals', '', true, true),
         new AssertLegacyTraitConfiguration('assertTitle', 'titleEquals'),
         new AssertLegacyTraitConfiguration('assertUniqueText', 'pageTextContainsOnce'),
         new AssertLegacyTraitConfiguration('assertUrl', 'addressEquals'),

--- a/tests/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector/fixture/assert_response.php.inc
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector/fixture/assert_response.php.inc
@@ -10,6 +10,7 @@ class BrowserTestBaseGetMock extends BrowserTestBase {
     public function example() {
         $this->drupalGet('test-page');
         $this->assertResponse(200);
+        $this->assertResponse(200, 'Some message.');
     }
 }
 ?>
@@ -25,6 +26,7 @@ class BrowserTestBaseGetMock extends BrowserTestBase {
      */
     public function example() {
         $this->drupalGet('test-page');
+        $this->assertSession()->statusCodeEquals(200);
         $this->assertSession()->statusCodeEquals(200);
     }
 }


### PR DESCRIPTION
## Problem

The Drupal 9 `AssertLegacyTrait` rector converts `$this->assertResponse(200, 'message')` to `$this->assertSession()->statusCodeEquals(200, 'message')`. However, `WebAssert::statusCodeEquals(int $code)` takes no message argument, so the surplus argument produces invalid output.

The sibling rules (`assertText`, `assertRaw`, `assertNoText`, `assertNoRaw`) already pass `processFirstArgumentOnly = true` to drop extra arguments; `assertResponse` was missed.

Reported in GitLab issue: https://git.drupalcode.org/project/rector/-/work_items/3332090

## Fix

One-line config change in `config/drupal-9/drupal-9.1-deprecations.php` (and the matching test config):

```diff
-new AssertLegacyTraitConfiguration('assertResponse', 'statusCodeEquals'),
+new AssertLegacyTraitConfiguration('assertResponse', 'statusCodeEquals', '', true, true),
```

The 4th parameter is `isAssertSessionMethod = true` (already the default) and the 5th is `processFirstArgumentOnly = true`, which reduces the call to a single argument.

## Tests

- Added a two-argument case (`$this->assertResponse(200, 'Some message.');` → `$this->assertSession()->statusCodeEquals(200);`) to the PHPUnit fixture `assert_response.php.inc` and to the functional `rector_examples` / `rector_examples_updated` fixtures.
- `./vendor/bin/phpunit --filter AssertLegacyTrait` is green (27 tests, 28 assertions).