### PR TITLE
Fix comment typo in rector.php

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -48,7 +48,7 @@ return static function (RectorConfig $rectorConfig): void {
     //     new DeprecationHelperRemoveConfiguration(\Drupal::VERSION),
     // ]);
 
-    // When phsptan-drupal is available, we should load it to get better type
+    // When phpstan-drupal is available, we should load it to get better type
     // inference to use in rectors.
     $phpstanDrupalExtension = __DIR__.'/vendor/mglaman/phpstan-drupal/extension.neon';
     if (file_exists($phpstanDrupalExtension)) {


### PR DESCRIPTION
The phpstan-drupal package name was spelled wrong

## Description
Explain the technical implementation of the work done.


## To Test
- Add steps to test this feature

## Drupal.org issue
Provide a link to the issue from https://www.drupal.org/project/rector/issues. If no issue exists, please create one and link to this PR.



## ^Also an issue: The link to the issues in the GitHub issue template is wrong

It should link to this:

https://git.drupalcode.org/project/rector/-/work_items
