### PR TITLE
hotfix: MethodToMethodWithCheckRector triggers on `maybe`

### DIFF
--- a/src/Rector/Deprecation/MethodToMethodWithCheckRector.php
+++ b/src/Rector/Deprecation/MethodToMethodWithCheckRector.php
@@ -54,7 +54,7 @@ class MethodToMethodWithCheckRector extends AbstractDrupalCoreRector
         $expectedType = new ObjectType($configuration->getClassName());
 
         $isSuperOf = $expectedType->isSuperTypeOf($callerType);
-        if (!$isSuperOf->yes() && !$isSuperOf->maybe()) {
+        if (!$isSuperOf->yes()) {
             return null;
         }
 

--- a/stubs/Drupal/Drupal.php
+++ b/stubs/Drupal/Drupal.php
@@ -8,4 +8,11 @@ class Drupal {
     const VERSION = '11.99.x-dev';
 
     public static function moduleHandler(): \Drupal\Core\Extension\ModuleHandlerInterface {}
+
+    /**
+     * @param $service
+     *
+     * @return \Drupal\Core\Cache\CacheBackendInterface
+     */
+    public static function service($service): \Drupal\Core\Cache\CacheBackendInterface {}
 }

--- a/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/fixture/cache_invalidate_all_service.php.inc
+++ b/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/fixture/cache_invalidate_all_service.php.inc
@@ -2,12 +2,10 @@
 
 \Drupal::service('cache.render')->invalidateAll();
 
-Drupal::service('cache.render')->invalidateAll();
 ?>
 -----
 <?php
 
 \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('cache.render')->deleteAll(), fn() => \Drupal::service('cache.render')->invalidateAll());
 
-\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => Drupal::service('cache.render')->deleteAll(), fn() => Drupal::service('cache.render')->invalidateAll());
 ?>


### PR DESCRIPTION
In webform this resulted in a problem where a class which was almost the same as the interface got replaced. This needs to be more defensive.