### PR TITLE
fix: emit plain basename() without BC wrapper in FileSystemBasenameToNativeRector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ release-by-release.
   BC wrapper is left untouched — the deprecated call sits in the
   `deprecatedCallable` arm and is skipped by the existing
   `isInBackwardsCompatibleCall()` guard.
+- **`FileSystemBasenameToNativeRector`** — no longer wraps the replacement in a
+  `DeprecationHelper::backwardsCompatibleCall()`. PHP's native `basename()` is
+  identical to `FileSystemInterface::basename()` on every PHP version Drupal 11
+  supports (the wrapper only worked around a pre-PHP-8.0 bug), so the rewrite is
+  always safe and emits a plain `basename(…)` call. Code already converted while
+  the rector still emitted a BC wrapper is left untouched — the deprecated call
+  sits in the `deprecatedCallable` arm and is skipped by the existing
+  `isInBackwardsCompatibleCall()` guard.
 
 ## [1.0.0-beta7] — 2026-06-24
 

--- a/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector.php
+++ b/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector.php
@@ -61,6 +61,20 @@ final class FileSystemBasenameToNativeRector extends AbstractDrupalCoreRector
         return [MethodCall::class];
     }
 
+    /**
+     * PHP's native basename() is identical to FileSystemInterface::basename() on
+     * every PHP version Drupal 11 supports (the wrapper only existed to work
+     * around a pre-8.0 PHP bug), so the replacement is always safe and needs no
+     * DeprecationHelper wrapper. The parent still skips calls that already sit in
+     * the `deprecatedCallable` arm of a backwardsCompatibleCall() (see
+     * AbstractDrupalCoreRector::isInBackwardsCompatibleCall()), so previously
+     * BC-wrapped code is left untouched.
+     */
+    public function supportBackwardsCompatibility(VersionedConfigurationInterface $configuration): bool
+    {
+        return false;
+    }
+
     public function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
     {
         assert($node instanceof MethodCall);

--- a/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/already_converted.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/already_converted.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Code that was previously converted while the rector still emitted a
+// DeprecationHelper wrapper must be left untouched: the deprecated call lives in
+// the `deprecatedCallable` arm and is skipped by isInBackwardsCompatibleCall().
+/** @var \Drupal\Core\File\FileSystemInterface $fileSystem */
+$base = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => basename($uri, '.txt'), fn() => $fileSystem->basename($uri, '.txt'));
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/basic.php.inc
@@ -9,7 +9,7 @@ $noop = $untyped->basename($uri, '.txt');
 <?php
 
 /** @var \Drupal\Core\File\FileSystemInterface $fileSystem */
-$base = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => basename($uri, '.txt'), fn() => $fileSystem->basename($uri, '.txt'));
+$base = basename($uri, '.txt');
 $noop = $untyped->basename($uri, '.txt');
 
 ?>

--- a/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/concrete_class.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/concrete_class.php.inc
@@ -8,6 +8,6 @@ $base = $fileSystem->basename($uri, '.txt');
 <?php
 
 /** @var \Drupal\Core\File\FileSystem $fileSystem */
-$base = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => basename($uri, '.txt'), fn() => $fileSystem->basename($uri, '.txt'));
+$base = basename($uri, '.txt');
 
 ?>

--- a/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/no_suffix.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/fixture/no_suffix.php.inc
@@ -8,6 +8,6 @@ $base = $fileSystem->basename($uri);
 <?php
 
 /** @var \Drupal\Core\File\FileSystemInterface $fileSystem */
-$base = \Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.3.0', fn() => basename($uri), fn() => $fileSystem->basename($uri));
+$base = basename($uri);
 
 ?>


### PR DESCRIPTION
## Summary

`FileSystemBasenameToNativeRector` rewrites deprecated `FileSystemInterface::basename()` / `FileSystem::basename()` calls to PHP's native `basename()`. Until now the replacement was wrapped in a `DeprecationHelper::backwardsCompatibleCall()`. That wrapper is unnecessary here: `FileSystemInterface::basename()` only existed to work around a `basename()` bug fixed in **PHP 8.0**, and every PHP version Drupal 11 supports is ≥ 8.1, so native `basename()` is behaviourally identical and the rewrite is **always safe**.

This PR makes the rector emit a plain call:

```php
// before
$base = $fileSystem->basename($uri, '.txt');
// after
$base = basename($uri, '.txt');
```

## How

- Override `supportBackwardsCompatibility()` to return `false` so `AbstractDrupalCoreRector::refactor()` returns the plain `basename(…)` replacement directly instead of wrapping it.
- **Idempotency:** code already converted while the rector still emitted a BC wrapper is left untouched — the deprecated call sits in the `deprecatedCallable` arm of `backwardsCompatibleCall()` and is skipped by the existing `isInBackwardsCompatibleCall()` guard. A new `already_converted.php.inc` fixture locks this in.
- Updated the transformed fixtures (`basic`, `concrete_class`, `no_suffix`) to expect plain-native output. `fixture-below-version` is unchanged (version gating is independent of BC).
- CHANGELOG `[Unreleased] / Changed` entry added.

## Verification

- `phpunit` (this rector): 5 tests, 6 assertions — OK
- `composer phpstan`: no errors
- `composer fix-style`: no changes

Refs Drupal.org issue [#3600786](https://git.drupalcode.org/project/rector/-/work_items/3600786), change record [node/3530869](https://www.drupal.org/node/3530869).