### PR TITLE
docs: prepare 1.1.0 release and backfill 1.0.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ release-by-release.
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-07-09
+
+### Added
+
+- **`AddSymfonyConstraintValidatorTypeDeclarationsRector`** — adds the Symfony 8 / Drupal 12 type declarations (`mixed $value` and `: void` on `validate()`, `: void` on `initialize()`) to `Symfony\Component\Validator\ConstraintValidatorInterface` implementers. Backward compatible on all supported Drupal versions, so no version gate. ([#3600790](https://git.drupalcode.org/project/rector/-/work_items/3600790))
+
 ### Fixed
 
 - **`RemoveAliasManagerCacheMethodCallsRector`** — no longer removes calls to
@@ -25,9 +31,14 @@ release-by-release.
   skipped on 11.3+. When BC support is disabled the call is removed as before.
   Reported by Berdir ([#3600789](https://git.drupalcode.org/project/rector/-/work_items/3600789)).
 
-### Added
+## [1.0.1] — 2026-07-02
 
-- **`AddSymfonyConstraintValidatorTypeDeclarationsRector`** — adds the Symfony 8 / Drupal 12 type declarations (`mixed $value` and `: void` on `validate()`, `: void` on `initialize()`) to `Symfony\Component\Validator\ConstraintValidatorInterface` implementers. Backward compatible on all supported Drupal versions, so no version gate. [#3600790]
+### Fixed
+
+- **Composer-based sets bootstrap** — the Drupal bootstrap now loads correctly
+  when rector is run through the composer-based sets, so rules that rely on the
+  Drupal container / class map resolve as expected in that scenario
+  ([#404](https://github.com/palantirnet/drupal-rector/pull/404)).
 
 ## [1.0.0] — 2026-07-02
 


### PR DESCRIPTION
## Summary

Prepares the **1.1.0** release and fixes the changelog, which had drifted for 1.0.1.

### Changelog fixes
- **Backfill `## [1.0.1] — 2026-07-02`** — the composer-based sets bootstrap fix ([#404](https://github.com/palantirnet/drupal-rector/pull/404)) was tagged as `1.0.1` on 2026-07-02 but never got a changelog section. It was sitting mislabeled under `[Unreleased]`.
- **New `## [1.1.0] — 2026-07-09`** — collects everything on `main` since 1.0.1:
  - **Added** `AddSymfonyConstraintValidatorTypeDeclarationsRector` (Symfony 8 / Drupal 12 validator type declarations, [#3600790](https://git.drupalcode.org/project/rector/-/work_items/3600790))
  - **Fixed** `RemoveAliasManagerCacheMethodCallsRector` BC regression on Drupal < 11.3 ([#3600789](https://git.drupalcode.org/project/rector/-/work_items/3600789))
- **Fixed broken link** — the `[#3600790]` reference was undefined; now inlined to the full GitLab URL.
- `[Unreleased]` is now empty.

### Not included
- The getrector.com documentation work (`DocumentedRuleInterface` + non-empty after-samples) on `fix/rule-documentation` is intentionally left out — it'll ship in a later release.

### Release steps after merge
1. Tag `1.1.0` on the merge commit and push (Packagist reads the tag; no hardcoded version anywhere).
2. Optionally create the GitHub Release with these notes.