### PR TITLE
fix: preserve positional id in annotation-to-attribute conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ release-by-release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`AnnotationToAttributeRector`** — preserve the positional (keyless) value when
+  converting a plugin annotation to an attribute. Previously a bare positional
+  value such as the id in `@FormElement("foo")` or `@ViewsField("id")` was
+  silently dropped, producing `#[FormElement]` with no constructor argument. The
+  value is now emitted as the attribute's first positional argument, with
+  positional arguments ordered before named ones as PHP requires (e.g.
+  `#[FormElement('foo')]` and `#[FormElement('id', label: ...)]`).
+  ([#3579141](https://www.drupal.org/i/3579141),
+  [#3470861](https://www.drupal.org/i/3470861))
+
 ## [1.0.0-beta3] — 2026-06-22
 
 ### Added

--- a/src/Drupal10/Rector/Deprecation/AnnotationToAttributeRector.php
+++ b/src/Drupal10/Rector/Deprecation/AnnotationToAttributeRector.php
@@ -239,7 +239,8 @@ CODE_SAMPLE,
     private function createAttribute(string $attributeClass, array $parsedArgs): Attribute
     {
         $fullyQualified = new FullyQualified($attributeClass);
-        $args = [];
+        $positionalArgs = [];
+        $namedArgs = [];
         foreach ($parsedArgs as $value) {
             if ($value->key == 'deriver') {
                 $arg = $this->nodeFactory->createClassConstFetch($value->value->value, 'class');
@@ -250,15 +251,21 @@ CODE_SAMPLE,
                 $arg = $attribute->value;
             }
 
-            // Sometimes the end ) matches. We need to remove it.
+            // A keyless (positional) annotation value, e.g. the bare plugin id in
+            // `@FormElement("foo")` or `@ViewsField("id")`. Emit it as a positional
+            // constructor argument instead of dropping it. PHP requires positional
+            // arguments before named ones, so collect them separately and merge
+            // positional-first below.
             if ($value->key === null) {
+                $positionalArgs[] = new Arg($arg);
+
                 continue;
             }
 
-            $args[] = new Arg($arg, \false, \false, [], new Node\Identifier($value->key));
+            $namedArgs[] = new Arg($arg, \false, \false, [], new Node\Identifier($value->key));
         }
 
-        return new Attribute($fullyQualified, $args);
+        return new Attribute($fullyQualified, array_merge($positionalArgs, $namedArgs));
     }
 
     public function convertAnnotation(DoctrineAnnotationTagValueNode $value): ?Node\Expr

--- a/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/config/configured_rule.php
+++ b/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/config/configured_rule.php
@@ -12,5 +12,7 @@ return static function (RectorConfig $rectorConfig): void {
         new AnnotationToAttributeConfiguration('10.2.0', '12.0.0', 'Action', 'Drupal\Core\Action\Attribute\Action'),
         new AnnotationToAttributeConfiguration('10.2.0', '12.0.0', 'Block', 'Drupal\Core\Action\Attribute\Block'),
         new AnnotationToAttributeConfiguration('10.2.0', '12.0.0', 'ContentEntityType', 'Drupal\Core\Entity\Attribute\ContentEntityType'),
+        new AnnotationToAttributeConfiguration('10.2.0', '12.0.0', 'FormElement', 'Drupal\Core\Render\Attribute\FormElement'),
+        new AnnotationToAttributeConfiguration('10.2.0', '12.0.0', 'ViewsField', 'Drupal\views\Attribute\ViewsField'),
     ]);
 };

--- a/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/fixture/form_element_positional_and_keyed_fixture.php.inc
+++ b/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/fixture/form_element_positional_and_keyed_fixture.php.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Provides a form element with a positional id and keyed values.
+ *
+ * @FormElement("my_element",
+ *   label = @Translation("My element"),
+ *   type = "system"
+ * )
+ */
+class BasicExample extends ActionBase implements ContainerFactoryPluginInterface {
+
+}
+?>
+
+-----
+<?php
+
+/**
+ * Provides a form element with a positional id and keyed values.
+ *
+ * @FormElement("my_element",
+ *   label = @Translation("My element"),
+ *   type = "system"
+ * )
+ */
+#[\Drupal\Core\Render\Attribute\FormElement('my_element', label: new \Drupal\Core\StringTranslation\TranslatableMarkup('My element'), type: 'system')]
+class BasicExample extends ActionBase implements ContainerFactoryPluginInterface {
+
+}
+?>

--- a/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/fixture/form_element_positional_fixture.php.inc
+++ b/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/fixture/form_element_positional_fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Provides a form element.
+ *
+ * @FormElement("foo_eligible_product_for_current_user_select")
+ */
+class BasicExample extends ActionBase implements ContainerFactoryPluginInterface {
+
+}
+?>
+
+-----
+<?php
+
+/**
+ * Provides a form element.
+ *
+ * @FormElement("foo_eligible_product_for_current_user_select")
+ */
+#[\Drupal\Core\Render\Attribute\FormElement('foo_eligible_product_for_current_user_select')]
+class BasicExample extends ActionBase implements ContainerFactoryPluginInterface {
+
+}
+?>

--- a/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/fixture/views_field_positional_fixture.php.inc
+++ b/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/fixture/views_field_positional_fixture.php.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Provides a views field handler.
+ *
+ * @ViewsField("field_id")
+ */
+class BasicExample extends ActionBase implements ContainerFactoryPluginInterface {
+
+}
+?>
+
+-----
+<?php
+
+/**
+ * Provides a views field handler.
+ *
+ * @ViewsField("field_id")
+ */
+#[\Drupal\views\Attribute\ViewsField('field_id')]
+class BasicExample extends ActionBase implements ContainerFactoryPluginInterface {
+
+}
+?>


### PR DESCRIPTION
When `AnnotationToAttributeRector` converts a Drupal plugin annotation to a PHP attribute, the bare positional (keyless) value was silently dropped.

## The bug

Two GitLab issues, one root cause:

- [#3579141](https://git.drupalcode.org/project/rector/-/work_items/3579141): `@FormElement("foo_eligible_product_for_current_user_select")` converted to `#[\Drupal\Core\Render\Attribute\FormElement]` — the plugin id was lost.
- [#3470861](https://git.drupalcode.org/project/rector/-/work_items/3470861): same problem with single-value annotations like `@ViewsField("id")` losing the id.

## Root cause

In `createAttribute()`, the loop that builds attribute arguments skipped any annotation value with `key === null`:

```php
if ($value->key === null) {
    continue; // dropped the positional value
}
```

A plugin annotation's bare positional value (the `"foo"` in `@FormElement("foo")`) has `key === null`, so it was never emitted as a constructor argument.

## The fix

Instead of skipping keyless values, emit them as positional `Arg`s. Because PHP requires positional arguments before named ones in an attribute, positional and named args are now collected separately and merged positional-first:

- `@FormElement("foo")` → `#[FormElement('foo')]`
- `@FormElement("my_element", label = ..., type = "system")` → `#[FormElement('my_element', label: ..., type: 'system')]`

The existing `deriver` handling and `@Translation` / nested-annotation handling are untouched.

## Tests

Added fixtures to the existing `AnnotationToAttributeRector` test, with `FormElement` and `ViewsField` annotation→attribute mappings added to the test config:

- `form_element_positional_fixture.php.inc` — positional-only id (#3579141)
- `views_field_positional_fixture.php.inc` — single-value positional id (#3470861)
- `form_element_positional_and_keyed_fixture.php.inc` — positional value plus keyed values, proving positional-first ordering

All tests pass: `OK (13 tests, 26 assertions)`.