### PR TITLE
ci: run php-cs-fixer weekly on a schedule

### DIFF
--- a/.github/workflows/codestyle.yml
+++ b/.github/workflows/codestyle.yml
@@ -1,10 +1,14 @@
 name: php-cs-fixer
 
-# This test will run on every pull request, and on every push on main branch
+# This test will run on every pull request, on every push on main branch, and
+# weekly on a schedule.
 on:
   push:
     branches:
       - main
+  schedule:
+    # Run weekly (to check for php-cs-fixer changes)
+    - cron:  '0 0 * * 0'
   pull_request:
 
 jobs:


### PR DESCRIPTION
The codestyle job only ran on push to `main` and on pull requests, so a php-cs-fixer release that adds or changes a rule went unnoticed until it surfaced in an unrelated PR.

That is exactly what happened on #421: the `@Symfony` ruleset in php-cs-fixer 3.95.24 enforces `nullable_type_declaration` with the `question_mark` style, and the dev constraint is `^3.95.1`, so the rule arrived via a floating minor. It failed a **composer.json-only change**, on a file untouched since it merged green in July.

`phpstan`, `phpunit` and `functional_test_single` already run weekly for the same class of reason (catching rector changes). Codestyle was the one left out.

## The change

```yaml
  schedule:
    # Run weekly (to check for php-cs-fixer changes)
    - cron:  '0 0 * * 0'
```

Same cron as the other three workflows — 00:00 UTC on Sunday.

## Why this actually works

`composer.lock` is not committed (`/composer.lock` is in `.gitignore`), so `composer install` resolves fresh on every run. The scheduled job therefore picks up whatever php-cs-fixer `^3.95.1` resolves to that week, which is the property that makes the drift detectable at all.

Verified the workflow still parses and now carries three triggers:

```
triggers: ['pull_request', 'push', 'schedule']
cron: [{'cron': '0 0 * * 0'}]
```

Scheduled workflows only run from the default branch, so this takes effect once merged rather than on this PR.

## Trade-off

This **detects** drift rather than preventing it — a rule change still lands whenever upstream ships it, we just find out on a predictable Sunday instead of in whichever PR happens to be open. Pinning php-cs-fixer to an exact version would prevent it instead, at the cost of manual bumps. Went with the weekly run so new rules still get adopted; happy to add a pin as well if you'd rather have both.
