### PR TITLE
docs: Add rule interface so we can publish docs on getrector.com

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -24,6 +24,11 @@ return (new PhpCsFixer\Config())
         'yoda_style' => false,
         'no_superfluous_phpdoc_tags' => false,
         'declare_strict_types' => true,
+        'fully_qualified_strict_types' => [
+            'import_symbols' => true,
+            'phpdoc_tags' => [],
+
+        ],
     ])
     ->setFinder($finder)
     ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ release-by-release.
 
 ### Fixed
 
+- **Composer-based sets bootstrap** — the Drupal bootstrap now loads correctly
+  when rector is run through the composer-based sets, so rules that rely on the
+  Drupal container / class map resolve as expected in that scenario
+  ([#404](https://github.com/palantirnet/drupal-rector/pull/404)).
 - **`RemoveAliasManagerCacheMethodCallsRector`** — no longer removes calls to
   `AliasManager::setCacheKey()` / `writeCache()` unconditionally, which broke
   backward compatibility on Drupal < 11.3. These methods only became no-ops in
@@ -27,7 +31,8 @@ release-by-release.
 
 ### Added
 
-- **`AddSymfonyConstraintValidatorTypeDeclarationsRector`** — adds the Symfony 8 / Drupal 12 type declarations (`mixed $value` and `: void` on `validate()`, `: void` on `initialize()`) to `Symfony\Component\Validator\ConstraintValidatorInterface` implementers. Backward compatible on all supported Drupal versions, so no version gate. [#3600790]
+- **`AddSymfonyConstraintValidatorTypeDeclarationsRector`** — adds the Symfony 8 / Drupal 12 type declarations (`mixed $value` and `: void` on `validate()`, `: void` on `initialize()`) to `Symfony\Component\Validator\ConstraintValidatorInterface` implementers. Backward compatible on all supported Drupal versions, so no version gate. ([#3600790](https://git.drupalcode.org/project/rector/-/work_items/3600790))
+- **Rule documentation on [getrector.com](https://getrector.com)** — all rules now implement Rector's `DocumentedRuleInterface`, so their definitions and code samples are picked up and published on the getrector.com documentation site. ([#3600962](https://git.drupalcode.org/project/rector/-/work_items/3600962))
 
 ## [1.0.0] — 2026-07-02
 

--- a/config/drupal-8/drupal-8.2-deprecations.php
+++ b/config/drupal-8/drupal-8.2-deprecations.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use DrupalRector\Rector\Deprecation\FunctionToStaticRector;
+use DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration;
 use DrupalRector\Services\AddCommentService;
 use Rector\Config\RectorConfig;
 
@@ -12,7 +13,7 @@ return static function (RectorConfig $rectorConfig): void {
     });
     // https://www.drupal.org/node/2418133
     $rectorConfig->ruleWithConfiguration(FunctionToStaticRector::class, [
-        new DrupalRector\Rector\ValueObject\FunctionToStaticConfiguration(
+        new FunctionToStaticConfiguration(
             '8.2.0',
             'file_directory_os_temp',
             'Drupal\Component\FileSystem\FileSystem',

--- a/config/drupal-8/drupal-8.6-deprecations.php
+++ b/config/drupal-8/drupal-8.6-deprecations.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Drupal8\Rector\Deprecation\StaticToFunctionRector;
 use DrupalRector\Drupal8\Rector\ValueObject\StaticToFunctionConfiguration;
 use DrupalRector\Services\AddCommentService;
 use Rector\Config\RectorConfig;
@@ -10,7 +11,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->singleton(AddCommentService::class, function () {
         return new AddCommentService();
     });
-    $rectorConfig->ruleWithConfiguration(DrupalRector\Drupal8\Rector\Deprecation\StaticToFunctionRector::class, [
+    $rectorConfig->ruleWithConfiguration(StaticToFunctionRector::class, [
         // https://www.drupal.org/node/2850048
         new StaticToFunctionConfiguration('Drupal\Component\Utility\Unicode', 'strlen', 'mb_strlen'),
         // https://www.drupal.org/node/2850048

--- a/config/drupal-9/drupal-9.1-deprecations.php
+++ b/config/drupal-9/drupal-9.1-deprecations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use DrupalRector\Drupal9\Rector\Deprecation\AssertFieldByIdRector;
 use DrupalRector\Drupal9\Rector\Deprecation\AssertFieldByNameRector;
+use DrupalRector\Drupal9\Rector\Deprecation\AssertLegacyTraitRector;
 use DrupalRector\Drupal9\Rector\Deprecation\AssertNoFieldByIdRector;
 use DrupalRector\Drupal9\Rector\Deprecation\AssertNoFieldByNameRector;
 use DrupalRector\Drupal9\Rector\Deprecation\AssertNoUniqueTextRector;
@@ -44,7 +45,7 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->rule(AssertNoFieldByNameRector::class);
     $rectorConfig->rule(AssertFieldByIdRector::class);
 
-    $rectorConfig->ruleWithConfiguration(DrupalRector\Drupal9\Rector\Deprecation\AssertLegacyTraitRector::class, [
+    $rectorConfig->ruleWithConfiguration(AssertLegacyTraitRector::class, [
         new AssertLegacyTraitConfiguration('assertLinkByHref', 'linkByHrefExists'),
         new AssertLegacyTraitConfiguration('assertLink', 'linkExists'),
         new AssertLegacyTraitConfiguration('assertNoEscaped', 'assertNoEscaped'),

--- a/config/drupal-9/drupal-9.3-deprecations.php
+++ b/config/drupal-9/drupal-9.3-deprecations.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use DrupalRector\Drupal9\Rector\Deprecation\ExtensionPathRector;
 use DrupalRector\Drupal9\Rector\Deprecation\FileBuildUriRector;
+use DrupalRector\Drupal9\Rector\Deprecation\FileCreateUrlRector;
+use DrupalRector\Drupal9\Rector\Deprecation\FileUrlTransformRelativeRector;
+use DrupalRector\Drupal9\Rector\Deprecation\FromUriRector;
 use DrupalRector\Drupal9\Rector\Deprecation\FunctionToEntityTypeStorageMethod;
 use DrupalRector\Drupal9\Rector\Deprecation\FunctionToFirstArgMethodRector;
 use DrupalRector\Drupal9\Rector\Deprecation\SystemSortByInfoNameRector;
@@ -33,9 +36,9 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     // Change record: https://www.drupal.org/node/2940031
-    $rectorConfig->rule(DrupalRector\Drupal9\Rector\Deprecation\FileCreateUrlRector::class);
-    $rectorConfig->rule(DrupalRector\Drupal9\Rector\Deprecation\FileUrlTransformRelativeRector::class);
-    $rectorConfig->rule(DrupalRector\Drupal9\Rector\Deprecation\FromUriRector::class);
+    $rectorConfig->rule(FileCreateUrlRector::class);
+    $rectorConfig->rule(FileUrlTransformRelativeRector::class);
+    $rectorConfig->rule(FromUriRector::class);
 
     // Change record: https://www.drupal.org/node/3223520
     $rectorConfig->ruleWithConfiguration(FunctionToServiceRector::class, [

--- a/config/drupal-9/drupal-9.4-deprecations.php
+++ b/config/drupal-9/drupal-9.4-deprecations.php
@@ -1,8 +1,10 @@
 <?php
 
 declare(strict_types=1);
+use DrupalRector\Drupal9\Rector\Deprecation\ModuleLoadRector;
+use Rector\Config\RectorConfig;
 
-return static function (Rector\Config\RectorConfig $rectorConfig): void {
+return static function (RectorConfig $rectorConfig): void {
     // Change record https://www.drupal.org/node/3220952
-    $rectorConfig->rule(DrupalRector\Drupal9\Rector\Deprecation\ModuleLoadRector::class);
+    $rectorConfig->rule(ModuleLoadRector::class);
 };

--- a/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector.php
+++ b/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -44,7 +45,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/2987159
  * @see https://www.drupal.org/node/3521459
  */
-class BlockContentSelectionExtendsRector extends AbstractRector
+class BlockContentSelectionExtendsRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const DEFAULT_SELECTION_CLASS = 'Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection';
 

--- a/src/Drupal11/Rector/Deprecation/BlockContentTestBaseStringToArrayRector.php
+++ b/src/Drupal11/Rector/Deprecation/BlockContentTestBaseStringToArrayRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3196937
  * @see https://www.drupal.org/node/3473739
  */
-class BlockContentTestBaseStringToArrayRector extends AbstractRector
+class BlockContentTestBaseStringToArrayRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/CheckMarkupToProcessedTextRector.php
+++ b/src/Drupal11/Rector/Deprecation/CheckMarkupToProcessedTextRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/455724
  * @see https://www.drupal.org/node/3588040
  */
-class CheckMarkupToProcessedTextRector extends AbstractRector
+class CheckMarkupToProcessedTextRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const PARAM_MAP = [
         'text' => '#text',

--- a/src/Drupal11/Rector/Deprecation/DrupalGetHeadersAssocArrayRector.php
+++ b/src/Drupal11/Rector/Deprecation/DrupalGetHeadersAssocArrayRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -28,7 +29,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3456178
  * @see https://www.drupal.org/node/3456233
  */
-class DrupalGetHeadersAssocArrayRector extends AbstractRector
+class DrupalGetHeadersAssocArrayRector extends AbstractRector implements DocumentedRuleInterface
 {
     // TODO PHPSTAN_MESSAGES DrupalGetHeadersAssocArrayRector: PHPStan emits no
     //   deprecation for the targeted call. The deprecation is triggered at

--- a/src/Drupal11/Rector/Deprecation/EntityFormModeEmptyDescriptionToNullRector.php
+++ b/src/Drupal11/Rector/Deprecation/EntityFormModeEmptyDescriptionToNullRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -25,7 +26,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3448457
  * @see https://www.drupal.org/node/3452144
  */
-class EntityFormModeEmptyDescriptionToNullRector extends AbstractRector
+class EntityFormModeEmptyDescriptionToNullRector extends AbstractRector implements DocumentedRuleInterface
 {
     // TODO PHPSTAN_MESSAGES EntityFormModeEmptyDescriptionToNullRector: PHPStan
     //   emits no deprecation for the targeted call. The deprecation is a

--- a/src/Drupal11/Rector/Deprecation/GetDrupalRootToRootPropertyRector.php
+++ b/src/Drupal11/Rector/Deprecation/GetDrupalRootToRootPropertyRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Identifier;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -26,7 +27,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3589047
  * @see https://www.drupal.org/node/3574112
  */
-final class GetDrupalRootToRootPropertyRector extends AbstractRector
+final class GetDrupalRootToRootPropertyRector extends AbstractRector implements DocumentedRuleInterface
 {
     public const PHPSTAN_MESSAGES = [
         'Call to deprecated method getDrupalRoot() of class Drupal\Tests\BrowserTestBase. Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Access $this->root directly.',

--- a/src/Drupal11/Rector/Deprecation/GetNameToNameRector.php
+++ b/src/Drupal11/Rector/Deprecation/GetNameToNameRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Identifier;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -17,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://www.drupal.org/node/3217904
  */
-class GetNameToNameRector extends AbstractRector
+class GetNameToNameRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector.php
+++ b/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Stmt\Function_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -32,7 +33,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3490846
  * @see https://www.drupal.org/node/3549685
  */
-final class HookRequirementsAlterRenameRector extends AbstractRector
+final class HookRequirementsAlterRenameRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const SUFFIX = '_requirements_alter';
 

--- a/src/Drupal11/Rector/Deprecation/LoadAllIncludesRector.php
+++ b/src/Drupal11/Rector/Deprecation/LoadAllIncludesRector.php
@@ -7,6 +7,7 @@ namespace DrupalRector\Drupal11\Rector\Deprecation;
 use PhpParser\Node;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -16,7 +17,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3536431
  * @see https://www.drupal.org/node/3536432
  */
-final class LoadAllIncludesRector extends AbstractRector
+final class LoadAllIncludesRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal11/Rector/Deprecation/MovePointerToMouseOverRector.php
+++ b/src/Drupal11/Rector/Deprecation/MovePointerToMouseOverRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -23,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3421202
  * @see https://www.drupal.org/node/3460567
  */
-class MovePointerToMouseOverRector extends AbstractRector
+class MovePointerToMouseOverRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/NodeStorageDeprecatedMethodsRector.php
+++ b/src/Drupal11/Rector/Deprecation/NodeStorageDeprecatedMethodsRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -17,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3396062
  * @see https://www.drupal.org/node/3519187
  */
-final class NodeStorageDeprecatedMethodsRector extends AbstractRector
+final class NodeStorageDeprecatedMethodsRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal11/Rector/Deprecation/NodeStorageDeprecatedMethodsRector.php
+++ b/src/Drupal11/Rector/Deprecation/NodeStorageDeprecatedMethodsRector.php
@@ -108,8 +108,13 @@ final class NodeStorageDeprecatedMethodsRector extends AbstractRector implements
                 "array_keys(\$storage->getQuery()->allRevisions()->accessCheck(FALSE)->condition('uid', \$account->id())->execute());"
             ),
             new CodeSample(
-                '$storage->countDefaultLanguageRevisions($node);',
-                ''
+                <<<'CODE_BEFORE'
+$storage->resetCache([$node->id()]);
+$storage->countDefaultLanguageRevisions($node);
+CODE_BEFORE,
+                <<<'CODE_AFTER'
+$storage->resetCache([$node->id()]);
+CODE_AFTER
             ),
         ]);
     }

--- a/src/Drupal11/Rector/Deprecation/RemoveAliasManagerCacheMethodCallsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveAliasManagerCacheMethodCallsRector.php
@@ -65,8 +65,13 @@ final class RemoveAliasManagerCacheMethodCallsRector extends AbstractDrupalCoreR
             'Remove calls to AliasManager::setCacheKey() and AliasManager::writeCache(), deprecated in drupal:11.3.0 and removed in drupal:13.0.0 with no replacement.',
             [
                 new ConfiguredCodeSample(
-                    '$this->aliasManager->setCacheKey($path);',
-                    '',
+                    <<<'CODE_BEFORE'
+$alias = $this->aliasManager->getAliasByPath($path);
+$this->aliasManager->setCacheKey($path);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$alias = $this->aliasManager->getAliasByPath($path);
+CODE_AFTER,
                     [new DrupalIntroducedVersionConfiguration('11.3.0')]
                 ),
             ]

--- a/src/Drupal11/Rector/Deprecation/RemoveAutomatedCronSubmitHandlerRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveAutomatedCronSubmitHandlerRector.php
@@ -62,8 +62,13 @@ final class RemoveAutomatedCronSubmitHandlerRector extends AbstractRector implem
     {
         return new RuleDefinition("Removes deprecated \$form['#submit'][] = 'automated_cron_settings_submit' handler assignments (drupal:11.4.0)", [
             new CodeSample(
-                "\$form['#submit'][] = 'automated_cron_settings_submit';",
-                ''
+                <<<'CODE_BEFORE'
+$form['#submit'][] = 'automated_cron_settings_submit';
+$form['#submit'][] = 'mymodule_settings_submit';
+CODE_BEFORE,
+                <<<'CODE_AFTER'
+$form['#submit'][] = 'mymodule_settings_submit';
+CODE_AFTER
             ),
         ]);
     }

--- a/src/Drupal11/Rector/Deprecation/RemoveAutomatedCronSubmitHandlerRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveAutomatedCronSubmitHandlerRector.php
@@ -7,6 +7,7 @@ namespace DrupalRector\Drupal11\Rector\Deprecation;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3566768
  * @see https://www.drupal.org/node/3566774
  */
-final class RemoveAutomatedCronSubmitHandlerRector extends AbstractRector
+final class RemoveAutomatedCronSubmitHandlerRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveCacheExpireOverrideRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveCacheExpireOverrideRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3576556
  * @see https://www.drupal.org/node/3576855
  */
-final class RemoveCacheExpireOverrideRector extends AbstractRector
+final class RemoveCacheExpireOverrideRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const CACHE_PLUGIN_BASE_FQCN = 'Drupal\views\Plugin\views\cache\CachePluginBase';
 

--- a/src/Drupal11/Rector/Deprecation/RemoveCacheTagChecksumAssertionsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveCacheTagChecksumAssertionsRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3511123
  * @see https://www.drupal.org/node/3511149
  */
-class RemoveCacheTagChecksumAssertionsRector extends AbstractRector
+class RemoveCacheTagChecksumAssertionsRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const DEPRECATED_KEYS = [
         'CacheTagChecksumCount',

--- a/src/Drupal11/Rector/Deprecation/RemoveDrupalToStringTraitRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveDrupalToStringTraitRector.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Return_;
 use PhpParser\Node\Stmt\TraitUse;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -32,7 +33,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3548957
  * @see https://www.drupal.org/node/3548961
  */
-final class RemoveDrupalToStringTraitRector extends AbstractRector
+final class RemoveDrupalToStringTraitRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const TRAIT_FQCN = 'Drupal\Component\Utility\ToStringTrait';
 

--- a/src/Drupal11/Rector/Deprecation/RemoveFilterTipsLongParamRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveFilterTipsLongParamRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -29,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3505370
  * @see https://www.drupal.org/node/3567879
  */
-class RemoveFilterTipsLongParamRector extends AbstractRector
+class RemoveFilterTipsLongParamRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const FILTER_SYMBOLS = [
         'Drupal\\filter\\Plugin\\FilterBase',

--- a/src/Drupal11/Rector/Deprecation/RemoveHandlerBaseDefineExtraOptionsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveHandlerBaseDefineExtraOptionsRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3485084
  * @see https://www.drupal.org/node/3486781
  */
-final class RemoveHandlerBaseDefineExtraOptionsRector extends AbstractRector
+final class RemoveHandlerBaseDefineExtraOptionsRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const HANDLER_BASE_FQCN = 'Drupal\views\Plugin\views\HandlerBase';
 

--- a/src/Drupal11/Rector/Deprecation/RemoveInstallSchemaSystemSequencesRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveInstallSchemaSystemSequencesRector.php
@@ -46,10 +46,11 @@ class RemoveInstallSchemaSystemSequencesRector extends AbstractRector implements
             [
                 new CodeSample(
                     <<<'CODE_BEFORE'
+$this->installEntitySchema('node');
 $this->installSchema('system', ['sequences']);
 CODE_BEFORE,
                     <<<'CODE_AFTER'
-
+$this->installEntitySchema('node');
 CODE_AFTER
                 ),
             ]

--- a/src/Drupal11/Rector/Deprecation/RemoveInstallSchemaSystemSequencesRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveInstallSchemaSystemSequencesRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -28,7 +29,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3335756
  * @see https://www.drupal.org/node/3349345
  */
-class RemoveInstallSchemaSystemSequencesRector extends AbstractRector
+class RemoveInstallSchemaSystemSequencesRector extends AbstractRector implements DocumentedRuleInterface
 {
     // TODO PHPSTAN_MESSAGES RemoveInstallSchemaSystemSequencesRector:
     // The installSchema() method itself is not annotated @deprecated — only

--- a/src/Drupal11/Rector/Deprecation/RemoveLinkWidgetValidateTitleElementRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveLinkWidgetValidateTitleElementRector.php
@@ -7,6 +7,7 @@ namespace DrupalRector\Drupal11\Rector\Deprecation;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3093118
  * @see https://www.drupal.org/node/3554139
  */
-final class RemoveLinkWidgetValidateTitleElementRector extends AbstractRector
+final class RemoveLinkWidgetValidateTitleElementRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveLinkWidgetValidateTitleElementRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveLinkWidgetValidateTitleElementRector.php
@@ -53,8 +53,13 @@ final class RemoveLinkWidgetValidateTitleElementRector extends AbstractRector im
     {
         return new RuleDefinition('Removes deprecated LinkWidget::validateTitleElement() calls. Validation is now handled by LinkTitleRequiredConstraint on the LinkItem field type (drupal:11.4.0)', [
             new CodeSample(
-                'LinkWidget::validateTitleElement($element, $form_state, $form);',
-                ''
+                <<<'CODE_BEFORE'
+LinkWidget::validateTitleElement($element, $form_state, $form);
+$element['#value'] = $value;
+CODE_BEFORE,
+                <<<'CODE_AFTER'
+$element['#value'] = $value;
+CODE_AFTER
             ),
         ]);
     }

--- a/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerAddModuleCallsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerAddModuleCallsRector.php
@@ -60,8 +60,13 @@ final class RemoveModuleHandlerAddModuleCallsRector extends AbstractRector imple
     {
         return new RuleDefinition('Removes deprecated ModuleHandlerInterface::addModule() and addProfile() calls, which are no-ops since drupal:11.2.0 and removed in drupal:12.0.0', [
             new CodeSample(
-                "\$moduleHandler->addModule('mymodule', 'modules/mymodule');",
-                ''
+                <<<'CODE_BEFORE'
+$moduleHandler->addModule('mymodule', 'modules/mymodule');
+$moduleHandler->load('mymodule');
+CODE_BEFORE,
+                <<<'CODE_AFTER'
+$moduleHandler->load('mymodule');
+CODE_AFTER
             ),
         ]);
     }

--- a/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerAddModuleCallsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerAddModuleCallsRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3528899
  * @see https://www.drupal.org/node/3491200
  */
-final class RemoveModuleHandlerAddModuleCallsRector extends AbstractRector
+final class RemoveModuleHandlerAddModuleCallsRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerDeprecatedMethodsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerDeprecatedMethodsRector.php
@@ -32,8 +32,13 @@ final class RemoveModuleHandlerDeprecatedMethodsRector extends AbstractRector im
             'Remove deprecated ModuleHandlerInterface::writeCache() calls and replace getHookInfo() with []',
             [
                 new CodeSample(
-                    '$this->moduleHandler->writeCache();',
-                    ''
+                    <<<'CODE_BEFORE'
+$this->moduleHandler->writeCache();
+$this->moduleHandler->resetImplementations();
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$this->moduleHandler->resetImplementations();
+CODE_AFTER
                 ),
                 new CodeSample(
                     '$hookInfo = $this->moduleHandler->getHookInfo();',

--- a/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerDeprecatedMethodsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerDeprecatedMethodsRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -23,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3442009
  * @see https://www.drupal.org/node/3442349
  */
-final class RemoveModuleHandlerDeprecatedMethodsRector extends AbstractRector
+final class RemoveModuleHandlerDeprecatedMethodsRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveRendererAddCacheableDependencyNonObjectRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveRendererAddCacheableDependencyNonObjectRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3525388
  * @see https://www.drupal.org/node/3525389
  */
-class RemoveRendererAddCacheableDependencyNonObjectRector extends AbstractRector
+class RemoveRendererAddCacheableDependencyNonObjectRector extends AbstractRector implements DocumentedRuleInterface
 {
     public const PHPSTAN_MESSAGES = [
         "Calling Drupal\\Core\\Render\\Renderer::addCacheableDependency() with an object that doesn't implement Drupal\\Core\\Cache\\CacheableDependencyInterface is deprecated in drupal:11.3.0 and will throw an error in drupal:13.0.0. See https://www.drupal.org/node/3525389",

--- a/src/Drupal11/Rector/Deprecation/RemoveRendererAddCacheableDependencyNonObjectRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveRendererAddCacheableDependencyNonObjectRector.php
@@ -37,8 +37,13 @@ class RemoveRendererAddCacheableDependencyNonObjectRector extends AbstractRector
             'Remove RendererInterface::addCacheableDependency() calls where the dependency argument cannot implement CacheableDependencyInterface (bool, int, float, string, null, array). Such calls silently make pages uncacheable and are deprecated in drupal:11.3.0.',
             [
                 new CodeSample(
-                    '$this->renderer->addCacheableDependency($build, false);',
-                    ''
+                    <<<'CODE_BEFORE'
+$build = ['#markup' => 'Hello'];
+$this->renderer->addCacheableDependency($build, false);
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$build = ['#markup' => 'Hello'];
+CODE_AFTER
                 ),
             ]
         );

--- a/src/Drupal11/Rector/Deprecation/RemoveRootFromCreateConnectionOptionsFromUrlRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveRootFromCreateConnectionOptionsFromUrlRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Name;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3506931
  * @see https://www.drupal.org/node/3511287
  */
-class RemoveRootFromCreateConnectionOptionsFromUrlRector extends AbstractRector
+class RemoveRootFromCreateConnectionOptionsFromUrlRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveSetUriCallbackRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveSetUriCallbackRector.php
@@ -32,8 +32,13 @@ final class RemoveSetUriCallbackRector extends AbstractRector implements Documen
             'Remove deprecated EntityTypeInterface::setUriCallback() calls',
             [
                 new CodeSample(
-                    '$entity_type->setUriCallback(\'my_entity_uri\');',
-                    ''
+                    <<<'CODE_BEFORE'
+$entity_type->setLinkTemplate('canonical', '/mymodule/{entity}');
+$entity_type->setUriCallback('my_entity_uri');
+CODE_BEFORE,
+                    <<<'CODE_AFTER'
+$entity_type->setLinkTemplate('canonical', '/mymodule/{entity}');
+CODE_AFTER
                 ),
             ]
         );

--- a/src/Drupal11/Rector/Deprecation/RemoveSetUriCallbackRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveSetUriCallbackRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Expression;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -23,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/2667040
  * @see https://www.drupal.org/node/3575062
  */
-final class RemoveSetUriCallbackRector extends AbstractRector
+final class RemoveSetUriCallbackRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector.php
@@ -7,6 +7,7 @@ namespace DrupalRector\Drupal11\Rector\Deprecation;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -38,7 +39,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3009349
  * @see https://www.drupal.org/node/3306373
  */
-final class RemoveSourceModuleFromMigrateSourceAttributeRector extends AbstractRector
+final class RemoveSourceModuleFromMigrateSourceAttributeRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveStateCacheSettingRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveStateCacheSettingRector.php
@@ -63,8 +63,13 @@ final class RemoveStateCacheSettingRector extends AbstractRector implements Docu
     {
         return new RuleDefinition("Removes deprecated \$settings['state_cache'] assignments. State caching is permanently enabled since drupal:11.0.0 and the setting has no effect", [
             new CodeSample(
-                "\$settings['state_cache'] = TRUE;",
-                ''
+                <<<'CODE_BEFORE'
+$settings['state_cache'] = TRUE;
+$settings['other_setting'] = TRUE;
+CODE_BEFORE,
+                <<<'CODE_AFTER'
+$settings['other_setting'] = TRUE;
+CODE_AFTER
             ),
         ]);
     }

--- a/src/Drupal11/Rector/Deprecation/RemoveStateCacheSettingRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveStateCacheSettingRector.php
@@ -7,6 +7,7 @@ namespace DrupalRector\Drupal11\Rector\Deprecation;
 use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3436954
  * @see https://www.drupal.org/node/2575105
  */
-final class RemoveStateCacheSettingRector extends AbstractRector
+final class RemoveStateCacheSettingRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal11/Rector/Deprecation/RemoveToolkitArgFromImageToolkitOperationConstructorRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveToolkitArgFromImageToolkitOperationConstructorRector.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -28,7 +29,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3559481
  * @see https://www.drupal.org/node/3562304
  */
-final class RemoveToolkitArgFromImageToolkitOperationConstructorRector extends AbstractRector
+final class RemoveToolkitArgFromImageToolkitOperationConstructorRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const TOOLKIT_INTERFACE = 'Drupal\\Core\\ImageToolkit\\ImageToolkitInterface';
 

--- a/src/Drupal11/Rector/Deprecation/RemoveUpdaterPostInstallMethodsRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveUpdaterPostInstallMethodsRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3417136
  * @see https://www.drupal.org/node/3461934
  */
-final class RemoveUpdaterPostInstallMethodsRector extends AbstractRector
+final class RemoveUpdaterPostInstallMethodsRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const DEPRECATED_METHODS = ['postInstall', 'postInstallTasks'];
 

--- a/src/Drupal11/Rector/Deprecation/RemoveViewsRowCacheKeysRector.php
+++ b/src/Drupal11/Rector/Deprecation/RemoveViewsRowCacheKeysRector.php
@@ -16,6 +16,7 @@ use PhpParser\Node\Stmt\Return_;
 use PhpParser\NodeVisitor;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -31,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3564937
  * @see https://www.drupal.org/node/3564958
  */
-final class RemoveViewsRowCacheKeysRector extends AbstractRector
+final class RemoveViewsRowCacheKeysRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const DEPRECATED_METHODS = ['getRowCacheKeys', 'getRowId'];
 

--- a/src/Drupal11/Rector/Deprecation/RenameHookRankingRector.php
+++ b/src/Drupal11/Rector/Deprecation/RenameHookRankingRector.php
@@ -8,6 +8,7 @@ use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -35,7 +36,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/1019966
  * @see https://www.drupal.org/node/2690393
  */
-final class RenameHookRankingRector extends AbstractRector
+final class RenameHookRankingRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/RenameStopProceduralHookScanRector.php
+++ b/src/Drupal11/Rector/Deprecation/RenameStopProceduralHookScanRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\UseUse;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://www.drupal.org/node/3495943
  */
-final class RenameStopProceduralHookScanRector extends AbstractRector
+final class RenameStopProceduralHookScanRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const OLD_FQCN = 'Drupal\Core\Hook\Attribute\StopProceduralHookScan';
     private const NEW_FQCN = 'Drupal\Core\Hook\Attribute\ProceduralHookScanStop';

--- a/src/Drupal11/Rector/Deprecation/ReplaceDialogClassOptionRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceDialogClassOptionRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -34,7 +35,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3571054
  * @see https://www.drupal.org/node/3440844
  */
-final class ReplaceDialogClassOptionRector extends AbstractRector
+final class ReplaceDialogClassOptionRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * Map: FQCN => zero-based index of the $dialog_options argument.

--- a/src/Drupal11/Rector/Deprecation/ReplaceHideShowWithPrintedRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceHideShowWithPrintedRector.php
@@ -12,6 +12,7 @@ use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -27,7 +28,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/2258355
  * @see https://www.drupal.org/node/3261271
  */
-final class ReplaceHideShowWithPrintedRector extends AbstractRector
+final class ReplaceHideShowWithPrintedRector extends AbstractRector implements DocumentedRuleInterface
 {
     /** @var array<string, bool> */
     private const FUNCTION_TO_PRINTED_VALUE = [

--- a/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -48,7 +49,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3589630
  * @see https://www.drupal.org/node/3589636
  */
-class ReplaceNodeViewControllerRector extends AbstractRector
+class ReplaceNodeViewControllerRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const OLD_CLASS = 'Drupal\node\Controller\NodeViewController';
 

--- a/src/Drupal11/Rector/Deprecation/ReplaceNonBoolAccessRector.php
+++ b/src/Drupal11/Rector/Deprecation/ReplaceNonBoolAccessRector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Scalar\Int_;
 use PhpParser\Node\Scalar\String_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3526250
  * @see https://www.drupal.org/node/3549344
  */
-class ReplaceNonBoolAccessRector extends AbstractRector
+class ReplaceNonBoolAccessRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/SystemSortThemesRector.php
+++ b/src/Drupal11/Rector/Deprecation/SystemSortThemesRector.php
@@ -18,6 +18,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\If_;
 use PhpParser\Node\Stmt\Return_;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -28,7 +29,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3571172
  * @see https://www.drupal.org/node/3566774
  */
-class SystemSortThemesRector extends AbstractRector
+class SystemSortThemesRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal11/Rector/Deprecation/TaxonomyTermPageVariableToViewModeRector.php
+++ b/src/Drupal11/Rector/Deprecation/TaxonomyTermPageVariableToViewModeRector.php
@@ -14,6 +14,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Function_;
 use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -29,7 +30,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3535439
  * @see https://www.drupal.org/node/3542527
  */
-final class TaxonomyTermPageVariableToViewModeRector extends AbstractRector
+final class TaxonomyTermPageVariableToViewModeRector extends AbstractRector implements DocumentedRuleInterface
 {
     // TODO PHPSTAN_MESSAGES TaxonomyTermPageVariableToViewModeRector:
     // The deprecation is signalled at runtime by core via

--- a/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector.php
+++ b/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal11\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://www.drupal.org/node/3555936
  */
-class UserLoadByNameAndMailRector extends AbstractRector
+class UserLoadByNameAndMailRector extends AbstractRector implements DocumentedRuleInterface
 {
     public const PHPSTAN_MESSAGES = [
         'Call to deprecated function user_load_by_name(). Deprecated in drupal:11.4.0 and is removed from drupal:13.0.0. Use Drupal::entityTypeManager()->getStorage(\'user\')->loadByProperties() instead.',

--- a/src/Drupal11/Rector/Deprecation/ViewsBlockItemsPerPageNoneToNullRector.php
+++ b/src/Drupal11/Rector/Deprecation/ViewsBlockItemsPerPageNoneToNullRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://www.drupal.org/node/3520946
  * @see https://www.drupal.org/node/3522240
  */
-final class ViewsBlockItemsPerPageNoneToNullRector extends AbstractRector
+final class ViewsBlockItemsPerPageNoneToNullRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal12/Rector/Deprecation/AddSymfonyConstraintValidatorTypeDeclarationsRector.php
+++ b/src/Drupal12/Rector/Deprecation/AddSymfonyConstraintValidatorTypeDeclarationsRector.php
@@ -10,6 +10,7 @@ use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Type\ObjectType;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -33,7 +34,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * @see https://git.drupalcode.org/project/redirect/-/merge_requests/200 (issue #3602388)
  * @see https://github.com/symfony/symfony/blob/8.0/src/Symfony/Component/Validator/ConstraintValidatorInterface.php
  */
-final class AddSymfonyConstraintValidatorTypeDeclarationsRector extends AbstractRector
+final class AddSymfonyConstraintValidatorTypeDeclarationsRector extends AbstractRector implements DocumentedRuleInterface
 {
     private const CONSTRAINT_VALIDATOR_INTERFACE = 'Symfony\Component\Validator\ConstraintValidatorInterface';
 

--- a/src/Drupal8/Rector/Deprecation/DBRector.php
+++ b/src/Drupal8/Rector/Deprecation/DBRector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -37,7 +38,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Inject the database connection
  * - Use calls to Database::getConnection() if the container is not yet available
  */
-class DBRector extends AbstractRector implements ConfigurableRectorInterface
+class DBRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * The method name, such as `db_query`.

--- a/src/Drupal8/Rector/Deprecation/DrupalLRector.php
+++ b/src/Drupal8/Rector/Deprecation/DrupalLRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Dependency injection
  */
-final class DrupalLRector extends AbstractRector
+final class DrupalLRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal8/Rector/Deprecation/DrupalSetMessageRector.php
+++ b/src/Drupal8/Rector/Deprecation/DrupalSetMessageRector.php
@@ -13,6 +13,7 @@ use PHPStan\PhpDocParser\Ast\PhpDoc\PhpDocTagNode;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -31,7 +32,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Add trait for classes
  *   - `use MessengerTrait;`
  */
-final class DrupalSetMessageRector extends AbstractRector
+final class DrupalSetMessageRector extends AbstractRector implements DocumentedRuleInterface
 {
     use FindParentByTypeTrait;
 

--- a/src/Drupal8/Rector/Deprecation/DrupalURLRector.php
+++ b/src/Drupal8/Rector/Deprecation/DrupalURLRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -20,7 +21,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Dependency injection
  */
-final class DrupalURLRector extends AbstractRector
+final class DrupalURLRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal8/Rector/Deprecation/EntityCreateRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityCreateRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Dependency injection
  * - Using class ::create() methods like Node::create().
  */
-final class EntityCreateRector extends AbstractRector
+final class EntityCreateRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal8/Rector/Deprecation/EntityDeleteMultipleRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityDeleteMultipleRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Dependency injection
  * - Using class ::create() methods like Node::create().
  */
-final class EntityDeleteMultipleRector extends AbstractRector
+final class EntityDeleteMultipleRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal8/Rector/Deprecation/EntityInterfaceLinkRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityInterfaceLinkRector.php
@@ -7,6 +7,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 use DrupalRector\Services\AddCommentService;
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities:
  * - Checks the variable has a certain class.
  */
-final class EntityInterfaceLinkRector extends AbstractRector
+final class EntityInterfaceLinkRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * @var AddCommentService

--- a/src/Drupal8/Rector/Deprecation/EntityLoadRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityLoadRector.php
@@ -9,6 +9,7 @@ use DrupalRector\Services\AddCommentService;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -24,7 +25,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Dependency injection
  */
-final class EntityLoadRector extends AbstractRector implements ConfigurableRectorInterface
+final class EntityLoadRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var EntityLoadConfiguration[]

--- a/src/Drupal8/Rector/Deprecation/EntityManagerRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityManagerRector.php
@@ -11,6 +11,7 @@ use Rector\Exception\ShouldNotHappenException;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -33,7 +34,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * - Complex use case handling when a different service is needed and the
  * method does not directly call the service
  */
-final class EntityManagerRector extends AbstractRector
+final class EntityManagerRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * @var ParentClassScopeResolver

--- a/src/Drupal8/Rector/Deprecation/EntityViewRector.php
+++ b/src/Drupal8/Rector/Deprecation/EntityViewRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -21,7 +22,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Include support for cache rest parameter.
  */
-final class EntityViewRector extends AbstractRector
+final class EntityViewRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal8/Rector/Deprecation/FileDefaultSchemeRector.php
+++ b/src/Drupal8/Rector/Deprecation/FileDefaultSchemeRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -14,7 +15,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * @see https://www.drupal.org/node/3049030 for change record.
  */
-final class FileDefaultSchemeRector extends AbstractRector
+final class FileDefaultSchemeRector extends AbstractRector implements DocumentedRuleInterface
 {
     protected string $deprecatedFunctionName = 'file_default_scheme';
 

--- a/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector.php
+++ b/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector.php
@@ -8,6 +8,7 @@ use Drupal\Tests\BrowserTestBase;
 use PhpParser\Builder\Property;
 use PhpParser\Node;
 use PHPStan\Php\PhpVersionFactory;
+use PHPStan\Reflection\Php\PhpPropertyReflection;
 use PHPStan\Type\ObjectType;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\Exception\ShouldNotHappenException;
@@ -104,7 +105,7 @@ CODE_SAMPLE
             $scope = $node->getAttribute('scope');
         }
         $defaultThemeProperty = $classReflection->getProperty('defaultTheme', $scope);
-        assert($defaultThemeProperty instanceof \PHPStan\Reflection\Php\PhpPropertyReflection);
+        assert($defaultThemeProperty instanceof PhpPropertyReflection);
 
         $reflectionProperty = $defaultThemeProperty->getNativeReflection();
         $betterReflection = $reflectionProperty->getBetterReflection();

--- a/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector.php
+++ b/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector.php
@@ -15,13 +15,14 @@ use Rector\Exception\ShouldNotHappenException;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @changelog https://www.drupal.org/node/3083055
  */
-final class FunctionalTestDefaultThemePropertyRector extends AbstractRector
+final class FunctionalTestDefaultThemePropertyRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * @var PhpDocInfoFactory

--- a/src/Drupal8/Rector/Deprecation/GetMockRector.php
+++ b/src/Drupal8/Rector/Deprecation/GetMockRector.php
@@ -11,6 +11,7 @@ use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -22,7 +23,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * What is covered:
  * - Checks the class being extended.
  */
-class GetMockRector extends AbstractRector implements ConfigurableRectorInterface
+class GetMockRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var ParentClassScopeResolver

--- a/src/Drupal8/Rector/Deprecation/LinkGeneratorTraitLRector.php
+++ b/src/Drupal8/Rector/Deprecation/LinkGeneratorTraitLRector.php
@@ -9,6 +9,7 @@ use DrupalRector\Utility\FindParentByTypeTrait;
 use PhpParser\Node;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -23,7 +24,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * Improvement opportunities
  * - Remove link generator trait.
  */
-final class LinkGeneratorTraitLRector extends AbstractRector
+final class LinkGeneratorTraitLRector extends AbstractRector implements DocumentedRuleInterface
 {
     use FindParentByTypeTrait;
 

--- a/src/Drupal8/Rector/Deprecation/RequestTimeConstRector.php
+++ b/src/Drupal8/Rector/Deprecation/RequestTimeConstRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class RequestTimeConstRector extends AbstractRector
+class RequestTimeConstRector extends AbstractRector implements DocumentedRuleInterface
 {
     protected string $deprecatedConstant = 'REQUEST_TIME';
 

--- a/src/Drupal8/Rector/Deprecation/SafeMarkupFormatRector.php
+++ b/src/Drupal8/Rector/Deprecation/SafeMarkupFormatRector.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Drupal8\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -19,7 +20,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  *
  * Improvement opportunities
  */
-final class SafeMarkupFormatRector extends AbstractRector
+final class SafeMarkupFormatRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal8/Rector/Deprecation/StaticToFunctionRector.php
+++ b/src/Drupal8/Rector/Deprecation/StaticToFunctionRector.php
@@ -8,6 +8,7 @@ use DrupalRector\Drupal8\Rector\ValueObject\StaticToFunctionConfiguration;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
@@ -17,7 +18,7 @@ use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
  * What is covered:
  * - Static replacement
  */
-class StaticToFunctionRector extends AbstractRector implements ConfigurableRectorInterface
+class StaticToFunctionRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var StaticToFunctionConfiguration[]

--- a/src/Drupal9/Rector/Deprecation/AssertFieldByIdRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertFieldByIdRector.php
@@ -7,10 +7,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 use PhpParser\Node;
 use PhpParser\Node\Expr\MethodCall;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertFieldByIdRector extends AbstractRector
+final class AssertFieldByIdRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/AssertFieldByNameRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertFieldByNameRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertFieldByNameRector extends AbstractRector
+final class AssertFieldByNameRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector.php
@@ -12,10 +12,11 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\VariadicPlaceholder;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class AssertLegacyTraitRector extends AbstractRector implements ConfigurableRectorInterface
+class AssertLegacyTraitRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/AssertNoFieldByIdRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertNoFieldByIdRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertNoFieldByIdRector extends AbstractRector
+final class AssertNoFieldByIdRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/AssertNoFieldByNameRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertNoFieldByNameRector.php
@@ -10,10 +10,11 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\VariadicPlaceholder;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertNoFieldByNameRector extends AbstractRector
+final class AssertNoFieldByNameRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/AssertNoUniqueTextRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertNoUniqueTextRector.php
@@ -8,10 +8,11 @@ use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertNoUniqueTextRector extends AbstractRector
+final class AssertNoUniqueTextRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/AssertOptionSelectedRector.php
+++ b/src/Drupal9/Rector/Deprecation/AssertOptionSelectedRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class AssertOptionSelectedRector extends AbstractRector
+final class AssertOptionSelectedRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/ConstructFieldXpathRector.php
+++ b/src/Drupal9/Rector/Deprecation/ConstructFieldXpathRector.php
@@ -7,10 +7,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class ConstructFieldXpathRector extends AbstractRector
+final class ConstructFieldXpathRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/ExtensionPathRector.php
+++ b/src/Drupal9/Rector/Deprecation/ExtensionPathRector.php
@@ -9,10 +9,11 @@ use DrupalRector\Services\AddCommentService;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class ExtensionPathRector extends AbstractRector implements ConfigurableRectorInterface
+class ExtensionPathRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var ExtensionPathConfiguration[]

--- a/src/Drupal9/Rector/Deprecation/FileBuildUriRector.php
+++ b/src/Drupal9/Rector/Deprecation/FileBuildUriRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class FileBuildUriRector extends AbstractRector
+final class FileBuildUriRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal9/Rector/Deprecation/FileCreateUrlRector.php
+++ b/src/Drupal9/Rector/Deprecation/FileCreateUrlRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class FileCreateUrlRector extends AbstractRector
+final class FileCreateUrlRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/FileUrlTransformRelativeRector.php
+++ b/src/Drupal9/Rector/Deprecation/FileUrlTransformRelativeRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class FileUrlTransformRelativeRector extends AbstractRector
+final class FileUrlTransformRelativeRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/FromUriRector.php
+++ b/src/Drupal9/Rector/Deprecation/FromUriRector.php
@@ -8,10 +8,11 @@ use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
 use Rector\StaticTypeMapper\ValueObject\Type\FullyQualifiedObjectType;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class FromUriRector extends AbstractRector
+final class FromUriRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/FunctionToEntityTypeStorageMethod.php
+++ b/src/Drupal9/Rector/Deprecation/FunctionToEntityTypeStorageMethod.php
@@ -8,10 +8,11 @@ use DrupalRector\Drupal9\Rector\ValueObject\FunctionToEntityTypeStorageConfigura
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class FunctionToEntityTypeStorageMethod extends AbstractRector implements ConfigurableRectorInterface
+class FunctionToEntityTypeStorageMethod extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array|FunctionToEntityTypeStorageConfiguration[]

--- a/src/Drupal9/Rector/Deprecation/GetAllOptionsRector.php
+++ b/src/Drupal9/Rector/Deprecation/GetAllOptionsRector.php
@@ -8,10 +8,11 @@ use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class GetAllOptionsRector extends AbstractRector
+final class GetAllOptionsRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/GetRawContentRector.php
+++ b/src/Drupal9/Rector/Deprecation/GetRawContentRector.php
@@ -8,10 +8,11 @@ use DrupalRector\Utility\GetDeclaringSourceTrait;
 use PhpParser\Node;
 use Rector\NodeCollector\ScopeResolver\ParentClassScopeResolver;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class GetRawContentRector extends AbstractRector
+final class GetRawContentRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/ModuleLoadRector.php
+++ b/src/Drupal9/Rector/Deprecation/ModuleLoadRector.php
@@ -6,13 +6,14 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * Replaces deprecated module_load_install call with ModuleHandler call.
  */
-class ModuleLoadRector extends AbstractRector
+class ModuleLoadRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal9/Rector/Deprecation/PassRector.php
+++ b/src/Drupal9/Rector/Deprecation/PassRector.php
@@ -9,10 +9,11 @@ use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class PassRector extends AbstractRector
+final class PassRector extends AbstractRector implements DocumentedRuleInterface
 {
     use GetDeclaringSourceTrait;
 

--- a/src/Drupal9/Rector/Deprecation/SystemSortByInfoNameRector.php
+++ b/src/Drupal9/Rector/Deprecation/SystemSortByInfoNameRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class SystemSortByInfoNameRector extends AbstractRector
+class SystemSortByInfoNameRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/src/Drupal9/Rector/Deprecation/TaxonomyTermLoadMultipleByNameRector.php
+++ b/src/Drupal9/Rector/Deprecation/TaxonomyTermLoadMultipleByNameRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class TaxonomyTermLoadMultipleByNameRector extends AbstractRector
+class TaxonomyTermLoadMultipleByNameRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/TaxonomyVocabularyGetNamesDrupalStaticResetRector.php
+++ b/src/Drupal9/Rector/Deprecation/TaxonomyVocabularyGetNamesDrupalStaticResetRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class TaxonomyVocabularyGetNamesDrupalStaticResetRector extends AbstractRector
+class TaxonomyVocabularyGetNamesDrupalStaticResetRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/TaxonomyVocabularyGetNamesRector.php
+++ b/src/Drupal9/Rector/Deprecation/TaxonomyVocabularyGetNamesRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class TaxonomyVocabularyGetNamesRector extends AbstractRector
+class TaxonomyVocabularyGetNamesRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
+++ b/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector.php
@@ -7,10 +7,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 use PhpParser\Node;
 use Rector\Exception\ShouldNotHappenException;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class UiHelperTraitDrupalPostFormRector extends AbstractRector
+final class UiHelperTraitDrupalPostFormRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getRuleDefinition(): RuleDefinition
     {

--- a/src/Drupal9/Rector/Deprecation/UserPasswordRector.php
+++ b/src/Drupal9/Rector/Deprecation/UserPasswordRector.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Drupal9\Rector\Deprecation;
 
 use PhpParser\Node;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class UserPasswordRector extends AbstractRector
+final class UserPasswordRector extends AbstractRector implements DocumentedRuleInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector.php
+++ b/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector.php
@@ -7,13 +7,14 @@ namespace DrupalRector\Drupal9\Rector\Property;
 use PhpParser\Node;
 use Rector\Privatization\NodeManipulator\VisibilityManipulator;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * @changelog https://www.drupal.org/node/2909426
  */
-final class ProtectedStaticModulesPropertyRector extends AbstractRector
+final class ProtectedStaticModulesPropertyRector extends AbstractRector implements DocumentedRuleInterface
 {
     private VisibilityManipulator $visibilityManipulator;
 

--- a/src/Rector/AbstractDrupalCoreRector.php
+++ b/src/Rector/AbstractDrupalCoreRector.php
@@ -18,8 +18,9 @@ use PHPStan\Reflection\MethodReflection;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 
-abstract class AbstractDrupalCoreRector extends AbstractRector implements ConfigurableRectorInterface
+abstract class AbstractDrupalCoreRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array|VersionedConfigurationInterface[]

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrupalRector\Rector\Convert;
 
 use Composer\InstalledVersions;
+use PhpParser\Comment\Doc;
 use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Name\FullyQualified;
@@ -268,7 +269,7 @@ CODE_SAMPLE
             ]);
             array_unshift($this->hookClass->stmts, new Node\Stmt\TraitUse([new Node\Name('StringTranslationTrait')]));
         }
-        $this->hookClass->setDocComment(new \PhpParser\Comment\Doc("/**\n * Hook implementations for $this->module.\n */"));
+        $this->hookClass->setDocComment(new Doc("/**\n * Hook implementations for $this->module.\n */"));
 
         return [
             new Node\Stmt\Namespace_(new Node\Name($namespace)),

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -23,10 +23,11 @@ use Rector\Doctrine\CodeQuality\Utils\CaseStringHelper;
 use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class HookConvertRector extends AbstractRector
+class HookConvertRector extends AbstractRector implements DocumentedRuleInterface
 {
     protected string $inputFilename = '';
 

--- a/src/Rector/Deprecation/DeprecationHelperRemoveRector.php
+++ b/src/Rector/Deprecation/DeprecationHelperRemoveRector.php
@@ -8,10 +8,11 @@ use DrupalRector\Rector\ValueObject\DeprecationHelperRemoveConfiguration;
 use PhpParser\Node;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class DeprecationHelperRemoveRector extends AbstractRector implements ConfigurableRectorInterface
+final class DeprecationHelperRemoveRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array|DeprecationHelperRemoveConfiguration[]

--- a/src/Rector/Deprecation/FunctionCallRemovalRector.php
+++ b/src/Rector/Deprecation/FunctionCallRemovalRector.php
@@ -9,13 +9,14 @@ use PhpParser\Node;
 use PhpParser\NodeVisitor;
 use Rector\Contract\Rector\ConfigurableRectorInterface;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\ConfiguredCodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 /**
  * Removes deprecated function call statements with no replacement.
  */
-class FunctionCallRemovalRector extends AbstractRector implements ConfigurableRectorInterface
+class FunctionCallRemovalRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 {
     /**
      * @var array|FunctionCallRemovalConfiguration[]

--- a/src/Rector/Deprecation/FunctionCallRemovalRector.php
+++ b/src/Rector/Deprecation/FunctionCallRemovalRector.php
@@ -65,8 +65,13 @@ class FunctionCallRemovalRector extends AbstractRector implements ConfigurableRe
     {
         return new RuleDefinition('Removes deprecated function call statements that have no replacement', [
             new ConfiguredCodeSample(
-                'deprecated_function();',
-                '',
+                <<<'CODE_BEFORE'
+deprecated_function();
+do_something_else();
+CODE_BEFORE,
+                <<<'CODE_AFTER'
+do_something_else();
+CODE_AFTER,
                 [new FunctionCallRemovalConfiguration('deprecated_function')]
             ),
         ]);

--- a/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector.php
+++ b/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector.php
@@ -17,6 +17,7 @@ use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\PhpDocParser\Ast\PhpDoc\GenericTagValueNode;
+use PHPUnit\Framework\TestCase;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfo;
 use Rector\BetterPhpDocParser\PhpDocInfo\PhpDocInfoFactory;
 use Rector\BetterPhpDocParser\PhpDocManipulator\PhpDocTagRemover;
@@ -307,7 +308,7 @@ final class PhpUnitTestAnnotationToAttributeRector extends AbstractDrupalCoreRec
             return false;
         }
 
-        return $classReflection->isSubclassOf(\PHPUnit\Framework\TestCase::class);
+        return $classReflection->isSubclassOf(TestCase::class);
     }
 
     public function getRuleDefinition(): RuleDefinition

--- a/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
+++ b/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrupalRector\Rector\PHPUnit;
 
 use PhpParser\Node;
+use PHPUnit\Framework\TestCase;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
@@ -37,7 +38,7 @@ class ShouldCallParentMethodsRector extends AbstractRector
             return null;
         }
 
-        if (!$scope->getClassReflection()->isSubclassOf(\PHPUnit\Framework\TestCase::class)) {
+        if (!$scope->getClassReflection()->isSubclassOf(TestCase::class)) {
             return null;
         }
 

--- a/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
+++ b/src/Rector/PHPUnit/ShouldCallParentMethodsRector.php
@@ -8,10 +8,11 @@ use PhpParser\Node;
 use PHPUnit\Framework\TestCase;
 use Rector\PHPStan\ScopeFetcher;
 use Rector\Rector\AbstractRector;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-class ShouldCallParentMethodsRector extends AbstractRector
+class ShouldCallParentMethodsRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function getNodeTypes(): array
     {

--- a/tests/functional/hookconvertrector/rector.php
+++ b/tests/functional/hookconvertrector/rector.php
@@ -3,10 +3,11 @@
 declare(strict_types=1);
 
 use DrupalFinder\DrupalFinder;
+use DrupalRector\Rector\Convert\HookConvertRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(DrupalRector\Rector\Convert\HookConvertRector::class);
+    $rectorConfig->rule(HookConvertRector::class);
 
     $drupalFinder = new DrupalFinder();
     $drupalFinder->locateRoot(__DIR__);

--- a/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/ActionAnnotationToAttributeRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/ActionAnnotationToAttributeRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\ActionAnnotationToAttri
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class ActionAnnotationToAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/BackwardsCompatibilityActionAnnotationToAttributeRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/ActionAnnotationToAttributeRector/BackwardsCompatibilityActionAnnotationToAttributeRectorTest.php
@@ -6,16 +6,18 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\ActionAnnotationToAttri
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class Drupal
 {
     public const VERSION = '11.0.x-dev';
 }
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class BackwardsCompatibilityActionAnnotationToAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal10/Rector/Deprecation/ReplaceModuleHandlerGetNameRector/ReplaceModuleHandlerGetNameRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/ReplaceModuleHandlerGetNameRector/ReplaceModuleHandlerGetNameRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\ReplaceModuleHandlerGet
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceModuleHandlerGetNameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceModuleHandlerGetNameRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal10/Rector/Deprecation/ReplaceRebuildThemeDataRector/ReplaceRebuildThemeDataRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/ReplaceRebuildThemeDataRector/ReplaceRebuildThemeDataRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\ReplaceRebuildThemeData
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceRebuildThemeDataRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceRebuildThemeDataRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal10/Rector/Deprecation/ReplaceRequestTimeConstantRector/ReplaceRequestTimeConstantRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/ReplaceRequestTimeConstantRector/ReplaceRequestTimeConstantRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\ReplaceRequestTimeConst
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceRequestTimeConstantRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceRequestTimeConstantRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal10/Rector/Deprecation/SystemTimeZonesRector/SystemTimeZonesRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/SystemTimeZonesRector/SystemTimeZonesRectorTest.php
@@ -7,11 +7,13 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\SystemTimeZonesRector;
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class SystemTimeZonesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -26,7 +28,7 @@ class SystemTimeZonesRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal10/Rector/Deprecation/WatchdogExceptionRector/WatchdogExceptionRectorTest.php
+++ b/tests/src/Drupal10/Rector/Deprecation/WatchdogExceptionRector/WatchdogExceptionRectorTest.php
@@ -7,11 +7,13 @@ namespace DrupalRector\Tests\Drupal10\Rector\Deprecation\WatchdogExceptionRector
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class WatchdogExceptionRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -26,7 +28,7 @@ class WatchdogExceptionRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/BlockContentSelectionExtendsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentSelectionExtendsRector/BlockContentSelectionExtendsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\BlockContentSelectionExtendsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BlockContentSelectionExtendsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/BlockContentTestBaseStringToArrayRector/BlockContentTestBaseStringToArrayRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/BlockContentTestBaseStringToArrayRector/BlockContentTestBaseStringToArrayRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\BlockContentTestBaseStringToArrayRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BlockContentTestBaseStringToArrayRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/CheckMarkupToProcessedTextRector/CheckMarkupToProcessedTextRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/CheckMarkupToProcessedTextRector/CheckMarkupToProcessedTextRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\CheckMarkupToProcessedTextRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CheckMarkupToProcessedTextRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/CommentLinkBuilderConstructorRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/CommentLinkBuilderConstructorRector/CommentLinkBuilderConstructorRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\CommentLinkBuilderConst
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CommentLinkBuilderConstructorRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class CommentLinkBuilderConstructorRectorTest extends AbstractDrupalRectorTestCa
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/DeprecatedFilterFunctionsRector/DeprecatedFilterFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/DeprecatedFilterFunctionsRector/DeprecatedFilterFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\DeprecatedFilterFunctio
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DeprecatedFilterFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class DeprecatedFilterFunctionsRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/DrupalGetHeadersAssocArrayRector/DrupalGetHeadersAssocArrayRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/DrupalGetHeadersAssocArrayRector/DrupalGetHeadersAssocArrayRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\DrupalGetHeadersAssocArrayRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DrupalGetHeadersAssocArrayRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/EntityFormModeEmptyDescriptionToNullRector/EntityFormModeEmptyDescriptionToNullRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/EntityFormModeEmptyDescriptionToNullRector/EntityFormModeEmptyDescriptionToNullRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\EntityFormModeEmptyDescriptionToNullRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class EntityFormModeEmptyDescriptionToNullRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ErrorCurrentErrorHandlerRector/ErrorCurrentErrorHandlerRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ErrorCurrentErrorHandlerRector/ErrorCurrentErrorHandlerRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ErrorCurrentErrorHandle
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ErrorCurrentErrorHandlerRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ErrorCurrentErrorHandlerRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/FileManagedFileSubmitRector/FileManagedFileSubmitRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/FileManagedFileSubmitRector/FileManagedFileSubmitRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\FileManagedFileSubmitRe
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FileManagedFileSubmitRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class FileManagedFileSubmitRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/FileSystemBasenameToNativeRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/FileSystemBasenameToNativeRector/FileSystemBasenameToNativeRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\FileSystemBasenameToNat
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FileSystemBasenameToNativeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class FileSystemBasenameToNativeRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/FilterFormatFunctionsToServiceRector/FilterFormatFunctionsToServiceRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/FilterFormatFunctionsToServiceRector/FilterFormatFunctionsToServiceRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\FilterFormatFunctionsTo
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FilterFormatFunctionsToServiceRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class FilterFormatFunctionsToServiceRectorTest extends AbstractDrupalRectorTestC
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/GetDrupalRootToRootPropertyRector/GetDrupalRootToRootPropertyRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/GetDrupalRootToRootPropertyRector/GetDrupalRootToRootPropertyRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\GetDrupalRootToRootPropertyRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GetDrupalRootToRootPropertyRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/GetNameToNameRector/GetNameToNameRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/GetNameToNameRector/GetNameToNameRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\GetNameToNameRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GetNameToNameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/GetOriginalClassToGetDecoratedClassesRector/GetOriginalClassToGetDecoratedClassesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/GetOriginalClassToGetDecoratedClassesRector/GetOriginalClassToGetDecoratedClassesRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\GetOriginalClassToGetDe
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GetOriginalClassToGetDecoratedClassesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class GetOriginalClassToGetDecoratedClassesRectorTest extends AbstractDrupalRect
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/HookRequirementsAlterRenameRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/HookRequirementsAlterRenameRector/HookRequirementsAlterRenameRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\HookRequirementsAlterRenameRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HookRequirementsAlterRenameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/LoadAllIncludesRector/LoadAllIncludesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/LoadAllIncludesRector/LoadAllIncludesRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\LoadAllIncludesRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LoadAllIncludesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/LocaleCompareIncToServiceRector/LocaleCompareIncToServiceRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/LocaleCompareIncToServiceRector/LocaleCompareIncToServiceRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\LocaleCompareIncToServi
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LocaleCompareIncToServiceRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class LocaleCompareIncToServiceRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/MediaFilterFormatEditFormValidateRector/MediaFilterFormatEditFormValidateRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/MediaFilterFormatEditFormValidateRector/MediaFilterFormatEditFormValidateRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\MediaFilterFormatEditFo
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MediaFilterFormatEditFormValidateRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class MediaFilterFormatEditFormValidateRectorTest extends AbstractDrupalRectorTe
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/MigrateSqlGetMigrationPluginManagerRector/MigrateSqlGetMigrationPluginManagerRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/MigrateSqlGetMigrationPluginManagerRector/MigrateSqlGetMigrationPluginManagerRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\MigrateSqlGetMigrationP
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MigrateSqlGetMigrationPluginManagerRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class MigrateSqlGetMigrationPluginManagerRectorTest extends AbstractDrupalRector
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/MovePointerToMouseOverRector/MovePointerToMouseOverRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/MovePointerToMouseOverRector/MovePointerToMouseOverRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\MovePointerToMouseOverRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class MovePointerToMouseOverRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/NodeAccessRebuildFunctionsRector/NodeAccessRebuildFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/NodeAccessRebuildFunctionsRector/NodeAccessRebuildFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\NodeAccessRebuildFuncti
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NodeAccessRebuildFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class NodeAccessRebuildFunctionsRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/NodeStorageDeprecatedMethodsRector/NodeStorageDeprecatedMethodsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/NodeStorageDeprecatedMethodsRector/NodeStorageDeprecatedMethodsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\NodeStorageDeprecatedMethodsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NodeStorageDeprecatedMethodsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/PluginBaseIsConfigurableRector/PluginBaseIsConfigurableRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/PluginBaseIsConfigurableRector/PluginBaseIsConfigurableRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\PluginBaseIsConfigurabl
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PluginBaseIsConfigurableRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class PluginBaseIsConfigurableRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveAliasManagerCacheMethodCallsRector/BackwardsCompatibilityRemoveAliasManagerCacheMethodCallsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveAliasManagerCacheMethodCallsRector/BackwardsCompatibilityRemoveAliasManagerCacheMethodCallsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveAliasManagerCache
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class BackwardsCompatibilityRemoveAliasManagerCacheMethodCallsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         // Backward compatibility enabled with a minimum supported core version

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveAliasManagerCacheMethodCallsRector/RemoveAliasManagerCacheMethodCallsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveAliasManagerCacheMethodCallsRector/RemoveAliasManagerCacheMethodCallsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveAliasManagerCache
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveAliasManagerCacheMethodCallsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         // Backward compatibility disabled: the deprecated call is removed.
@@ -22,7 +23,7 @@ class RemoveAliasManagerCacheMethodCallsRectorTest extends AbstractDrupalRectorT
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         // Target Drupal is below the 11.3.0 deprecation: the rector must not

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveAutomatedCronSubmitHandlerRector/RemoveAutomatedCronSubmitHandlerRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveAutomatedCronSubmitHandlerRector/RemoveAutomatedCronSubmitHandlerRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveAutomatedCronSubmitHandlerRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveAutomatedCronSubmitHandlerRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveCacheExpireOverrideRector/RemoveCacheExpireOverrideRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveCacheExpireOverrideRector/RemoveCacheExpireOverrideRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveCacheExpireOverrideRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveCacheExpireOverrideRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveCacheTagChecksumAssertionsRector/RemoveCacheTagChecksumAssertionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveCacheTagChecksumAssertionsRector/RemoveCacheTagChecksumAssertionsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveCacheTagChecksumAssertionsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveCacheTagChecksumAssertionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector/RemoveConfigSaveTrustedDataArgRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveConfigSaveTrustedDataArgRector/RemoveConfigSaveTrustedDataArgRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveConfigSaveTrusted
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveConfigSaveTrustedDataArgRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class RemoveConfigSaveTrustedDataArgRectorTest extends AbstractDrupalRectorTestC
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveDrupalToStringTraitRector/RemoveDrupalToStringTraitRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveDrupalToStringTraitRector/RemoveDrupalToStringTraitRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveDrupalToStringTraitRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveDrupalToStringTraitRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveFilterTipsLongParamRector/RemoveFilterTipsLongParamRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveFilterTipsLongParamRector/RemoveFilterTipsLongParamRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveFilterTipsLongParamRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveFilterTipsLongParamRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveHandlerBaseDefineExtraOptionsRector/RemoveHandlerBaseDefineExtraOptionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveHandlerBaseDefineExtraOptionsRector/RemoveHandlerBaseDefineExtraOptionsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveHandlerBaseDefineExtraOptionsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveHandlerBaseDefineExtraOptionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveInstallSchemaSystemSequencesRector/RemoveInstallSchemaSystemSequencesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveInstallSchemaSystemSequencesRector/RemoveInstallSchemaSystemSequencesRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveInstallSchemaSystemSequencesRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveInstallSchemaSystemSequencesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveLinkWidgetValidateTitleElementRector/RemoveLinkWidgetValidateTitleElementRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveLinkWidgetValidateTitleElementRector/RemoveLinkWidgetValidateTitleElementRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveLinkWidgetValidateTitleElementRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveLinkWidgetValidateTitleElementRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerAddModuleCallsRector/RemoveModuleHandlerAddModuleCallsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerAddModuleCallsRector/RemoveModuleHandlerAddModuleCallsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveModuleHandlerAddModuleCallsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveModuleHandlerAddModuleCallsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerDeprecatedMethodsRector/RemoveModuleHandlerDeprecatedMethodsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveModuleHandlerDeprecatedMethodsRector/RemoveModuleHandlerDeprecatedMethodsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveModuleHandlerDeprecatedMethodsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveModuleHandlerDeprecatedMethodsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemovePhpUnitCompatibilityTraitRector/RemovePhpUnitCompatibilityTraitRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemovePhpUnitCompatibilityTraitRector/RemovePhpUnitCompatibilityTraitRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemovePhpUnitCompatibil
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemovePhpUnitCompatibilityTraitRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class RemovePhpUnitCompatibilityTraitRectorTest extends AbstractDrupalRectorTest
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRendererAddCacheableDependencyNonObjectRector/RemoveRendererAddCacheableDependencyNonObjectRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRendererAddCacheableDependencyNonObjectRector/RemoveRendererAddCacheableDependencyNonObjectRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveRendererAddCacheableDependencyNonObjectRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveRendererAddCacheableDependencyNonObjectRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRootFromConvertDbUrlRector/RemoveRootFromConvertDbUrlRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRootFromConvertDbUrlRector/RemoveRootFromConvertDbUrlRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveRootFromConvertDb
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveRootFromConvertDbUrlRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class RemoveRootFromConvertDbUrlRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRootFromCreateConnectionOptionsFromUrlRector/RemoveRootFromCreateConnectionOptionsFromUrlRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRootFromCreateConnectionOptionsFromUrlRector/RemoveRootFromCreateConnectionOptionsFromUrlRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveRootFromCreateConnectionOptionsFromUrlRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveRootFromCreateConnectionOptionsFromUrlRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/RemoveRouteBuilderDeprecatedArgsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveRouteBuilderDeprecatedArgsRector/RemoveRouteBuilderDeprecatedArgsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveRouteBuilderDepre
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveRouteBuilderDeprecatedArgsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class RemoveRouteBuilderDeprecatedArgsRectorTest extends AbstractDrupalRectorTes
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSetUriCallbackRector/RemoveSetUriCallbackRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSetUriCallbackRector/RemoveSetUriCallbackRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveSetUriCallbackRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveSetUriCallbackRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/RemoveSourceModuleFromMigrateSourceAttributeRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveSourceModuleFromMigrateSourceAttributeRector/RemoveSourceModuleFromMigrateSourceAttributeRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveSourceModuleFromMigrateSourceAttributeRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveSourceModuleFromMigrateSourceAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveStateCacheSettingRector/RemoveStateCacheSettingRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveStateCacheSettingRector/RemoveStateCacheSettingRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveStateCacheSettingRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveStateCacheSettingRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveToolkitArgFromImageToolkitOperationConstructorRector/RemoveToolkitArgFromImageToolkitOperationConstructorRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveToolkitArgFromImageToolkitOperationConstructorRector/RemoveToolkitArgFromImageToolkitOperationConstructorRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveToolkitArgFromImageToolkitOperationConstructorRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveToolkitArgFromImageToolkitOperationConstructorRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveTrustDataCallRector/RemoveTrustDataCallRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveTrustDataCallRector/RemoveTrustDataCallRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveTrustDataCallRect
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveTrustDataCallRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class RemoveTrustDataCallRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveTwigNodeTransTagArgumentRector/RemoveTwigNodeTransTagArgumentRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveTwigNodeTransTagArgumentRector/RemoveTwigNodeTransTagArgumentRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveTwigNodeTransTagA
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveTwigNodeTransTagArgumentRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class RemoveTwigNodeTransTagArgumentRectorTest extends AbstractDrupalRectorTestC
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveUpdaterPostInstallMethodsRector/RemoveUpdaterPostInstallMethodsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveUpdaterPostInstallMethodsRector/RemoveUpdaterPostInstallMethodsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveUpdaterPostInstallMethodsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveUpdaterPostInstallMethodsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RemoveViewsRowCacheKeysRector/RemoveViewsRowCacheKeysRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RemoveViewsRowCacheKeysRector/RemoveViewsRowCacheKeysRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RemoveViewsRowCacheKeysRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RemoveViewsRowCacheKeysRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/RenameHookRankingRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameHookRankingRector/RenameHookRankingRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RenameHookRankingRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RenameHookRankingRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/RenameStopProceduralHookScanRector/RenameStopProceduralHookScanRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/RenameStopProceduralHookScanRector/RenameStopProceduralHookScanRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\RenameStopProceduralHookScanRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class RenameStopProceduralHookScanRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceAddCachedDiscoveryMethodCallRector/ReplaceAddCachedDiscoveryMethodCallRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceAddCachedDiscoveryMethodCallRector/ReplaceAddCachedDiscoveryMethodCallRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceAddCachedDiscove
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceAddCachedDiscoveryMethodCallRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class ReplaceAddCachedDiscoveryMethodCallRectorTest extends AbstractDrupalRector
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceAlphadecimalToIntNullRector/ReplaceAlphadecimalToIntNullRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceAlphadecimalToIntNullRector/ReplaceAlphadecimalToIntNullRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceAlphadecimalToIn
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceAlphadecimalToIntNullRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceAlphadecimalToIntNullRectorTest extends AbstractDrupalRectorTestCas
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceCommentManagerGetCountNewCommentsRector/ReplaceCommentManagerGetCountNewCommentsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceCommentManagerGetCountNewCommentsRector/ReplaceCommentManagerGetCountNewCommentsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceCommentManagerGe
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceCommentManagerGetCountNewCommentsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceCommentManagerGetCountNewCommentsRectorTest extends AbstractDrupalR
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceCommentPreviewConstantsRector/ReplaceCommentPreviewConstantsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceCommentPreviewConstantsRector/ReplaceCommentPreviewConstantsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceCommentPreviewCo
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceCommentPreviewConstantsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceCommentPreviewConstantsRectorTest extends AbstractDrupalRectorTestC
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDateTimeRangeConstantsRector/ReplaceDateTimeRangeConstantsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDateTimeRangeConstantsRector/ReplaceDateTimeRangeConstantsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceDateTimeRangeCon
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceDateTimeRangeConstantsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceDateTimeRangeConstantsRectorTest extends AbstractDrupalRectorTestCa
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDialogClassOptionRector/ReplaceDialogClassOptionRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDialogClassOptionRector/ReplaceDialogClassOptionRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceDialogClassOptionRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceDialogClassOptionRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/ReplaceDrupalStaticResetFileReferencesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceDrupalStaticResetFileReferencesRector/ReplaceDrupalStaticResetFileReferencesRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceDrupalStaticRese
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceDrupalStaticResetFileReferencesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class ReplaceDrupalStaticResetFileReferencesRectorTest extends AbstractDrupalRec
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceEditorLoadRector/ReplaceEditorLoadRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceEditorLoadRector/ReplaceEditorLoadRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceEditorLoadRector
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceEditorLoadRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceEditorLoadRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceEntityOriginalPropertyRector/ReplaceEntityOriginalPropertyRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceEntityOriginalPropertyRector/ReplaceEntityOriginalPropertyRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceEntityOriginalPr
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceEntityOriginalPropertyRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceEntityOriginalPropertyRectorTest extends AbstractDrupalRectorTestCa
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceEntityReferenceRecursiveLimitRector/ReplaceEntityReferenceRecursiveLimitRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceEntityReferenceRecursiveLimitRector/ReplaceEntityReferenceRecursiveLimitRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceEntityReferenceR
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceEntityReferenceRecursiveLimitRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceEntityReferenceRecursiveLimitRectorTest extends AbstractDrupalRecto
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceExpectDeprecationRector/ReplaceExpectDeprecationRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceExpectDeprecationRector/ReplaceExpectDeprecationRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceExpectDeprecatio
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceExpectDeprecationRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceExpectDeprecationRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceFieldgroupToFieldsetRector/ReplaceFieldgroupToFieldsetRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceFieldgroupToFieldsetRector/ReplaceFieldgroupToFieldsetRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceFieldgroupToFiel
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceFieldgroupToFieldsetRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceFieldgroupToFieldsetRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceHideShowWithPrintedRector/ReplaceHideShowWithPrintedRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceHideShowWithPrintedRector/ReplaceHideShowWithPrintedRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceHideShowWithPrintedRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceHideShowWithPrintedRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/ReplaceItemAttributesWithAttributesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceItemAttributesWithAttributesRector/ReplaceItemAttributesWithAttributesRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceItemAttributesWi
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceItemAttributesWithAttributesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceItemAttributesWithAttributesRectorTest extends AbstractDrupalRector
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/ReplaceLocaleBatchProceduralFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleBatchProceduralFunctionsRector/ReplaceLocaleBatchProceduralFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceLocaleBatchProce
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceLocaleBatchProceduralFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class ReplaceLocaleBatchProceduralFunctionsRectorTest extends AbstractDrupalRect
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleConfigBatchFunctionsRector/ReplaceLocaleConfigBatchFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleConfigBatchFunctionsRector/ReplaceLocaleConfigBatchFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceLocaleConfigBatc
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceLocaleConfigBatchFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceLocaleConfigBatchFunctionsRectorTest extends AbstractDrupalRectorTe
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleTranslationPathConfigRector/ReplaceLocaleTranslationPathConfigRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceLocaleTranslationPathConfigRector/ReplaceLocaleTranslationPathConfigRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceLocaleTranslatio
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceLocaleTranslationPathConfigRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceLocaleTranslationPathConfigRectorTest extends AbstractDrupalRectorT
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeAccessViewAllNodesRector/ReplaceNodeAccessViewAllNodesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeAccessViewAllNodesRector/ReplaceNodeAccessViewAllNodesRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNodeAccessViewAl
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceNodeAccessViewAllNodesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceNodeAccessViewAllNodesRectorTest extends AbstractDrupalRectorTestCa
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeAddBodyFieldRector/ReplaceNodeAddBodyFieldRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeAddBodyFieldRector/ReplaceNodeAddBodyFieldRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNodeAddBodyField
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceNodeAddBodyFieldRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceNodeAddBodyFieldRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeModuleProceduralFunctionsRector/ReplaceNodeModuleProceduralFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeModuleProceduralFunctionsRector/ReplaceNodeModuleProceduralFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNodeModuleProced
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceNodeModuleProceduralFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceNodeModuleProceduralFunctionsRectorTest extends AbstractDrupalRecto
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeSetPreviewModeRector/ReplaceNodeSetPreviewModeRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeSetPreviewModeRector/ReplaceNodeSetPreviewModeRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNodeSetPreviewMo
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceNodeSetPreviewModeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceNodeSetPreviewModeRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/ReplaceNodeViewControllerRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNodeViewControllerRector/ReplaceNodeViewControllerRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNodeViewControllerRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceNodeViewControllerRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceNonBoolAccessRector/ReplaceNonBoolAccessRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceNonBoolAccessRector/ReplaceNonBoolAccessRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceNonBoolAccessRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceNonBoolAccessRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ReplacePdoFetchConstantsRector/ReplacePdoFetchConstantsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplacePdoFetchConstantsRector/ReplacePdoFetchConstantsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplacePdoFetchConstant
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplacePdoFetchConstantsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplacePdoFetchConstantsRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceRecipeRunnerInstallModuleRector/ReplaceRecipeRunnerInstallModuleRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceRecipeRunnerInstallModuleRector/ReplaceRecipeRunnerInstallModuleRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceRecipeRunnerInst
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceRecipeRunnerInstallModuleRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceRecipeRunnerInstallModuleRectorTest extends AbstractDrupalRectorTes
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceSessionManagerDeleteRector/ReplaceSessionManagerDeleteRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceSessionManagerDeleteRector/ReplaceSessionManagerDeleteRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceSessionManagerDe
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceSessionManagerDeleteRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceSessionManagerDeleteRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceSessionWritesWithRequestSessionRector/ReplaceSessionWritesWithRequestSessionRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceSessionWritesWithRequestSessionRector/ReplaceSessionWritesWithRequestSessionRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceSessionWritesWit
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceSessionWritesWithRequestSessionRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceSessionWritesWithRequestSessionRectorTest extends AbstractDrupalRec
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceSystemPerformanceGzipKeyRector/ReplaceSystemPerformanceGzipKeyRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceSystemPerformanceGzipKeyRector/ReplaceSystemPerformanceGzipKeyRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceSystemPerformanc
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceSystemPerformanceGzipKeyRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceSystemPerformanceGzipKeyRectorTest extends AbstractDrupalRectorTest
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceThemeGetSettingRector/ReplaceThemeGetSettingRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceThemeGetSettingRector/ReplaceThemeGetSettingRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceThemeGetSettingR
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceThemeGetSettingRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceThemeGetSettingRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceTwigExtensionRector/ReplaceTwigExtensionRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceTwigExtensionRector/ReplaceTwigExtensionRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceTwigExtensionRec
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceTwigExtensionRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceTwigExtensionRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/ReplaceUserOneTimeAuthFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserOneTimeAuthFunctionsRector/ReplaceUserOneTimeAuthFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceUserOneTimeAuthF
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceUserOneTimeAuthFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class ReplaceUserOneTimeAuthFunctionsRectorTest extends AbstractDrupalRectorTest
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceUserSessionNamePropertyRector/ReplaceUserSessionNamePropertyRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceUserSessionNamePropertyRector/ReplaceUserSessionNamePropertyRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceUserSessionNameP
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceUserSessionNamePropertyRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceUserSessionNamePropertyRectorTest extends AbstractDrupalRectorTestC
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ReplaceViewsProceduralFunctionsRector/ReplaceViewsProceduralFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ReplaceViewsProceduralFunctionsRector/ReplaceViewsProceduralFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ReplaceViewsProceduralF
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ReplaceViewsProceduralFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ReplaceViewsProceduralFunctionsRectorTest extends AbstractDrupalRectorTest
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('11.3.0');

--- a/tests/src/Drupal11/Rector/Deprecation/StatementPrefetchIteratorFetchColumnRector/StatementPrefetchIteratorFetchColumnRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/StatementPrefetchIteratorFetchColumnRector/StatementPrefetchIteratorFetchColumnRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\StatementPrefetchIterat
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class StatementPrefetchIteratorFetchColumnRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class StatementPrefetchIteratorFetchColumnRectorTest extends AbstractDrupalRecto
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/StripMigrationDependenciesExpandArgRector/StripMigrationDependenciesExpandArgRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/StripMigrationDependenciesExpandArgRector/StripMigrationDependenciesExpandArgRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\StripMigrationDependenc
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class StripMigrationDependenciesExpandArgRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class StripMigrationDependenciesExpandArgRectorTest extends AbstractDrupalRector
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/SystemRegionFunctionsRector/SystemRegionFunctionsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/SystemRegionFunctionsRector/SystemRegionFunctionsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\SystemRegionFunctionsRe
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SystemRegionFunctionsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -22,7 +23,7 @@ class SystemRegionFunctionsRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/SystemSortThemesRector/SystemSortThemesRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/SystemSortThemesRector/SystemSortThemesRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\SystemSortThemesRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class SystemSortThemesRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/TaxonomyTermPageVariableToViewModeRector/TaxonomyTermPageVariableToViewModeRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/TaxonomyTermPageVariableToViewModeRector/TaxonomyTermPageVariableToViewModeRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\TaxonomyTermPageVariableToViewModeRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class TaxonomyTermPageVariableToViewModeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/UploadedFileConstraintArrayOptionsToNamedArgsRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UploadedFileConstraintArrayOptionsToNamedArgsRector/UploadedFileConstraintArrayOptionsToNamedArgsRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\UploadedFileConstraintA
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UploadedFileConstraintArrayOptionsToNamedArgsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class UploadedFileConstraintArrayOptionsToNamedArgsRectorTest extends AbstractDr
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/UseEntityTypeHasIntegerIdRector/UseEntityTypeHasIntegerIdRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UseEntityTypeHasIntegerIdRector/UseEntityTypeHasIntegerIdRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\UseEntityTypeHasInteger
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UseEntityTypeHasIntegerIdRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class UseEntityTypeHasIntegerIdRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/UserLoadByNameAndMailRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/UserLoadByNameAndMailRector/UserLoadByNameAndMailRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\UserLoadByNameAndMailRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class UserLoadByNameAndMailRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ViewsBlockItemsPerPageNoneToNullRector/ViewsBlockItemsPerPageNoneToNullRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ViewsBlockItemsPerPageNoneToNullRector/ViewsBlockItemsPerPageNoneToNullRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ViewsBlockItemsPerPageNoneToNullRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ViewsBlockItemsPerPageNoneToNullRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal11/Rector/Deprecation/ViewsConfigUpdaterClassResolverToServiceRector/ViewsConfigUpdaterClassResolverToServiceRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ViewsConfigUpdaterClassResolverToServiceRector/ViewsConfigUpdaterClassResolverToServiceRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ViewsConfigUpdaterClass
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ViewsConfigUpdaterClassResolverToServiceRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -21,7 +22,7 @@ class ViewsConfigUpdaterClassResolverToServiceRectorTest extends AbstractDrupalR
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal11/Rector/Deprecation/ViewsPluginHandlerManagerRector/ViewsPluginHandlerManagerRectorTest.php
+++ b/tests/src/Drupal11/Rector/Deprecation/ViewsPluginHandlerManagerRector/ViewsPluginHandlerManagerRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal11\Rector\Deprecation\ViewsPluginHandlerManag
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class ViewsPluginHandlerManagerRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class ViewsPluginHandlerManagerRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Drupal12/Rector/Deprecation/AddSymfonyConstraintValidatorTypeDeclarationsRector/AddSymfonyConstraintValidatorTypeDeclarationsRectorTest.php
+++ b/tests/src/Drupal12/Rector/Deprecation/AddSymfonyConstraintValidatorTypeDeclarationsRector/AddSymfonyConstraintValidatorTypeDeclarationsRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Drupal12\Rector\Deprecation\AddSymfonyConstraintValidatorTypeDeclarationsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AddSymfonyConstraintValidatorTypeDeclarationsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal8/Rector/Deprecation/DrupalSetMessageRector/DrupalSetMessageRectorTest.php
+++ b/tests/src/Drupal8/Rector/Deprecation/DrupalSetMessageRector/DrupalSetMessageRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal8\Rector\Deprecation\DrupalSetMessageRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class DrupalSetMessageRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal8/Rector/Deprecation/EntityDeleteMultipleRector/EntityDeleteMultipleRectorTest.php
+++ b/tests/src/Drupal8/Rector/Deprecation/EntityDeleteMultipleRector/EntityDeleteMultipleRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal8\Rector\Deprecation\EntityDeleteMultipleRect
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class EntityDeleteMultipleRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal8/Rector/Deprecation/EntityManagerRector/EntityManagerRectorTest.php
+++ b/tests/src/Drupal8/Rector/Deprecation/EntityManagerRector/EntityManagerRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal8\Rector\Deprecation\EntityManagerRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class EntityManagerRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal8/Rector/Deprecation/EntityViewRector/EntityViewRectorTest.php
+++ b/tests/src/Drupal8/Rector/Deprecation/EntityViewRector/EntityViewRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal8\Rector\Deprecation\EntityViewRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class EntityViewRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector/FunctionalTestDefaultThemePropertyRectorTest.php
+++ b/tests/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector/FunctionalTestDefaultThemePropertyRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal8\Rector\Deprecation\FunctionalTestDefaultThe
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use DrupalRector\Tests\Rector\Class_\FunctionalTestDefaultThemePropertyRector\Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class FunctionalTestDefaultThemePropertyRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector/config/configured_rule.php
+++ b/tests/src/Drupal8/Rector/Deprecation/FunctionalTestDefaultThemePropertyRector/config/configured_rule.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Drupal8\Rector\Deprecation\FunctionalTestDefaultThemePropertyRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(DrupalRector\Drupal8\Rector\Deprecation\FunctionalTestDefaultThemePropertyRector::class);
+    $rectorConfig->rule(FunctionalTestDefaultThemePropertyRector::class);
 };

--- a/tests/src/Drupal8/Rector/Deprecation/GetMockRector/GetMockRectorTest.php
+++ b/tests/src/Drupal8/Rector/Deprecation/GetMockRector/GetMockRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal8\Rector\Deprecation\GetMockRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class GetMockRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/AssertFieldByIdRector/AssertFieldByIdRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertFieldByIdRector/AssertFieldByIdRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\AssertFieldByIdRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class AssertFieldByIdRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/AssertFieldByNameRector/AssertFieldByNameRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertFieldByNameRector/AssertFieldByNameRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\AssertFieldByNameRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class AssertFieldByNameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector/AssertLegacyTraitRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertLegacyTraitRector/AssertLegacyTraitRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\AssertLegacyTraitRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class AssertLegacyTraitRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/AssertNoFieldByNameRector/AssertNoFieldByNameRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertNoFieldByNameRector/AssertNoFieldByNameRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\AssertNoFieldByNameRecto
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class AssertNoFieldByNameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/AssertNoUniqueTextRector/AssertNoUniqueTextRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/AssertNoUniqueTextRector/AssertNoUniqueTextRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\AssertNoUniqueTextRector
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class AssertNoUniqueTextRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/ExtensionPathRector/ExtensionPathRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/ExtensionPathRector/ExtensionPathRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\ExtensionPathRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class ExtensionPathRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/FileFunctionRector/FileFunctionRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/FileFunctionRector/FileFunctionRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\FileFunctionRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class FileFunctionRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/FileUrlGeneratorRector/FileUrlGeneratorRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/FileUrlGeneratorRector/FileUrlGeneratorRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\FileUrlGeneratorRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class FileUrlGeneratorRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/ModuleLoadRector/ModuleLoadRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/ModuleLoadRector/ModuleLoadRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\ModuleLoadRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class ModuleLoadRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/PassRector/PassRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/PassRector/PassRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\PassRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class PassRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         if (str_contains($filePath, 'skip') && method_exists($this, 'doTestFileExpectingWarningAboutRuleApplied')) {

--- a/tests/src/Drupal9/Rector/Deprecation/SystemSortByInfoName/SystemSortByInfoNameRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/SystemSortByInfoName/SystemSortByInfoNameRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\SystemSortByInfoName;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class SystemSortByInfoNameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/TaxonomyRectorCollection/TaxonomyRectorCollectionTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/TaxonomyRectorCollection/TaxonomyRectorCollectionTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\TaxonomyRectorCollection
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class TaxonomyRectorCollectionTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector/UiHelperTraitDrupalPostFormRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/UiHelperTraitDrupalPostFormRector/UiHelperTraitDrupalPostFormRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\UiHelperTraitDrupalPostF
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class UiHelperTraitDrupalPostFormRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Deprecation/UserPasswordRector/UserPasswordRectorTest.php
+++ b/tests/src/Drupal9/Rector/Deprecation/UserPasswordRector/UserPasswordRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Drupal9\Rector\Deprecation\UserPasswordRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class UserPasswordRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector/ProtectedStaticModulesPropertyRectorTest.php
+++ b/tests/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector/ProtectedStaticModulesPropertyRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Drupal9\Rector\Property\ProtectedStaticModulesPrope
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 final class ProtectedStaticModulesPropertyRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector/config/configured_rule.php
+++ b/tests/src/Drupal9/Rector/Property/ProtectedStaticModulesPropertyRector/config/configured_rule.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
+use DrupalRector\Drupal9\Rector\Property\ProtectedStaticModulesPropertyRector;
 use Rector\Config\RectorConfig;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->rule(DrupalRector\Drupal9\Rector\Property\ProtectedStaticModulesPropertyRector::class);
+    $rectorConfig->rule(ProtectedStaticModulesPropertyRector::class);
 };

--- a/tests/src/Rector/AbstractDrupalCoreRector/AbstractDrupalCoreRectorBcTest.php
+++ b/tests/src/Rector/AbstractDrupalCoreRector/AbstractDrupalCoreRectorBcTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Rector\AbstractDrupalCoreRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AbstractDrupalCoreRectorBcTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/AbstractDrupalCoreRector/AbstractDrupalCoreRectorTest.php
+++ b/tests/src/Rector/AbstractDrupalCoreRector/AbstractDrupalCoreRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Rector\AbstractDrupalCoreRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class AbstractDrupalCoreRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorFixtureTest.php
+++ b/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorFixtureTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Rector\Convert\HookConvertRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HookConvertRectorFixtureTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
+++ b/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
@@ -10,9 +10,14 @@ use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\Function_;
+use PhpParser\NodeFinder;
 use PhpParser\ParserFactory;
 use PHPUnit\Framework\TestCase;
+use Rector\Configuration\Option;
+use Rector\Configuration\Parameter\SimpleParameterProvider;
+use Rector\NodeAnalyzer\ExprAnalyzer;
 use Rector\PhpParser\Printer\BetterStandardPrinter;
+use Rector\Util\Reflection\PrivatesAccessor;
 
 class HookConvertRectorTest extends TestCase
 {
@@ -165,7 +170,7 @@ CODE);
         // t() became $this->t(), so the method must stay an instance method.
         $this->assertFalse($method->isStatic(), 'A method using $this->t() must not be static.');
 
-        $finder = new \PhpParser\NodeFinder();
+        $finder = new NodeFinder();
         $thisT = $finder->findFirst(
             $method->stmts ?? [],
             fn (Node $n) => $n instanceof Node\Expr\MethodCall
@@ -195,7 +200,7 @@ CODE);
 
         $this->assertFalse($method->isStatic(), '\t() must be rewritten to $this->t() and keep the method instance.');
 
-        $finder = new \PhpParser\NodeFinder();
+        $finder = new NodeFinder();
         $funcCall = $finder->findFirst(
             $method->stmts ?? [],
             fn (Node $n) => $n instanceof Node\Expr\FuncCall
@@ -233,7 +238,7 @@ function mymodule_user_cancel($edit, $account, $method) {
 }
 CODE);
 
-        $finder = new \PhpParser\NodeFinder();
+        $finder = new NodeFinder();
         $thisCalls = $finder->find(
             $method->stmts ?? [],
             fn (Node $n) => $n instanceof Node\Expr\MethodCall
@@ -263,12 +268,12 @@ CODE);
     {
         // Indent parameters are normally seeded by the Rector container; set
         // them so the standalone printer can lay out statements.
-        \Rector\Configuration\Parameter\SimpleParameterProvider::setParameter(\Rector\Configuration\Option::INDENT_CHAR, ' ');
-        \Rector\Configuration\Parameter\SimpleParameterProvider::setParameter(\Rector\Configuration\Option::INDENT_SIZE, 4);
+        SimpleParameterProvider::setParameter(Option::INDENT_CHAR, ' ');
+        SimpleParameterProvider::setParameter(Option::INDENT_SIZE, 4);
 
-        $exprAnalyzer = (new \ReflectionClass(\Rector\NodeAnalyzer\ExprAnalyzer::class))->newInstanceWithoutConstructor();
+        $exprAnalyzer = (new \ReflectionClass(ExprAnalyzer::class))->newInstanceWithoutConstructor();
 
-        return new BetterStandardPrinter($exprAnalyzer, new \Rector\Util\Reflection\PrivatesAccessor());
+        return new BetterStandardPrinter($exprAnalyzer, new PrivatesAccessor());
     }
 
     public function testGeneratedHookClassFileIsPrintedCorrectly(): void

--- a/tests/src/Rector/Deprecation/ClassConstantToClassConstantRector/ClassConstantToClassConstantRectorTest.php
+++ b/tests/src/Rector/Deprecation/ClassConstantToClassConstantRector/ClassConstantToClassConstantRectorTest.php
@@ -7,11 +7,13 @@ namespace DrupalRector\Tests\Rector\Deprecation\ClassConstantToClassConstantRect
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class ClassConstantToClassConstantRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
@@ -25,7 +27,7 @@ class ClassConstantToClassConstantRectorTest extends AbstractDrupalRectorTestCas
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Rector/Deprecation/ConstantToClassConstantRector/ConstantToClassConstantRectorTest.php
+++ b/tests/src/Rector/Deprecation/ConstantToClassConstantRector/ConstantToClassConstantRectorTest.php
@@ -7,11 +7,13 @@ namespace DrupalRector\Tests\Rector\Deprecation\ConstantToClassConstantRector;
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class ConstantToClassConstantRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
@@ -25,7 +27,7 @@ class ConstantToClassConstantRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Rector/Deprecation/DeprecationHelperRemoveRector/DeprecationHelperRemoveRectorTest.php
+++ b/tests/src/Rector/Deprecation/DeprecationHelperRemoveRector/DeprecationHelperRemoveRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\Deprecation\DeprecationHelperRemoveRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class DeprecationHelperRemoveRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Deprecation/DrupalServiceRenameRector/DrupalServiceRenameRectorTest.php
+++ b/tests/src/Rector/Deprecation/DrupalServiceRenameRector/DrupalServiceRenameRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Rector\Deprecation\DrupalServiceRenameRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class DrupalServiceRenameRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Deprecation/FunctionCallRemovalRector/FunctionCallRemovalRectorTest.php
+++ b/tests/src/Rector/Deprecation/FunctionCallRemovalRector/FunctionCallRemovalRectorTest.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Rector\Deprecation\FunctionCallRemovalRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FunctionCallRemovalRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Deprecation/FunctionToFirstArgMethodRector/FunctionToFirstArgMethodRectorTest.php
+++ b/tests/src/Rector/Deprecation/FunctionToFirstArgMethodRector/FunctionToFirstArgMethodRectorTest.php
@@ -6,10 +6,11 @@ namespace DrupalRector\Tests\Rector\Deprecation\FunctionToFirstArgMethodRector;
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class FunctionToFirstArgMethodRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function testAboveVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');
@@ -24,7 +25,7 @@ class FunctionToFirstArgMethodRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/FunctionToFirstArgMethodSetCollisionTest.php
+++ b/tests/src/Rector/Deprecation/FunctionToFirstArgMethodSetCollision/FunctionToFirstArgMethodSetCollisionTest.php
@@ -6,6 +6,7 @@ namespace DrupalRector\Tests\Rector\Deprecation\FunctionToFirstArgMethodSetColli
 
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * Regression test for the Drupal 9 + Drupal 11 set collision.
@@ -19,7 +20,7 @@ use DrupalRector\Tests\AbstractDrupalRectorTestCase;
  */
 class FunctionToFirstArgMethodSetCollisionTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('99.99.99');

--- a/tests/src/Rector/Deprecation/FunctionToServiceRector/FunctionToServiceRectorTest.php
+++ b/tests/src/Rector/Deprecation/FunctionToServiceRector/FunctionToServiceRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\Deprecation\FunctionToServiceRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class FunctionToServiceRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Deprecation/FunctionToStaticRector/FunctionToStaticRectorTest.php
+++ b/tests/src/Rector/Deprecation/FunctionToStaticRector/FunctionToStaticRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\Deprecation\FunctionToStaticRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class FunctionToStaticRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/MethodToMethodWithCheckRectorTest.php
+++ b/tests/src/Rector/Deprecation/MethodToMethodWithCheckRector/MethodToMethodWithCheckRectorTest.php
@@ -7,11 +7,13 @@ namespace DrupalRector\Tests\Rector\Deprecation\MethodToMethodWithCheckRector;
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class MethodToMethodWithCheckRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);
@@ -25,7 +27,7 @@ class MethodToMethodWithCheckRectorTest extends AbstractDrupalRectorTestCase
         return self::yieldFilesFromDirectory(__DIR__.'/fixture');
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideDataBelowVersion')]
+    #[DataProvider('provideDataBelowVersion')]
     public function testBelowVersion(string $filePath): void
     {
         static::getContainer()->make(DrupalRectorSettings::class)->setDrupalVersion('1.0.0');

--- a/tests/src/Rector/PHPUnit/PhpUnitAddRunTestsInSeparateProcessesAttributeRector/BelowVersionPhpUnitAddRunTestsInSeparateProcessesAttributeRectorTest.php
+++ b/tests/src/Rector/PHPUnit/PhpUnitAddRunTestsInSeparateProcessesAttributeRector/BelowVersionPhpUnitAddRunTestsInSeparateProcessesAttributeRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\PHPUnit\PhpUnitAddRunTestsInSeparateProcesse
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class BelowVersionPhpUnitAddRunTestsInSeparateProcessesAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/PHPUnit/PhpUnitAddRunTestsInSeparateProcessesAttributeRector/PhpUnitAddRunTestsInSeparateProcessesAttributeRectorTest.php
+++ b/tests/src/Rector/PHPUnit/PhpUnitAddRunTestsInSeparateProcessesAttributeRector/PhpUnitAddRunTestsInSeparateProcessesAttributeRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\PHPUnit\PhpUnitAddRunTestsInSeparateProcesse
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class PhpUnitAddRunTestsInSeparateProcessesAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector/BackwardCompatibilityDisabledPhpUnitTestAnnotationToAttributeRectorTest.php
+++ b/tests/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector/BackwardCompatibilityDisabledPhpUnitTestAnnotationToAttributeRectorTest.php
@@ -7,8 +7,10 @@ namespace DrupalRector\Tests\Rector\PHPUnit\PhpUnitTestAnnotationToAttributeRect
 use DrupalRector\Services\DrupalRectorSettings;
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class BackwardCompatibilityDisabledPhpUnitTestAnnotationToAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
     protected function setUp(): void
@@ -19,7 +21,7 @@ class BackwardCompatibilityDisabledPhpUnitTestAnnotationToAttributeRectorTest ex
         static::getContainer()->make(DrupalRectorSettings::class)->disableBackwardCompatibility();
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector/BackwardsCompatibilityPhpUnitTestAnnotationToAttributeRectorTest.php
+++ b/tests/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector/BackwardsCompatibilityPhpUnitTestAnnotationToAttributeRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\PHPUnit\PhpUnitTestAnnotationToAttributeRect
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class BackwardsCompatibilityPhpUnitTestAnnotationToAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector/PhpUnitTestAnnotationToAttributeRectorTest.php
+++ b/tests/src/Rector/PHPUnit/PhpUnitTestAnnotationToAttributeRector/PhpUnitTestAnnotationToAttributeRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\PHPUnit\PhpUnitTestAnnotationToAttributeRect
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class PhpUnitTestAnnotationToAttributeRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/ShouldCallParentMethodsRectorTest.php
+++ b/tests/src/Rector/PHPUnit/ShouldCallParentMethodsRector/ShouldCallParentMethodsRectorTest.php
@@ -6,11 +6,13 @@ namespace DrupalRector\Tests\Rector\PHPUnit\ShouldCallParentMethodsRector;
 
 use DrupalRector\Tests\AbstractDrupalRectorTestCase;
 use Iterator;
+use PHPUnit\Framework\Attributes\CoversFunction;
+use PHPUnit\Framework\Attributes\DataProvider;
 
-#[\PHPUnit\Framework\Attributes\CoversFunction('refactor')]
+#[CoversFunction('refactor')]
 class ShouldCallParentMethodsRectorTest extends AbstractDrupalRectorTestCase
 {
-    #[\PHPUnit\Framework\Attributes\DataProvider('provideData')]
+    #[DataProvider('provideData')]
     public function test(string $filePath): void
     {
         $this->doTestFile($filePath);

--- a/tests/src/Set/DrupalSetProviderTest.php
+++ b/tests/src/Set/DrupalSetProviderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DrupalRector\Tests\Set;
 
 use DrupalRector\Set\DrupalSetProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Rector\Composer\ValueObject\InstalledPackage;
 use Rector\Set\ValueObject\ComposerTriggeredSet;
@@ -101,7 +102,7 @@ final class DrupalSetProviderTest extends TestCase
     /**
      * @param string[] $expectedFiles
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('installedVersionProvider')]
+    #[DataProvider('installedVersionProvider')]
     public function testCumulativeMatchingByInstalledCoreVersion(string $installedVersion, array $expectedFiles): void
     {
         $installedPackages = [


### PR DESCRIPTION
## Description
To get rule docs on getrector.php we need to extend an interface. See https://github.com/rectorphp/rector/issues/9778#issuecomment-4918908262

## Drupal.org issue
Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.
