### PR TITLE
docs: prepare 1.0.0-beta7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ release-by-release.
 
 ## [Unreleased]
 
+## [1.0.0-beta7] — 2026-06-24
+
 ### Fixed
 
 - **Backward-compatible call wrapping** — when a deprecation replacement passes a


### PR DESCRIPTION
Cuts the `1.0.0-beta7` CHANGELOG section, moving the `[Unreleased]` entry into it.

### Included since beta6

- **Backward-compatible call wrapping** — by-reference arguments (`template_preprocess_*(&$variables)`, form `*_process`/`*_validate`/`*_builder` callbacks with `&$form`, `views_add_contextual_links(&$render_element)`) are now wrapped in long `function () use (&$var) { … }` closures instead of arrow functions, so the mutation is no longer silently dropped. Void targets emit a bare expression statement to avoid PHPStan's `function.void`. (#398)

Verified against the testset run (pipeline 863470): generated patches now emit the by-reference closure form with zero broken arrow wrappers.