### PR TITLE
Don't make converted hook methods static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ release-by-release.
 
 - **Rule documentation on [getrector.com](https://getrector.com)** — all rules now implement Rector's `DocumentedRuleInterface`, so their definitions and code samples are picked up and published on the getrector.com documentation site. ([#3600962](https://git.drupalcode.org/project/rector/-/work_items/3600962))
 
+### Changed
+
+- **`HookConvertRector`** — converted hook methods are no longer declared `static` when they don't reference `$this`; they are always generated as plain `public` methods. Making them `static` followed a PHPStan opinion that doesn't fit hooks: hooks are essentially interface implementations (they implement a contract rather than defining an API), and core always calls them as a method on an object, so implementations don't get to decide to be static. Reverts the `static` behavior added in [#3600921](https://git.drupalcode.org/project/rector/-/work_items/3600921). Reported by Berdir ([#3600963](https://git.drupalcode.org/project/rector/-/work_items/3600963)).
+
 ## [1.1.0] — 2026-07-09
 
 ### Added

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -315,9 +315,7 @@ CODE_SAMPLE
                 public function leaveNode(Node $node)
                 {
                     // Rewrite the global t() to $this->t() so the method uses
-                    // StringTranslationTrait. This intentionally introduces
-                    // $this, which keeps the method non-static. Matches both
-                    // t() and \t().
+                    // StringTranslationTrait. Matches both t() and \t().
                     if ($node instanceof Node\Expr\FuncCall && $node->name instanceof Node\Name && $node->name->toString() === 't') {
                         $this->usedTranslation = true;
 

--- a/src/Rector/Convert/HookConvertRector.php
+++ b/src/Rector/Convert/HookConvertRector.php
@@ -348,15 +348,7 @@ CODE_SAMPLE
             }
             // Convert the function to a method.
             $method = new ClassMethod($this->getMethodName($node), get_object_vars($node), $node->getAttributes());
-            // Declare the method static when its body never touches $this. The
-            // body comes from a procedural function, so the only $this it can
-            // contain is the one introduced by the t() -> $this->t() rewrite
-            // above; that case correctly keeps the method non-static.
-            $usesThis = (bool) (new NodeFinder())->findFirst(
-                $method->stmts ?? [],
-                fn (Node $n) => $n instanceof Node\Expr\Variable && \is_string($n->name) && $n->name === 'this'
-            );
-            $method->flags = $usesThis ? Modifiers::PUBLIC : Modifiers::PUBLIC | Modifiers::STATIC;
+            $method->flags = Modifiers::PUBLIC;
             // Assemble the arguments for the #[Hook] attribute.
             $arguments = [new Node\Arg(new String_($hook))];
             if ($implementsModule !== $this->module) {

--- a/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks.php
+++ b/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks.php
@@ -13,7 +13,7 @@ class HookconvertrectorHooks
      * Implements hook_user_cancel().
      */
     #[Hook('user_cancel')]
-    public static function userCancel($edit, \UserInterface $account, $method)
+    public function userCancel($edit, \UserInterface $account, $method)
     {
         $red = 'red';
         $method = [
@@ -32,7 +32,7 @@ class HookconvertrectorHooks
      * Implements hook_page_attachments().
      */
     #[Hook('page_attachments')]
-    public static function pageAttachments(array &$page)
+    public function pageAttachments(array &$page)
     {
         // Routes that don't use BigPipe also don't need no-JS detection.
         if (\Drupal::routeMatch()->getRouteObject()->getOption('_no_big_pipe')) {

--- a/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks1.php
+++ b/tests/functional/hookconvertrector/fixture/hookconvertrector_updated/src/Hook/HookconvertrectorHooks1.php
@@ -13,7 +13,7 @@ class HookconvertrectorHooks1
      * Implements hook_theme_suggestions_HOOK_alter().
      */
     #[Hook('theme_suggestions_form_element_alter')]
-    public static function themeSuggestionsFormElementAlter(&$suggestions, $variables)
+    public function themeSuggestionsFormElementAlter(&$suggestions, $variables)
     {
         $red = 'red';
         $method = [
@@ -32,7 +32,7 @@ class HookconvertrectorHooks1
      * Implements hook_page_attachments_alter().
      */
     #[Hook('page_attachments_alter')]
-    public static function pageAttachmentsAlter(array &$page)
+    public function pageAttachmentsAlter(array &$page)
     {
         // Routes that don't use BigPipe also don't need no-JS detection.
         if (\Drupal::routeMatch()->getRouteObject()->getOption('_no_big_pipe')) {

--- a/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
+++ b/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
@@ -140,21 +140,6 @@ class HookConvertRectorTest extends TestCase
         return $method->invoke($this->rector, $fn);
     }
 
-    public function testMethodWithoutThisIsDeclaredStatic(): void
-    {
-        $method = $this->createMethod(<<<'CODE'
-<?php
-/**
- * Implements hook_user_cancel().
- */
-function mymodule_user_cancel($edit, $account, $method) {
-    $account->block();
-}
-CODE);
-
-        $this->assertTrue($method->isStatic(), 'A method that never uses $this should be static.');
-    }
-
     public function testTranslationCallMakesMethodInstanceAndFlagsTrait(): void
     {
         $method = $this->createMethod(<<<'CODE'
@@ -330,6 +315,6 @@ CODE));
         $this->assertStringContainsString('public function userCancel(', $output);
         $this->assertStringContainsString('$this->t(\'Cancelled\')', $output);
         // Non-translating hook is static.
-        $this->assertStringContainsString('public static function userLogin(', $output);
+        $this->assertStringContainsString('public function userLogin(', $output);
     }
 }

--- a/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
+++ b/tests/src/Rector/Convert/HookConvertRector/HookConvertRectorTest.php
@@ -281,8 +281,8 @@ CODE);
         $create = new \ReflectionMethod($rector, 'createMethodFromFunction');
         $create->setAccessible(true);
 
-        // One hook that translates (instance + $this->t()), one that does not
-        // (static). Bodies are array-free so the stubbed ExprAnalyzer is unused.
+        // One hook that translates (uses $this->t()), one that does not.
+        // Bodies are array-free so the stubbed ExprAnalyzer is unused.
         $class->stmts[] = $create->invoke($rector, $this->parseFunction(<<<'CODE'
 <?php
 /**
@@ -314,7 +314,7 @@ CODE));
         // Translating hook stays an instance method and uses $this->t().
         $this->assertStringContainsString('public function userCancel(', $output);
         $this->assertStringContainsString('$this->t(\'Cancelled\')', $output);
-        // Non-translating hook is static.
+        // Non-translating hook is still a plain instance method.
         $this->assertStringContainsString('public function userLogin(', $output);
     }
 }


### PR DESCRIPTION
Reverts the `static` behavior added in [#3600921](https://git.drupalcode.org/project/rector/-/work_items/3600921): `HookConvertRector` no longer declares $this-free hook methods `static`. It now always generates plain `public` methods.

### Why

Making hook methods `static` follows a PHPStan opinion — methods that don't need `$this` shouldn't have access to it — but that opinion doesn't fit hooks. PHPStan doesn't know that hooks are essentially interface implementations: they don't define an API, they implement one.

- It's similar to unused hook parameters: tools complain, but a hook implements a contract and the hook definition dictates the parameters you receive, so we declare them all even when unused. PHPStan wouldn't complain about implementing an actual interface — there's just no language feature for what hooks do.
- Same with `static`: core always calls hooks as a method on an object. Hook implementations don't get to decide that.

Rationale from @berdir.

Drupal issue: https://git.drupalcode.org/project/rector/-/work_items/3600963