### PR TITLE
feat: populate phpstan-drupal ServiceMap in bootstrap when Rector injects the PHPStan container [#3600964]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ release-by-release.
 ### Feature
 
 - **Rule documentation on [getrector.com](https://getrector.com)** — all rules now implement Rector's `DocumentedRuleInterface`, so their definitions and code samples are picked up and published on the getrector.com documentation site. ([#3600962](https://git.drupalcode.org/project/rector/-/work_items/3600962))
+- **phpstan-drupal ServiceMap in the bootstrap** — `config/drupal-phpunit-bootstrap-file.php` now hands off to phpstan-drupal's own `drupal-autoloader.php` when Rector injects the PHPStan container ([rectorphp/rector#8190](https://github.com/rectorphp/rector/pull/8190)), which populates phpstan-drupal's ServiceMap so `\Drupal::service('…')` type inference resolves concrete service classes instead of a bare `object`. On Rector versions without that container injection it falls back to the previous namespace-autoloading behaviour, so the change is backward compatible and needs no `rector/rector` constraint bump. ([#3600964](https://git.drupalcode.org/project/rector/-/work_items/3600964))
 
 ### Changed
 

--- a/config/drupal-phpunit-bootstrap-file.php
+++ b/config/drupal-phpunit-bootstrap-file.php
@@ -4,11 +4,19 @@
  * @file
  *
  * This fixes Drupal testing namespace autoloading and PHPUnit compatibility.
+ *
+ * Rector releases that contain rectorphp/rector#8190 inject the PHPStan
+ * dependency-injection container into bootstrap files as a `$container`
+ * variable. When it is present we hand off to phpstan-drupal's own
+ * `drupal-autoloader.php`, which not only sets up Drupal autoloading but also
+ * populates phpstan-drupal's ServiceMap — so `\Drupal::service('…')` type
+ * inference resolves to concrete service classes instead of a bare `object`.
+ *
+ * On older Rector (no `$container`) — or when phpstan-drupal is not installed,
+ * or the hand-off fails — we fall back to the legacy namespace-autoloading
+ * below, which is exactly the behaviour shipped before this change. This keeps
+ * the file working across Rector versions without a version bump.
  */
-
-use Rector\Core\Autoloading\BootstrapFilesIncluder;
-use Rector\Core\Exception\ShouldNotHappenException;
-
 
 if (class_exists('DrupalFinder\DrupalFinderComposerRuntime')) {
     $drupalFinder = new DrupalFinder\DrupalFinderComposerRuntime();
@@ -22,6 +30,25 @@ $drupalVendorRoot = $drupalFinder->getVendorDir();
 
 if (! (bool) $drupalRoot || ! (bool) $drupalVendorRoot) {
     throw new \RuntimeException("Unable to detect Drupal at $drupalRoot");
+}
+
+// Prefer phpstan-drupal's own autoloader when Rector gives us the PHPStan
+// container (rectorphp/rector#8190+). It performs the same test-namespace
+// autoloading as the legacy code below and, crucially, fills the ServiceMap
+// that `\Drupal::service()` type inference depends on. Guarded so any failure
+// (phpstan-drupal absent, ServiceMap service not registered because
+// extension.neon was not loaded, …) degrades to the legacy autoloading.
+if (isset($container) && $container instanceof \PHPStan\DependencyInjection\Container) {
+    $phpstanDrupalAutoloader = $drupalVendorRoot . '/mglaman/phpstan-drupal/drupal-autoloader.php';
+    if (file_exists($phpstanDrupalAutoloader)) {
+        try {
+            require $phpstanDrupalAutoloader;
+
+            return;
+        } catch (\Throwable $e) {
+            // Fall through to the legacy autoloading below.
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## What

Makes `config/drupal-phpunit-bootstrap-file.php` container-aware. When Rector injects the PHPStan DI container into bootstrap files ([rectorphp/rector#8190](https://github.com/rectorphp/rector/pull/8190)), it hands off to phpstan-drupal's own `drupal-autoloader.php`, which does the test-namespace autoloading **and** populates phpstan-drupal's `ServiceMap`. Otherwise it falls back to the existing legacy autoloading.

## Why

Rector only *builds* the PHPStan container from `phpstanConfigs([… /extension.neon])` — it never runs the extension's declared `bootstrapFiles:`. So phpstan-drupal's ServiceMap stays **empty** under Rector, and `\Drupal::service('renderer')` resolves to a bare `object` instead of `Drupal\Core\Render\Renderer`. Type-guarded rectors keyed on a `service()` receiver then silently skip real call sites. Our bootstrap only ever set up test-namespace autoloading; it never filled the ServiceMap. The old `bootstrapFiles([drupal-autoloader.php])` idea couldn't work because that file hard-requires a `$container` Rector didn't provide.

`#8190` provides exactly that `$container`, so we can finally delegate to phpstan-drupal's autoloader.

## Backward compatibility

Purely additive. The delegate path only runs when `$container instanceof PHPStan\DependencyInjection\Container`; on older Rector, when phpstan-drupal is absent, or if the hand-off throws, it falls through to the previous behaviour unchanged. **No `rector/rector` constraint bump** — the file works across Rector versions, and users on a release containing #8190 automatically gain accurate `\Drupal::service()` inference.

## Validation

Sandbox: Drupal 11.4.4, `rector/rector:dev-main`, `mglaman/phpstan-drupal:2.1.1`, drupal-rector as a path repo.

| Scenario | ServiceMap size | `service('renderer')` | Rule fires |
|---|---|---|---|
| Baseline (extension.neon loaded, autoloader not run) | 0 | bare `object` | — |
| Current fork bootstrap | 0 | bare `object` | — |
| Delegate branch (Rector #8190 injects `$container`) | **2025** | `Drupal\Core\Render\Renderer` | yes |
| Fallback branch (no `$container`) | identical to fork: **737** test namespaces registered, no throw | — | — |

`BlockContentTestBaseStringToArrayRector` produces an identical diff under the legacy fork and the new delegate path.

Also drops the stale `Rector\Core\*` `use` imports (Rector v1 namespace, unused).

## Notes

- rectorphp/rector#8190 is currently in Rector `dev-main` (unreleased); the delegate path activates automatically once it lands in a tagged release. Nothing here requires it — older Rector keeps working via the fallback.
- rectorphp/rector#9782 (auto-running an extension neon's own `bootstrapFiles:`) is still open; #8190 is the narrower enabling change, so we still list the bootstrap file explicitly.

Closes #411
Drupal.org issue: https://git.drupalcode.org/project/rector/-/work_items/3600964
