### PR TITLE
docs: backfill missing 1.1.1 and 1.1.2 changelog sections, prepare 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,20 +12,32 @@ release-by-release.
 
 ## [Unreleased]
 
-### Feature
-
-- **Rule documentation on [getrector.com](https://getrector.com)** — all rules now implement Rector's `DocumentedRuleInterface`, so their definitions and code samples are picked up and published on the getrector.com documentation site. ([#3600962](https://git.drupalcode.org/project/rector/-/work_items/3600962))
-- **phpstan-drupal ServiceMap in the bootstrap** — `config/drupal-phpunit-bootstrap-file.php` now hands off to phpstan-drupal's own `drupal-autoloader.php` when Rector injects the PHPStan container ([rectorphp/rector#8190](https://github.com/rectorphp/rector/pull/8190)), which populates phpstan-drupal's ServiceMap so `\Drupal::service('…')` type inference resolves concrete service classes instead of a bare `object`. On Rector versions without that container injection it falls back to the previous namespace-autoloading behaviour, so the change is backward compatible and needs no `rector/rector` constraint bump. ([#3600964](https://git.drupalcode.org/project/rector/-/work_items/3600964))
+## [1.1.3] — 2026-09-03
 
 ### Changed
 
 - **`rector/rector` 2.6.2 and newer are blocked** — added a `conflict` on `rector/rector >=2.6.2`. Rector 2.6.2 removed every version-specific set constant from its first-party extension packages ([rectorphp/rector-phpunit#760](https://github.com/rectorphp/rector-phpunit/pull/760)) in favour of the new composer-based sets, which makes the `Drupal8SetList`, `Drupal9SetList` and `Drupal10SetList` sets that reference `PHPUnitSetList`, `SymfonySetList` and `TwigSetList` constants abort with `Undefined constant …` or `Could not detect twig set.`. Verified: 2.6.1 is the last release on which every Drupal set loads; the Drupal 11 and 12 sets are unaffected because they reference no third-party sets. The conflict is a stopgap that keeps installs working while the sets are ported to the composer-based mechanism ([#419](https://github.com/palantirnet/drupal-rector/pull/419)); it will be lifted once that port lands. Reported by ptmkenny ([#420](https://github.com/palantirnet/drupal-rector/issues/420)).
-- **`HookConvertRector`** — converted hook methods are no longer declared `static` when they don't reference `$this`; they are always generated as plain `public` methods. Making them `static` followed a PHPStan opinion that doesn't fit hooks: hooks are essentially interface implementations (they implement a contract rather than defining an API), and core always calls them as a method on an object, so implementations don't get to decide to be static. Reverts the `static` behavior added in [#3600921](https://git.drupalcode.org/project/rector/-/work_items/3600921). Reported by Berdir ([#3600963](https://git.drupalcode.org/project/rector/-/work_items/3600963)).
+
+## [1.1.2] — 2026-08-07
+
+### Added
+
+- **phpstan-drupal ServiceMap in the bootstrap** — `config/drupal-phpunit-bootstrap-file.php` now hands off to phpstan-drupal's own `drupal-autoloader.php` when Rector injects the PHPStan container ([rectorphp/rector#8190](https://github.com/rectorphp/rector/pull/8190)), which populates phpstan-drupal's ServiceMap so `\Drupal::service('…')` type inference resolves concrete service classes instead of a bare `object`. On Rector versions without that container injection it falls back to the previous namespace-autoloading behaviour, so the change is backward compatible and needs no `rector/rector` constraint bump. ([#3600964](https://git.drupalcode.org/project/rector/-/work_items/3600964))
 
 ### Removed
 
 - **`RemoveAliasManagerCacheMethodCallsRector`** — removed; `AliasManager::setCacheKey()` / `writeCache()` calls ([#3496369](https://www.drupal.org/node/3496369)) are no longer rewritten by the Drupal 11.3 deprecation set. Both methods are no-ops from 11.3.0 on, so removing the call only reclaims a lost preload-cache micro-optimization, while with BC support enabled (the default) the rule emitted a `DeprecationHelper::backwardsCompatibleCall()` wrapper around a no-op. The value didn't justify the surface. Note for `upgrade_status` users: the two deprecation messages are still listed in `DeprecationAnalyzer::isRectorCovered()`, so upgrade_status will keep reporting them as rector-covered until that list is updated upstream. Reported by catch ([#415](https://github.com/palantirnet/drupal-rector/issues/415)).
 - **Drupal 11.4 search plugin renames dropped from `DRUPAL_114_BREAKING`** — the `Drupal\help\Plugin\Search\HelpSearch` → `Drupal\search_help\Plugin\Search\SearchHelpSearch` ([#3581109](https://www.drupal.org/node/3581109)) and `Drupal\node\Plugin\Search\NodeSearch` → `Drupal\search_node\Plugin\Search\SearchNode` ([#3587564](https://www.drupal.org/node/3587564)) `RenameClassRector` entries are no longer registered in the opt-in breaking set. Both replacements live in new core sub-modules, and the rename cannot add the matching `dependencies:` entry to the module's `info.yml`, so the output was incomplete by construction. Core has since restored both old classes as deprecated stubs on 11.4.x (drupal-core `af7dd6efc0`, [#3608912](https://www.drupal.org/i/3608912)), so the rename is no longer needed to avoid a missing-class fatal either. Reported by catch ([#414](https://github.com/palantirnet/drupal-rector/issues/414)).
+
+## [1.1.1] — 2026-07-11
+
+### Added
+
+- **Rule documentation on [getrector.com](https://getrector.com)** — all rules now implement Rector's `DocumentedRuleInterface`, so their definitions and code samples are picked up and published on the getrector.com documentation site. ([#3600962](https://git.drupalcode.org/project/rector/-/work_items/3600962))
+
+### Changed
+
+- **`HookConvertRector`** — converted hook methods are no longer declared `static` when they don't reference `$this`; they are always generated as plain `public` methods. Making them `static` followed a PHPStan opinion that doesn't fit hooks: hooks are essentially interface implementations (they implement a contract rather than defining an API), and core always calls them as a method on an object, so implementations don't get to decide to be static. Reverts the `static` behavior added in [#3600921](https://git.drupalcode.org/project/rector/-/work_items/3600921). Reported by Berdir ([#3600963](https://git.drupalcode.org/project/rector/-/work_items/3600963)).
 
 ## [1.1.0] — 2026-07-09
 


### PR DESCRIPTION
The changelog's newest released section is `[1.1.0]`, but **1.1.1 and 1.1.2 have both shipped since**. Everything they contained was still sitting under `[Unreleased]`, so the file claimed six unreleased items that users have had for weeks.

## What happened

The `docs: prepare 1.1.1 release` commit (`ce254b66`) was made on top of `17405041` and tagged `1.1.1` — but **never landed on `main`**. Later work continued from `17405041` with `[Unreleased]` untouched, and `1.1.2` was tagged straight onto `50bb5fb7` with no release-prep commit at all.

GitHub's generated notes show the same gap from the other side: the [1.1.2 release](https://github.com/palantirnet/drupal-rector/releases/tag/1.1.2) compares `1.1.0...1.1.2` and re-lists #408 and #410, because the `1.1.1` tag is not an ancestor of it.

**No code was lost.** `git diff 17405041 ce254b66` is the changelog edit and nothing else, so the released 1.1.1 code matches `main`'s lineage and the tag needs no correction.

## The change

Items are filed under the release that actually shipped them:

| Release | Items |
| --- | --- |
| **1.1.1** — 2026-07-11 | getrector.com rule documentation (#408) · `HookConvertRector` no longer emits `static` methods (#410) |
| **1.1.2** — 2026-08-07 | phpstan-drupal ServiceMap in the bootstrap (#412) · `RemoveAliasManagerCacheMethodCallsRector` removed (#418) · Drupal 11.4 search plugin renames dropped (#417) |
| **1.1.3** — 2026-09-03 | `rector/rector >=2.6.2` conflict (#421) |

Bullet text is carried over **verbatim** — verified by diffing the sorted bullet lines before and after, which are identical. Only headings changed, plus the non-standard `### Feature` heading normalized to `### Added` to match every other section.

Not included: the `rector.php` comment typo (#413) and the composer set naming docs (#416), both docs-only and consistent with how earlier sections treat trivial changes.

## Points for review

- **The version number.** 1.1.3 assumes patch. Adding a `conflict` does restrict what consumers can install — someone already on rector 2.6.6 can no longer `composer update` drupal-rector — so there is an argument for 1.2.0. Happy to change it.
- **The 1.1.3 date** is set to today, 2026-09-03. Needs moving if the tag lands on a different day.
- **Dates used are the GitHub *published* dates** (1.1.2 was created 2026-07-31, published 2026-08-07), consistent with 1.1.0 which matches its published date.

## Process note

The `1.1.1` gap happened because the release-prep commit was tagged before it landed on `main`. Worth making the prep commit go through `main` first, then tagging the merged commit.
