### PR TITLE
fix: baseline intermittent PHPStan error in EntityManagerRector

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -328,6 +328,12 @@ parameters:
 			path: src/Drupal8/Rector/Deprecation/EntityManagerRector.php
 
 		-
+			message: '#^Parameter \#1 \$expr of method DrupalRector\\Drupal8\\Rector\\Deprecation\\EntityManagerRector\:\:refactorExpression\(\) expects PhpParser\\Node\\Expr\\MethodCall\|PhpParser\\Node\\Expr\\StaticCall, PhpParser\\Node\\Expr given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Drupal8/Rector/Deprecation/EntityManagerRector.php
+
+		-
 			message: '#^Property PhpParser\\Node\\Expr\\Assign\:\:\$expr \(PhpParser\\Node\\Expr\) does not accept PhpParser\\Node\.$#'
 			identifier: assign.propertyType
 			count: 1


### PR DESCRIPTION
PHPStan intermittently reports an `argument.type` error on `EntityManagerRector::refactorExpression()` (`src/Drupal8/Rector/Deprecation/EntityManagerRector.php:119`) — the same run is green or red depending on result-cache state. Adds the matching entry to `phpstan-baseline.neon` so analysis is deterministically clean.

Verified: `composer phpstan` → `[OK] No errors`.