### PR TITLE
docs: prepare 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ release-by-release.
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-07-02
+
 ### Changed
 
 - **`RemoveConfigSaveTrustedDataArgRector`** — no longer wraps the rewrite in a


### PR DESCRIPTION
Cuts the stable **1.0.0** release from `1.0.0-beta7`.

Moves the two `[Unreleased]` entries (`RemoveConfigSaveTrustedDataArgRector` and `FileSystemBasenameToNativeRector` BC-wrapper simplifications) under a dated `## [1.0.0] — 2026-07-02` heading and leaves a fresh empty `[Unreleased]`. Same one-line pattern as the prior `docs: prepare 1.0.0-betaN` PRs.

After merge + CI: tag `1.0.0` and publish the GitHub release.