### PR TITLE
fix: capture by-reference arguments in BC-call closures

### DIFF
--- a/.claude/skills/rector-implement/SKILL.md
+++ b/.claude/skills/rector-implement/SKILL.md
@@ -181,6 +181,50 @@ transformation.
 
 ---
 
+### After QG-B: Quality Gate QG-C — By-Reference Parameter Audit (BC-wrapped rectors only)
+
+Apply only if the rector extends `AbstractDrupalCoreRector` and the conversion happens in an
+**expression context** (the call gets wrapped in `DeprecationHelper::backwardsCompatibleCall`).
+This catches the class of bug fixed in `3ac6e255`: the BC wrapper closes over the caller's
+arguments, and an arrow function captures **by value**, so any mutation made through a
+**by-reference parameter** (`&$variables`, `&$form`, `&$element`, …) is silently dropped on the
+rewritten code — breaking the module at runtime (e.g. `template_preprocess_html(&$variables)`).
+
+1. **Check both signatures for `&` parameters.** Look at the replacement target method (the
+   class/method in your `FunctionToServiceConfiguration`) **and** the deprecated function, in
+   `repos/drupal-core`:
+   ```bash
+   rg -n 'function preprocessHtml|function template_preprocess_html' repos/drupal-core/core
+   ```
+   If neither has a `&$param`, this gate is N/A — done.
+
+2. **If a by-reference parameter exists**, `AbstractDrupalCoreRector` handles it automatically by
+   reflecting the **target service method**, but only when that method is reflectable at runtime.
+   So you must:
+   - **Add a classmap stub** under `stubs/Drupal/...` for the target class, with `&` at the exact
+     by-ref positions (drop type hints — `isPassedByReference()` does not need them) **and the
+     correct return type** (see step 3). Guard it with `if (class_exists(\FQCN::class)) { return; }`.
+     Run `ddev composer dump-autoload` after adding stubs.
+   - **Add/extend a fixture** that proves the output is a long closure capturing the variable by
+     reference, e.g. `function () use (&$variables) { … }` for **both** the new and old branches —
+     not `fn() => …`.
+
+3. **Void vs value — the closure body.** PHPStan flags `return <void-expr>;` as `function.void`
+   at every level (but allows a bare expression statement and an arrow function's implicit return).
+   So the wrapper emits `return <expr>;` only when the target method returns a value, and a bare
+   `<expr>;` statement when it returns `void`. The decision is made by reflecting the **target
+   method's return type**, so the stub's return type must match core (`: void` for preprocess and
+   most form callbacks; `: array` etc. for value-returning ones). Your fixture must reflect this:
+   void target → no `return` in the closure body; value target → `return`.
+
+4. **Verify**: `ddev exec vendor/bin/phpunit --filter <RectorName>` is green, and a quick
+   `vendor/bin/phpstan analyse --level=0` on a sample of the generated output shows no
+   `function.void`.
+
+See `project_byref_bc_wrapper_fix` in memory for the full mechanism.
+
+---
+
 ### After Step 14: Record the implemented digest
 
 `docs/implemented-digests.yml` is the **authoritative, hand-maintained** record of
@@ -232,10 +276,11 @@ Before declaring the implementation complete, verify all items from `.claude/ski
 - [ ] QG-A: `isObjectType()` guard present for all MethodCall/PropertyFetch nodes (or explicitly not needed)
 - [ ] QG-A: `no_change_unrelated.php.inc` fixture exists if a type guard was added
 - [ ] QG-B: `testAboveVersion()` + `testBelowVersion()` (with `DrupalRectorSettings::setDrupalVersion`) and `fixture-below-version/basic.php.inc` present if BC-wrapped
+- [ ] QG-C: by-reference parameters on the target/deprecated function checked; if present, stub (`&` positions + return type) and long-closure fixture added (or explicitly N/A)
 - [ ] `vendor/bin/phpunit tests/src/Drupal11/Rector/Deprecation/[ClassName]/` passes
 - [ ] `ddev composer phpstan` reports no new errors
 - [ ] `ddev composer fix-style` produces no changes
-- [ ] rector-qa reports **Overall: PASS** (all four passes green)
+- [ ] rector-qa reports **Overall: PASS** (all passes green)
 - [ ] Digest recorded in `docs/implemented-digests.yml` (append-only source of truth)
 
 ## Quick Reference: Phase 1 (config-only) path

--- a/.claude/skills/rector-qa/SKILL.md
+++ b/.claude/skills/rector-qa/SKILL.md
@@ -360,9 +360,46 @@ Reference case: `PhpUnitTestAnnotationToAttributeRector` and
 
 ---
 
+## Pass 7 — By-Reference Capture Audit
+
+**Goal:** a BC-wrapped conversion of a call whose target takes a parameter
+**by reference** must wrap it in a long closure that captures the variable by
+reference (`function () use (&$var) { … }`), **not** an arrow function. Arrow
+functions capture by value, so the `&$` mutation is silently dropped and the
+rewritten module breaks at runtime (the webform render/form test failures that
+prompted fix `3ac6e255`).
+
+**Applies only** to rectors extending `AbstractDrupalCoreRector` whose conversion is
+in an expression context (`FunctionToServiceRector`, `MethodToMethodRector`, …).
+
+**Steps:**
+
+1. Identify the replacement target (class + method) and the deprecated function.
+   If neither has a `&$param` in `repos/drupal-core` → **N/A**.
+   ```bash
+   rg -n 'function <targetMethod>|function <deprecated_function>' repos/drupal-core/core
+   ```
+2. If a by-ref parameter exists, confirm:
+   - a classmap stub for the target class exists under `stubs/Drupal/...` with `&` at
+     the correct positions **and** a return type matching core; and
+   - a fixture asserts the output is a long `function () use (&$var) {` closure (both
+     branches), with the closure body being a bare `<expr>;` for a `void` target or
+     `return <expr>;` for a value-returning one.
+   Missing stub or fixture → **AT-RISK**.
+3. **Prove** it: `ddev exec vendor/bin/phpunit --filter <RectorName>` and a quick
+   `phpstan analyse --level=0` of a sample output showing no `function.void`.
+
+**Output:** `Pass 7: [SAFE|AT-RISK|N/A] — <note>`
+
+**If AT-RISK:** add the stub (correct `&` positions + return type), regenerate the
+autoloader (`ddev composer dump-autoload`), and add the closure fixture. See
+`project_byref_bc_wrapper_fix` in memory.
+
+---
+
 ## Final Summary
 
-After all six passes, produce a summary checklist:
+After all seven passes, produce a summary checklist:
 
 ```
 === QA Summary: <ClassName> ===
@@ -373,6 +410,7 @@ Pass 3 — BC Decision:   [PASS|FAIL] — <note>
 Pass 4 — @see URL:      [PASS|WARN|FAIL] — issue:<n> CR:<n> — <present/missing>
 Pass 5 — Registration:  [PASS|FAIL] — <note>
 Pass 6 — Common Bugs:   [SAFE|AT-RISK|N/A] — <note>
+Pass 7 — By-Reference:  [SAFE|AT-RISK|N/A] — <note>
 
 Overall: [PASS — ready to merge | NEEDS FIXES — see above]
 ```
@@ -383,4 +421,4 @@ If any pass shows AT-RISK or FAIL, do not declare the rector ready to merge. App
 
 ## Running on a "known good" rector
 
-To verify the skill works correctly, run it on `ReplaceSessionManagerDeleteRector` — all six passes should be PASS/SAFE/N-A.
+To verify the skill works correctly, run it on `ReplaceSessionManagerDeleteRector` — all seven passes should be PASS/SAFE/N-A.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ release-by-release.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Backward-compatible call wrapping** — when a deprecation replacement passes a
+  variable to a *by-reference* parameter (`template_preprocess_html(&$variables)`,
+  form `*_process`/`*_validate`/`*_builder` callbacks with `&$form`,
+  `views_add_contextual_links(&$render_element)`, …), the generated
+  `DeprecationHelper::backwardsCompatibleCall()` now wraps the call in a long
+  closure that captures the variable by reference (`function () use (&$var) { … }`)
+  instead of an arrow function. Arrow functions capture by value, so a mutation
+  made through the reference was silently dropped — breaking, for example, webform
+  render and form-handling tests. By-reference parameters are detected by
+  reflecting the replacement service method, so the fix is automatic for every
+  affected deprecation. Closures wrapping a `void` target emit a bare expression
+  statement instead of `return <expr>;`, avoiding PHPStan's `function.void`.
+
 ## [1.0.0-beta6] — 2026-06-24
 
 ### Fixed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -553,7 +553,7 @@ parameters:
 			path: src/Drupal9/Rector/Deprecation/PassRector.php
 
 		-
-			message: '#^Parameter \#3 \$args of method Rector\\PhpParser\\Node\\NodeFactory\:\:createStaticCall\(\) expects array\<PhpParser\\Node\>, array\<int, PhpParser\\Node\\Expr\\ArrowFunction\|PhpParser\\Node\\Expr\\ClassConstFetch\|string\> given\.$#'
+			message: '#^Parameter \#3 \$args of method Rector\\PhpParser\\Node\\NodeFactory\:\:createStaticCall\(\) expects array\<PhpParser\\Node\>, array\<int, PhpParser\\Node\\Expr\\ArrowFunction\|PhpParser\\Node\\Expr\\ClassConstFetch\|PhpParser\\Node\\Expr\\Closure\|string\> given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/Rector/AbstractDrupalCoreRector.php

--- a/src/Rector/AbstractDrupalCoreRector.php
+++ b/src/Rector/AbstractDrupalCoreRector.php
@@ -6,9 +6,14 @@ namespace DrupalRector\Rector;
 
 use Drupal\Component\Utility\DeprecationHelper;
 use DrupalRector\Contract\VersionedConfigurationInterface;
+use DrupalRector\Rector\ValueObject\FunctionToServiceConfiguration;
 use DrupalRector\Services\DrupalRectorSettings;
 use PhpParser\Node;
+use PhpParser\Node\ClosureUse;
 use PhpParser\Node\Expr\ArrowFunction;
+use PhpParser\Node\Expr\Closure;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Stmt\Return_;
 use PHPStan\Reflection\MethodReflection;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
@@ -90,7 +95,7 @@ abstract class AbstractDrupalCoreRector extends AbstractRector implements Config
             }
 
             if ($node instanceof Node\Expr && $result instanceof Node\Expr) {
-                return $this->createBcCallOnExpr($node, $result, $configuration->getIntroducedVersion());
+                return $this->createBcCallOnExpr($node, $result, $configuration);
             }
 
             return $result;
@@ -106,16 +111,217 @@ abstract class AbstractDrupalCoreRector extends AbstractRector implements Config
      */
     abstract protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration);
 
-    protected function createBcCallOnExpr(Node\Expr $node, Node\Expr $result, string $introducedVersion): Node\Expr\StaticCall
+    /**
+     * @param VersionedConfigurationInterface|string $configuration the matched
+     *                                                              configuration, or — for callers that replace constants and have no call
+     *                                                              arguments to worry about — the introduced version string directly
+     */
+    protected function createBcCallOnExpr(Node\Expr $node, Node\Expr $result, $configuration): Node\Expr\StaticCall
     {
+        $introducedVersion = $configuration instanceof VersionedConfigurationInterface
+            ? $configuration->getIntroducedVersion()
+            : $configuration;
+        $configuration = $configuration instanceof VersionedConfigurationInterface ? $configuration : null;
+
         $clonedNode = clone $node;
+
+        // DeprecationHelper::backwardsCompatibleCall() invokes the callables with
+        // no arguments, so they have to close over the call's arguments. An arrow
+        // function captures by value, which silently drops any mutation made
+        // through a by-reference parameter (e.g. template_preprocess_html(&$variables)).
+        // When the call passes a local variable to a by-reference parameter we
+        // therefore emit a long closure that captures that variable by reference;
+        // otherwise we keep the cleaner arrow function.
+        $byRefVariables = $this->collectByReferenceArgumentVariables($node, $configuration);
+
+        if ($byRefVariables === []) {
+            $newCallable = new ArrowFunction(['expr' => $result]);
+            $oldCallable = new ArrowFunction(['expr' => $clonedNode]);
+        } else {
+            // PHPStan flags `return <void-expr>;` (function.void) at every level,
+            // but allows the same call as a bare expression statement — exactly
+            // what an arrow function's implicit return is treated as. Only return
+            // a value when the replacement method actually produces one.
+            $returnsValue = !$this->serviceMethodReturnsVoid($configuration);
+            $newCallable = $this->createByReferenceClosure($result, $byRefVariables, $returnsValue);
+            $oldCallable = $this->createByReferenceClosure($clonedNode, $byRefVariables, $returnsValue);
+        }
 
         return $this->nodeFactory->createStaticCall(DeprecationHelper::class, 'backwardsCompatibleCall', [
             $this->nodeFactory->createClassConstFetch(\Drupal::class, 'VERSION'),
             $introducedVersion,
-            new ArrowFunction(['expr' => $result]),
-            new ArrowFunction(['expr' => $clonedNode]),
+            $newCallable,
+            $oldCallable,
         ]);
+    }
+
+    /**
+     * Builds a `function () use (&$a, &$b) { <expr>; }` closure.
+     *
+     * When $returnsValue is true the body is `return <expr>;`, otherwise it is
+     * the bare expression statement `<expr>;` so PHPStan does not flag the use
+     * of a void result (function.void).
+     *
+     * @param string[] $variableNames
+     */
+    private function createByReferenceClosure(Node\Expr $expr, array $variableNames, bool $returnsValue): Closure
+    {
+        $uses = array_map(
+            static fn (string $name): ClosureUse => new ClosureUse(new Node\Expr\Variable($name), true),
+            $variableNames
+        );
+
+        $statement = $returnsValue ? new Return_($expr) : new Expression($expr);
+
+        return new Closure([
+            'uses' => $uses,
+            'stmts' => [$statement],
+        ]);
+    }
+
+    /**
+     * Whether the replacement service method is declared to return void.
+     *
+     * A long closure is only ever emitted once a real, reflectable class method
+     * has been found (by-reference detection requires it), so the return type is
+     * reliably available here. Anything other than an explicit `void` return
+     * type — including an undeclared return type — keeps the `return` so a real
+     * value is never silently dropped; PHPStan only flags function.void when it
+     * actually knows the call is void.
+     */
+    private function serviceMethodReturnsVoid(?VersionedConfigurationInterface $configuration): bool
+    {
+        if (!$configuration instanceof FunctionToServiceConfiguration) {
+            return false;
+        }
+
+        $className = $configuration->getServiceName();
+        $methodName = $configuration->getServiceMethodName();
+        if (!class_exists($className) || !method_exists($className, $methodName)) {
+            return false;
+        }
+
+        try {
+            $returnType = (new \ReflectionMethod($className, $methodName))->getReturnType();
+        } catch (\ReflectionException) {
+            return false;
+        }
+
+        return $returnType instanceof \ReflectionNamedType && $returnType->getName() === 'void';
+    }
+
+    /**
+     * Returns the local variables passed to a by-reference parameter of the call.
+     *
+     * The by-reference parameters are collected from both the original
+     * (deprecated) callable and the replacement callable, so a mutation is
+     * preserved whichever branch DeprecationHelper picks. Capturing a variable
+     * that is actually consumed by value is harmless: the closure body is a
+     * single expression and never reassigns the variable.
+     *
+     * @return string[] the names of the local variables to capture by reference
+     */
+    private function collectByReferenceArgumentVariables(Node\Expr $node, ?VersionedConfigurationInterface $configuration): array
+    {
+        if (!$node instanceof Node\Expr\CallLike) {
+            return [];
+        }
+
+        $byRefPositions = [];
+
+        // Replacement service method: when the target is a fully-qualified class
+        // name (rather than a container service id) it is a real class, reliably
+        // reflectable. reflectByReferenceParameterPositions() guards class_exists(),
+        // so service ids such as 'file.repository' just yield nothing here.
+        if ($configuration instanceof FunctionToServiceConfiguration) {
+            foreach ($this->reflectByReferenceParameterPositions($configuration->getServiceName(), $configuration->getServiceMethodName()) as $position) {
+                $byRefPositions[$position] = true;
+            }
+        }
+
+        // Original deprecated function: best-effort, procedural functions are
+        // frequently not autoloadable during a Rector run.
+        if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name) {
+            $functionName = $node->name->toString();
+            if (function_exists($functionName)) {
+                try {
+                    foreach ((new \ReflectionFunction($functionName))->getParameters() as $position => $parameter) {
+                        if ($parameter->isPassedByReference()) {
+                            $byRefPositions[$position] = true;
+                        }
+                    }
+                } catch (\ReflectionException) {
+                    // Ignore: fall back to whatever the replacement told us.
+                }
+            }
+        }
+
+        if ($byRefPositions === []) {
+            return [];
+        }
+
+        $variableNames = [];
+        foreach ($node->getArgs() as $position => $arg) {
+            if (!isset($byRefPositions[$position])) {
+                continue;
+            }
+            $rootVariable = $this->resolveRootVariableName($arg->value);
+            if ($rootVariable !== null) {
+                $variableNames[$rootVariable] = $rootVariable;
+            }
+        }
+
+        return array_values($variableNames);
+    }
+
+    /**
+     * @return int[] zero-based positions of by-reference parameters
+     */
+    private function reflectByReferenceParameterPositions(string $className, string $methodName): array
+    {
+        if (!class_exists($className) || !method_exists($className, $methodName)) {
+            return [];
+        }
+
+        try {
+            $method = new \ReflectionMethod($className, $methodName);
+        } catch (\ReflectionException) {
+            return [];
+        }
+
+        $positions = [];
+        foreach ($method->getParameters() as $position => $parameter) {
+            if ($parameter->isPassedByReference()) {
+                $positions[] = $position;
+            }
+        }
+
+        return $positions;
+    }
+
+    /**
+     * Returns the name of the local variable an argument is rooted at.
+     *
+     * `$variables`, `$variables['x']` and `$obj->prop` (rooted at `$obj`) all
+     * resolve to that local variable. `$this->prop` returns null: the object is
+     * shared with the closure regardless of capture, so an arrow function would
+     * preserve the mutation anyway.
+     */
+    private function resolveRootVariableName(Node\Expr $expr): ?string
+    {
+        while (
+            $expr instanceof Node\Expr\ArrayDimFetch
+            || $expr instanceof Node\Expr\PropertyFetch
+            || $expr instanceof Node\Expr\NullsafePropertyFetch
+        ) {
+            $expr = $expr->var;
+        }
+
+        if ($expr instanceof Node\Expr\Variable && is_string($expr->name) && $expr->name !== 'this') {
+            return $expr->name;
+        }
+
+        return null;
     }
 
     /**

--- a/src/Rector/Deprecation/DeprecationHelperRemoveRector.php
+++ b/src/Rector/Deprecation/DeprecationHelperRemoveRector.php
@@ -90,6 +90,21 @@ CODE_AFTER,
             if ($newCall instanceof Node\Expr\ArrowFunction) {
                 return $newCall->expr;
             }
+
+            // By-reference calls are wrapped in a long closure (see
+            // AbstractDrupalCoreRector::createBcCallOnExpr) so the mutation is
+            // preserved. Unwrap it to its single statement: `return <expr>;` for
+            // value-returning targets, or a bare `<expr>;` for void ones.
+            if ($newCall instanceof Node\Expr\Closure) {
+                foreach ($newCall->stmts as $stmt) {
+                    if ($stmt instanceof Node\Stmt\Return_ && $stmt->expr !== null) {
+                        return $stmt->expr;
+                    }
+                    if ($stmt instanceof Node\Stmt\Expression) {
+                        return $stmt->expr;
+                    }
+                }
+            }
         }
 
         return null;

--- a/stubs/Drupal/Core/Breadcrumb/BreadcrumbPreprocess.php
+++ b/stubs/Drupal/Core/Breadcrumb/BreadcrumbPreprocess.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Breadcrumb;
+
+if (class_exists(\Drupal\Core\Breadcrumb\BreadcrumbPreprocess::class)) {
+    return;
+}
+
+class BreadcrumbPreprocess
+{
+    public function preprocessBreadcrumb(&$variables): void {}
+}

--- a/stubs/Drupal/Core/Datetime/DatePreprocess.php
+++ b/stubs/Drupal/Core/Datetime/DatePreprocess.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Datetime;
+
+if (class_exists(\Drupal\Core\Datetime\DatePreprocess::class)) {
+    return;
+}
+
+class DatePreprocess
+{
+    public function preprocessTime(&$variables): void {}
+
+    public function preprocessDatetimeForm(&$variables): void {}
+
+    public function preprocessDatetimeWrapper(&$variables): void {}
+}

--- a/stubs/Drupal/Core/Field/FieldPreprocess.php
+++ b/stubs/Drupal/Core/Field/FieldPreprocess.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Field;
+
+if (class_exists(\Drupal\Core\Field\FieldPreprocess::class)) {
+    return;
+}
+
+class FieldPreprocess
+{
+    public function preprocessField(&$variables): void {}
+
+    public function preprocessFieldMultipleValueForm(&$variables): void {}
+}

--- a/stubs/Drupal/Core/Menu/MenuPreprocess.php
+++ b/stubs/Drupal/Core/Menu/MenuPreprocess.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Menu;
+
+if (class_exists(\Drupal\Core\Menu\MenuPreprocess::class)) {
+    return;
+}
+
+class MenuPreprocess
+{
+    public function preprocessMenuLocalTask(&$variables): void {}
+
+    public function preprocessMenuLocalAction(&$variables): void {}
+}

--- a/stubs/Drupal/Core/Pager/PagerPreprocess.php
+++ b/stubs/Drupal/Core/Pager/PagerPreprocess.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Pager;
+
+if (class_exists(\Drupal\Core\Pager\PagerPreprocess::class)) {
+    return;
+}
+
+class PagerPreprocess
+{
+    public function preprocessPager(&$variables): void {}
+}

--- a/stubs/Drupal/Core/Theme/ImagePreprocess.php
+++ b/stubs/Drupal/Core/Theme/ImagePreprocess.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Theme;
+
+if (class_exists(\Drupal\Core\Theme\ImagePreprocess::class)) {
+    return;
+}
+
+class ImagePreprocess
+{
+    public function preprocessImage(&$variables): void {}
+}

--- a/stubs/Drupal/Core/Theme/ThemePreprocess.php
+++ b/stubs/Drupal/Core/Theme/ThemePreprocess.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Core\Theme;
+
+if (class_exists(\Drupal\Core\Theme\ThemePreprocess::class)) {
+    return;
+}
+
+class ThemePreprocess
+{
+    public function preprocessContainer(&$variables): void {}
+
+    public function preprocessLinks(&$variables): void {}
+
+    public function preprocessHtml(&$variables): void {}
+
+    public function preprocessPage(&$variables): void {}
+
+    public function preprocessTable(&$variables): void {}
+
+    public function preprocessTablesortIndicator(&$variables): void {}
+
+    public function preprocessItemList(&$variables): void {}
+
+    public function preprocessRegion(&$variables): void {}
+
+    public function preprocessMaintenancePage(&$variables): void {}
+
+    public function preprocessMaintenanceTaskList(&$variables): void {}
+
+    public function preprocessInstallPage(&$variables): void {}
+}

--- a/stubs/Drupal/content_translation/ContentTranslationEnableTranslationPerBundle.php
+++ b/stubs/Drupal/content_translation/ContentTranslationEnableTranslationPerBundle.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\content_translation;
+
+if (class_exists(\Drupal\content_translation\ContentTranslationEnableTranslationPerBundle::class)) {
+    return;
+}
+
+class ContentTranslationEnableTranslationPerBundle
+{
+    public function getWidget($entityTypeId, $bundle, &$form, $formState): array { return []; }
+
+    public function configElementProcess($element, $formState, &$form): array { return []; }
+
+    public function configElementValidate($element, $formState, &$form): void {}
+
+    public function configElementSubmit($form, $formState): void {}
+}

--- a/stubs/Drupal/content_translation/Hook/ContentTranslationHooks.php
+++ b/stubs/Drupal/content_translation/Hook/ContentTranslationHooks.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\content_translation\Hook;
+
+if (class_exists(\Drupal\content_translation\Hook\ContentTranslationHooks::class)) {
+    return;
+}
+
+class ContentTranslationHooks
+{
+    public function installFieldStorageDefinitions($entityTypeId): void {}
+}

--- a/stubs/Drupal/layout_discovery/Hook/LayoutDiscoveryThemeHooks.php
+++ b/stubs/Drupal/layout_discovery/Hook/LayoutDiscoveryThemeHooks.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\layout_discovery\Hook;
+
+if (class_exists(\Drupal\layout_discovery\Hook\LayoutDiscoveryThemeHooks::class)) {
+    return;
+}
+
+class LayoutDiscoveryThemeHooks
+{
+    public function preprocessLayout(&$variables): void {}
+}

--- a/stubs/Drupal/media_library/Hook/MediaLibraryHooks.php
+++ b/stubs/Drupal/media_library/Hook/MediaLibraryHooks.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\media_library\Hook;
+
+if (class_exists(\Drupal\media_library\Hook\MediaLibraryHooks::class)) {
+    return;
+}
+
+class MediaLibraryHooks
+{
+    public function mediaTypeFormSubmit(&$form, $formState): void {}
+
+    public function viewsFormAfterBuild($form, $formState) {}
+}

--- a/stubs/Drupal/menu_ui/Hook/MenuUiHooks.php
+++ b/stubs/Drupal/menu_ui/Hook/MenuUiHooks.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\menu_ui\Hook;
+
+if (class_exists(\Drupal\menu_ui\Hook\MenuUiHooks::class)) {
+    return;
+}
+
+class MenuUiHooks
+{
+    public function nodeBuilder($entityType, $entity, &$form, $formState): void {}
+
+    public function formNodeFormSubmit($form, $formState): void {}
+
+    public function formNodeTypeFormValidate(&$form, $formState): void {}
+
+    public function formNodeTypeFormBuilder($entityType, $type, &$form, $formState): void {}
+}

--- a/stubs/Drupal/menu_ui/MenuUiUtility.php
+++ b/stubs/Drupal/menu_ui/MenuUiUtility.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\menu_ui;
+
+if (class_exists(\Drupal\menu_ui\MenuUiUtility::class)) {
+    return;
+}
+
+class MenuUiUtility
+{
+    public function menuUiNodeSave($node, $values): void {}
+
+    public function getMenuLinkDefaults($node) {}
+}

--- a/stubs/Drupal/views/ContextualLinksHelper.php
+++ b/stubs/Drupal/views/ContextualLinksHelper.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\views;
+
+if (class_exists(\Drupal\views\ContextualLinksHelper::class)) {
+    return;
+}
+
+class ContextualLinksHelper
+{
+    public function addLinks(&$renderElement, $location, $displayId, $viewElement = NULL): void {}
+}

--- a/tests/src/Rector/Deprecation/DeprecationHelperRemoveRector/fixture/by_reference_closure.php.inc
+++ b/tests/src/Rector/Deprecation/DeprecationHelperRemoveRector/fixture/by_reference_closure.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+function example(&$variables)
+{
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '9.1.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessHtml($variables);
+    }, function () use (&$variables) {
+        template_preprocess_html($variables);
+    });
+}
+
+?>
+-----
+<?php
+
+function example(&$variables)
+{
+    \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessHtml($variables);
+}
+
+?>

--- a/tests/src/Rector/Deprecation/DeprecationHelperRemoveRector/fixture/by_reference_closure_with_return.php.inc
+++ b/tests/src/Rector/Deprecation/DeprecationHelperRemoveRector/fixture/by_reference_closure_with_return.php.inc
@@ -1,0 +1,21 @@
+<?php
+
+function example($entity_type, $bundle, &$form, $form_state)
+{
+    $form = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '9.1.0', function () use (&$form) {
+        return \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->getWidget($entity_type, $bundle, $form, $form_state);
+    }, function () use (&$form) {
+        return content_translation_enable_widget($entity_type, $bundle, $form, $form_state);
+    });
+}
+
+?>
+-----
+<?php
+
+function example($entity_type, $bundle, &$form, $form_state)
+{
+    $form = \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->getWidget($entity_type, $bundle, $form, $form_state);
+}
+
+?>

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/content_translation_procedural_functions.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/content_translation_procedural_functions.php.inc
@@ -14,9 +14,21 @@ function example($entity, $entity_type, $bundle, $form, $form_state, $element, $
 
 function example($entity, $entity_type, $bundle, $form, $form_state, $element, $entity_type_id) {
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('content_translation.manager')->access($entity), fn() => content_translation_translate_access($entity));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->getWidget($entity_type, $bundle, $form, $form_state), fn() => content_translation_enable_widget($entity_type, $bundle, $form, $form_state));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->configElementProcess($element, $form_state, $form), fn() => content_translation_language_configuration_element_process($element, $form_state, $form));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->configElementValidate($element, $form_state, $form), fn() => content_translation_language_configuration_element_validate($element, $form_state, $form));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form) {
+        return \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->getWidget($entity_type, $bundle, $form, $form_state);
+    }, function () use (&$form) {
+        return content_translation_enable_widget($entity_type, $bundle, $form, $form_state);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form) {
+        return \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->configElementProcess($element, $form_state, $form);
+    }, function () use (&$form) {
+        return content_translation_language_configuration_element_process($element, $form_state, $form);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form) {
+        \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->configElementValidate($element, $form_state, $form);
+    }, function () use (&$form) {
+        content_translation_language_configuration_element_validate($element, $form_state, $form);
+    });
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\content_translation\ContentTranslationEnableTranslationPerBundle')->configElementSubmit($form, $form_state), fn() => content_translation_language_configuration_element_submit($form, $form_state));
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\content_translation\Hook\ContentTranslationHooks')->installFieldStorageDefinitions($entity_type_id), fn() => _content_translation_install_field_storage_definitions($entity_type_id));
 }

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/media_library_procedural_functions.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/media_library_procedural_functions.php.inc
@@ -9,7 +9,11 @@ function example($form, $form_state) {
 <?php
 
 function example($form, $form_state) {
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\media_library\Hook\MediaLibraryHooks::class)->mediaTypeFormSubmit($form, $form_state), fn() => _media_library_media_type_form_submit($form, $form_state));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form) {
+        \Drupal::service(\Drupal\media_library\Hook\MediaLibraryHooks::class)->mediaTypeFormSubmit($form, $form_state);
+    }, function () use (&$form) {
+        _media_library_media_type_form_submit($form, $form_state);
+    });
     $result = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\media_library\Hook\MediaLibraryHooks::class)->viewsFormAfterBuild($form, $form_state), fn() => _media_library_views_form_media_library_after_build($form, $form_state));
 }
 ?>

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/menu_ui_procedural_functions.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/menu_ui_procedural_functions.php.inc
@@ -15,9 +15,21 @@ function example($node, $values, $form, $form_state) {
 function example($node, $values, $form, $form_state) {
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\menu_ui\MenuUiUtility')->menuUiNodeSave($node, $values), fn() => _menu_ui_node_save($node, $values));
     $defaults = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\menu_ui\MenuUiUtility')->getMenuLinkDefaults($node), fn() => menu_ui_get_menu_link_defaults($node));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->nodeBuilder($node, $form, $form_state), fn() => menu_ui_node_builder($node, $form, $form_state));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form_state) {
+        \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->nodeBuilder($node, $form, $form_state);
+    }, function () use (&$form_state) {
+        menu_ui_node_builder($node, $form, $form_state);
+    });
     \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->formNodeFormSubmit($form, $form_state), fn() => menu_ui_form_node_form_submit($form, $form_state));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->formNodeTypeFormValidate($form, $form_state), fn() => menu_ui_form_node_type_form_validate($form, $form_state));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->formNodeTypeFormBuilder($node, $form, $form_state), fn() => menu_ui_form_node_type_form_builder($node, $form, $form_state));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form) {
+        \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->formNodeTypeFormValidate($form, $form_state);
+    }, function () use (&$form) {
+        menu_ui_form_node_type_form_validate($form, $form_state);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$form_state) {
+        \Drupal::service('Drupal\menu_ui\Hook\MenuUiHooks')->formNodeTypeFormBuilder($node, $form, $form_state);
+    }, function () use (&$form_state) {
+        menu_ui_form_node_type_form_builder($node, $form, $form_state);
+    });
 }
 ?>

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_3504125.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_3504125.php.inc
@@ -21,19 +21,75 @@ function example(&$variables) {
 <?php
 
 function example(&$variables) {
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessTable($variables), fn() => template_preprocess_table($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessTablesortIndicator($variables), fn() => template_preprocess_tablesort_indicator($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessItemList($variables), fn() => template_preprocess_item_list($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessRegion($variables), fn() => template_preprocess_region($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessMaintenancePage($variables), fn() => template_preprocess_maintenance_page($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessMaintenanceTaskList($variables), fn() => template_preprocess_maintenance_task_list($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessInstallPage($variables), fn() => template_preprocess_install_page($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Theme\ImagePreprocess')->preprocessImage($variables), fn() => template_preprocess_image($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Breadcrumb\BreadcrumbPreprocess')->preprocessBreadcrumb($variables), fn() => template_preprocess_breadcrumb($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Pager\PagerPreprocess')->preprocessPager($variables), fn() => template_preprocess_pager($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Field\FieldPreprocess')->preprocessField($variables), fn() => template_preprocess_field($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Field\FieldPreprocess')->preprocessFieldMultipleValueForm($variables), fn() => template_preprocess_field_multiple_value_form($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Menu\MenuPreprocess')->preprocessMenuLocalTask($variables), fn() => template_preprocess_menu_local_task($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service('Drupal\Core\Menu\MenuPreprocess')->preprocessMenuLocalAction($variables), fn() => template_preprocess_menu_local_action($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessTable($variables);
+    }, function () use (&$variables) {
+        template_preprocess_table($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessTablesortIndicator($variables);
+    }, function () use (&$variables) {
+        template_preprocess_tablesort_indicator($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessItemList($variables);
+    }, function () use (&$variables) {
+        template_preprocess_item_list($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessRegion($variables);
+    }, function () use (&$variables) {
+        template_preprocess_region($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessMaintenancePage($variables);
+    }, function () use (&$variables) {
+        template_preprocess_maintenance_page($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessMaintenanceTaskList($variables);
+    }, function () use (&$variables) {
+        template_preprocess_maintenance_task_list($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessInstallPage($variables);
+    }, function () use (&$variables) {
+        template_preprocess_install_page($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ImagePreprocess')->preprocessImage($variables);
+    }, function () use (&$variables) {
+        template_preprocess_image($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Breadcrumb\BreadcrumbPreprocess')->preprocessBreadcrumb($variables);
+    }, function () use (&$variables) {
+        template_preprocess_breadcrumb($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Pager\PagerPreprocess')->preprocessPager($variables);
+    }, function () use (&$variables) {
+        template_preprocess_pager($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Field\FieldPreprocess')->preprocessField($variables);
+    }, function () use (&$variables) {
+        template_preprocess_field($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Field\FieldPreprocess')->preprocessFieldMultipleValueForm($variables);
+    }, function () use (&$variables) {
+        template_preprocess_field_multiple_value_form($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Menu\MenuPreprocess')->preprocessMenuLocalTask($variables);
+    }, function () use (&$variables) {
+        template_preprocess_menu_local_task($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Menu\MenuPreprocess')->preprocessMenuLocalAction($variables);
+    }, function () use (&$variables) {
+        template_preprocess_menu_local_action($variables);
+    });
 }
 ?>

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_layout.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_layout.php.inc
@@ -8,6 +8,10 @@ function my_preprocess(&$variables) {
 <?php
 
 function my_preprocess(&$variables) {
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => \Drupal::service(\Drupal\layout_discovery\Hook\LayoutDiscoveryThemeHooks::class)->preprocessLayout($variables), fn() => template_preprocess_layout($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', function () use (&$variables) {
+        \Drupal::service(\Drupal\layout_discovery\Hook\LayoutDiscoveryThemeHooks::class)->preprocessLayout($variables);
+    }, function () use (&$variables) {
+        template_preprocess_layout($variables);
+    });
 }
 ?>

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_service.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/template_preprocess_service.php.inc
@@ -14,12 +14,40 @@ function example(&$variables) {
 <?php
 
 function example(&$variables) {
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessContainer($variables), fn() => template_preprocess_container($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessLinks($variables), fn() => template_preprocess_links($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessHtml($variables), fn() => template_preprocess_html($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessPage($variables), fn() => template_preprocess_page($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Datetime\DatePreprocess')->preprocessTime($variables), fn() => template_preprocess_time($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Datetime\DatePreprocess')->preprocessDatetimeForm($variables), fn() => template_preprocess_datetime_form($variables));
-    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', fn() => \Drupal::service('Drupal\Core\Datetime\DatePreprocess')->preprocessDatetimeWrapper($variables), fn() => template_preprocess_datetime_wrapper($variables));
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessContainer($variables);
+    }, function () use (&$variables) {
+        template_preprocess_container($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessLinks($variables);
+    }, function () use (&$variables) {
+        template_preprocess_links($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessHtml($variables);
+    }, function () use (&$variables) {
+        template_preprocess_html($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Theme\ThemePreprocess')->preprocessPage($variables);
+    }, function () use (&$variables) {
+        template_preprocess_page($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Datetime\DatePreprocess')->preprocessTime($variables);
+    }, function () use (&$variables) {
+        template_preprocess_time($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Datetime\DatePreprocess')->preprocessDatetimeForm($variables);
+    }, function () use (&$variables) {
+        template_preprocess_datetime_form($variables);
+    });
+    \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0', function () use (&$variables) {
+        \Drupal::service('Drupal\Core\Datetime\DatePreprocess')->preprocessDatetimeWrapper($variables);
+    }, function () use (&$variables) {
+        template_preprocess_datetime_wrapper($variables);
+    });
 }
 ?>

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/views-add-contextual-links-2571679.php.inc
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/fixture/views-add-contextual-links-2571679.php.inc
@@ -5,5 +5,9 @@ views_add_contextual_links($element, 'view', $display_id);
 -----
 <?php
 
-\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => \Drupal::service(\Drupal\views\ContextualLinksHelper::class)->addLinks($element, 'view', $display_id), fn() => views_add_contextual_links($element, 'view', $display_id));
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', function () use (&$element) {
+    \Drupal::service(\Drupal\views\ContextualLinksHelper::class)->addLinks($element, 'view', $display_id);
+}, function () use (&$element) {
+    views_add_contextual_links($element, 'view', $display_id);
+});
 ?>


### PR DESCRIPTION
## Problem

`DeprecationHelper::backwardsCompatibleCall()` invokes its callables with **no arguments**, so the converted call has to close over the caller's arguments. `AbstractDrupalCoreRector::createBcCallOnExpr()` used **arrow functions** for this — and arrow functions capture **by value**. Any mutation made through a **by-reference parameter** was therefore silently dropped on the rewritten code.

This breaks replacements such as:

- `template_preprocess_*(&$variables)` → `ThemePreprocess::preprocess*()` etc.
- form `*_process` / `*_validate` / `*_builder` callbacks taking `&$form`
- `views_add_contextual_links(&$render_element)`

In webform it surfaced as failing render/form PHPUnit tests on the generated patch (e.g. `Undefined array key "html_attributes"`), because the `&$variables` populated inside `template_preprocess_html()` never made it back to the caller.

## Fix

`createBcCallOnExpr()` now detects by-reference parameters and, when a call argument is a local variable bound to one, emits a **long closure that captures it by reference** instead of an arrow function:

```php
DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.2.0',
    function () use (&$variables) { \Drupal::service(ThemePreprocess::class)->preprocessHtml($variables); },
    function () use (&$variables) { template_preprocess_html($variables); },
);
```

By-reference parameters are discovered by **reflecting the replacement service method** (and, best-effort, the deprecated function), so detection is automatic for every affected deprecation — no per-rule flags. When no argument is bound to a by-reference parameter, the cleaner arrow function is kept.

### void vs. return

PHPStan flags `return <void-expr>;` as `function.void` at **every** level, while allowing both an arrow function's implicit return and a bare expression statement. So a closure wrapping a **void** target emits a bare `<expr>;` statement, and only a value-returning target keeps `return <expr>;`. The replacement method's reflected return type decides which form is emitted. `DeprecationHelperRemoveRector` unwraps both forms.

## Changes

- `AbstractDrupalCoreRector::createBcCallOnExpr()` — by-reference detection + long-closure emission, void-aware closure body.
- `DeprecationHelperRemoveRector` — unwraps both `return` and bare-expression closures.
- Classmap stubs for the reflected target classes (correct `&` positions + return types) so detection is deterministic in the test suite.
- Fixtures covering preprocess, content_translation, menu_ui, media_library and views by-reference conversions.
- `rector-implement` QG-C and `rector-qa` Pass 7 document a by-reference audit step for future rules.

## Testing

Full suite green (694 tests). Source PHPStan clean.

Companion issue: https://git.drupalcode.org/project/rector/-/work_items/3600785