### PR TITLE
fix: emit plain save() without BC wrapper in RemoveConfigSaveTrustedDataArgRector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ release-by-release.
 
 ## [Unreleased]
 
+### Changed
+
+- **`RemoveConfigSaveTrustedDataArgRector`** — no longer wraps the rewrite in a
+  `DeprecationHelper::backwardsCompatibleCall()`. The deprecated
+  `$has_trusted_data` argument to `Config::save()` is only a performance hint
+  (skip re-casting data already typed to its schema); re-casting is idempotent,
+  so dropping the argument is behaviourally equivalent on every Drupal version
+  that ships `Config::save()` and the rector now emits a plain `$config->save()`.
+  Confirmed with berdir. Code already converted while the rector still emitted a
+  BC wrapper is left untouched — the deprecated call sits in the
+  `deprecatedCallable` arm and is skipped by the existing
+  `isInBackwardsCompatibleCall()` guard.
+
 ## [1.0.0-beta7] — 2026-06-24
 
 ### Fixed

--- a/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector.php
@@ -61,6 +61,22 @@ final class RemoveConfigSaveTrustedDataArgRector extends AbstractDrupalCoreRecto
         return [MethodCall::class];
     }
 
+    /**
+     * The deprecated $has_trusted_data argument is only a performance hint: TRUE
+     * tells Config::save() that the data is already cast to its schema types and
+     * the cast can be skipped. Re-casting already-typed data is idempotent, so
+     * dropping the argument (`save()` re-casts) is behaviourally equivalent on
+     * every Drupal version that ships Config::save() — no DeprecationHelper
+     * wrapper is needed. Confirmed with berdir. The parent still skips calls that
+     * already sit in the `deprecatedCallable` arm of a backwardsCompatibleCall()
+     * (see AbstractDrupalCoreRector::isInBackwardsCompatibleCall()), so
+     * previously BC-wrapped code is left untouched.
+     */
+    public function supportBackwardsCompatibility(VersionedConfigurationInterface $configuration): bool
+    {
+        return false;
+    }
+
     protected function refactorWithConfiguration(Node $node, VersionedConfigurationInterface $configuration): ?Node
     {
         assert($node instanceof MethodCall);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector/fixture/already_converted.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector/fixture/already_converted.php.inc
@@ -1,0 +1,9 @@
+<?php
+
+// Code previously converted while the rector still emitted a DeprecationHelper
+// wrapper must be left untouched: the deprecated save(TRUE) call lives in the
+// `deprecatedCallable` arm and is skipped by isInBackwardsCompatibleCall().
+/** @var \Drupal\Core\Config\Config $config */
+\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => $config->save(), fn() => $config->save(TRUE));
+
+?>

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector/fixture/basic.php.inc
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector/fixture/basic.php.inc
@@ -13,8 +13,8 @@ $other->save(TRUE);
 <?php
 
 /** @var \Drupal\Core\Config\Config $config */
-\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => $config->save(), fn() => $config->save(TRUE));
-\Drupal\Component\Utility\DeprecationHelper::backwardsCompatibleCall(\Drupal::VERSION, '11.4.0', fn() => $config->save(), fn() => $config->save(FALSE));
+$config->save();
+$config->save();
 $config->save();
 
 // Untyped — must not be changed.


### PR DESCRIPTION
## Summary

`RemoveConfigSaveTrustedDataArgRector` strips the deprecated boolean `$has_trusted_data` argument from `Config::save()` calls. Until now the rewrite was wrapped in a `DeprecationHelper::backwardsCompatibleCall()`. That wrapper is unnecessary: `$has_trusted_data` is purely a **performance hint** — `TRUE` tells `save()` the data is already cast to its schema types so the cast can be skipped. Re-casting already-typed data is **idempotent**, so calling `save()` (which re-casts) produces the same stored configuration as `save(TRUE)`/`save(FALSE)` on every Drupal version that ships `Config::save()`.

Confirmed with **berdir**.

```php
// before
$config->save(TRUE);
// after
$config->save();
```

## How

- Override `supportBackwardsCompatibility()` to return `false` so `AbstractDrupalCoreRector::refactor()` returns the plain `$config->save()` rewrite directly instead of wrapping it.
- **Idempotency:** code already converted while the rector still emitted a BC wrapper is left untouched — the deprecated `save(TRUE)` call sits in the `deprecatedCallable` arm of `backwardsCompatibleCall()` and is skipped by the existing `isInBackwardsCompatibleCall()` guard. A new `already_converted.php.inc` fixture locks this in.
- Updated `fixture/basic.php.inc` to expect plain output (`save(TRUE)` and `save(FALSE)` both → `save()`). `fixture-below-version` is unchanged (version gating is independent of BC).
- CHANGELOG `[Unreleased] / Changed` entry added.

## Verification

- `phpunit` (this rector): 4 tests, 5 assertions — OK
- `composer phpstan`: no errors
- `composer fix-style`: no changes

Refs Drupal.org issue [#3600787](https://git.drupalcode.org/project/rector/-/work_items/3600787), change record [node/3348180](https://www.drupal.org/node/3348180).